### PR TITLE
Remove all Lombok annotations except for "@ToString" and "@EqualsAndHashCode"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ allprojects {
         cloudNetCodeName = 'Tsunami'
 
         //Dependencies
+        dependencyLombokVersion = '1.18.6'
         dependencyH2Version = '1.4.197'
         dependencyGsonVersion = '2.8.2'
         dependencyNettyVersion = '4.1.36.Final'
@@ -164,7 +165,9 @@ subprojects {
     targetCompatibility = 1.8
 
     dependencies {
+        compileOnly group: 'org.projectlombok', name: 'lombok', version: dependencyLombokVersion
         testCompile group: 'junit', name: 'junit', version: testJunitVersion
+        annotationProcessor group: 'org.projectlombok', name: 'lombok', version: dependencyLombokVersion
     }
 
     /*= ------------------------------------------------------------------------------------------- =*/

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ allprojects {
         cloudNetCodeName = 'Tsunami'
 
         //Dependencies
-        dependencyLombokVersion = '1.18.6'
         dependencyH2Version = '1.4.197'
         dependencyGsonVersion = '2.8.2'
         dependencyNettyVersion = '4.1.36.Final'
@@ -165,9 +164,7 @@ subprojects {
     targetCompatibility = 1.8
 
     dependencies {
-        compileOnly group: 'org.projectlombok', name: 'lombok', version: dependencyLombokVersion
         testCompile group: 'junit', name: 'junit', version: testJunitVersion
-        annotationProcessor group: 'org.projectlombok', name: 'lombok', version: dependencyLombokVersion
     }
 
     /*= ------------------------------------------------------------------------------------------- =*/

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/Value.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/Value.java
@@ -1,11 +1,16 @@
 package de.dytanic.cloudnet.common;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * A class that provides the reference of an object.
  * It is interesting for asynchronous operations or anonymous classes.
  *
  * @param <T> the type of value, that you want to set
  */
+@ToString
+@EqualsAndHashCode
 public class Value<T> {
 
     /**
@@ -29,30 +34,4 @@ public class Value<T> {
         this.value = value;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof Value)) return false;
-        final Value<?> other = (Value<?>) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$value = this.getValue();
-        final Object other$value = other.getValue();
-        if (this$value == null ? other$value != null : !this$value.equals(other$value)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof Value;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $value = this.getValue();
-        result = result * PRIME + ($value == null ? 43 : $value.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "Value(value=" + this.getValue() + ")";
-    }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/Value.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/Value.java
@@ -1,18 +1,11 @@
 package de.dytanic.cloudnet.common;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
  * A class that provides the reference of an object.
  * It is interesting for asynchronous operations or anonymous classes.
  *
  * @param <T> the type of value, that you want to set
  */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class Value<T> {
 
     /**
@@ -21,4 +14,45 @@ public class Value<T> {
      */
     protected volatile T value;
 
+    public Value(T value) {
+        this.value = value;
+    }
+
+    public Value() {
+    }
+
+    public T getValue() {
+        return this.value;
+    }
+
+    public void setValue(T value) {
+        this.value = value;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Value)) return false;
+        final Value<?> other = (Value<?>) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$value = this.getValue();
+        final Object other$value = other.getValue();
+        if (this$value == null ? other$value != null : !this$value.equals(other$value)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof Value;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $value = this.getValue();
+        result = result * PRIME + ($value == null ? 43 : $value.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "Value(value=" + this.getValue() + ")";
+    }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/collection/Pair.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/collection/Pair.java
@@ -1,9 +1,5 @@
 package de.dytanic.cloudnet.common.collection;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
  * This class can capture 2 references of 2 types and set or
  * clear the data using setFirst() / getFirst() and setSecond() / getSecond().
@@ -13,9 +9,6 @@ import lombok.NoArgsConstructor;
  * @param <F> the first type, which you want to defined
  * @param <S> the second type which you want to defined
  */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class Pair<F, S> {
 
     /**
@@ -32,4 +25,59 @@ public class Pair<F, S> {
      */
     protected S second;
 
+    public Pair(F first, S second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    public Pair() {
+    }
+
+    public F getFirst() {
+        return this.first;
+    }
+
+    public S getSecond() {
+        return this.second;
+    }
+
+    public void setFirst(F first) {
+        this.first = first;
+    }
+
+    public void setSecond(S second) {
+        this.second = second;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Pair)) return false;
+        final Pair<?, ?> other = (Pair<?, ?>) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$first = this.getFirst();
+        final Object other$first = other.getFirst();
+        if (this$first == null ? other$first != null : !this$first.equals(other$first)) return false;
+        final Object this$second = this.getSecond();
+        final Object other$second = other.getSecond();
+        if (this$second == null ? other$second != null : !this$second.equals(other$second)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof Pair;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $first = this.getFirst();
+        result = result * PRIME + ($first == null ? 43 : $first.hashCode());
+        final Object $second = this.getSecond();
+        result = result * PRIME + ($second == null ? 43 : $second.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "Pair(first=" + this.getFirst() + ", second=" + this.getSecond() + ")";
+    }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/collection/Pair.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/collection/Pair.java
@@ -1,5 +1,8 @@
 package de.dytanic.cloudnet.common.collection;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * This class can capture 2 references of 2 types and set or
  * clear the data using setFirst() / getFirst() and setSecond() / getSecond().
@@ -9,6 +12,8 @@ package de.dytanic.cloudnet.common.collection;
  * @param <F> the first type, which you want to defined
  * @param <S> the second type which you want to defined
  */
+@ToString
+@EqualsAndHashCode
 public class Pair<F, S> {
 
     /**
@@ -49,35 +54,4 @@ public class Pair<F, S> {
         this.second = second;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof Pair)) return false;
-        final Pair<?, ?> other = (Pair<?, ?>) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$first = this.getFirst();
-        final Object other$first = other.getFirst();
-        if (this$first == null ? other$first != null : !this$first.equals(other$first)) return false;
-        final Object this$second = this.getSecond();
-        final Object other$second = other.getSecond();
-        if (this$second == null ? other$second != null : !this$second.equals(other$second)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof Pair;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $first = this.getFirst();
-        result = result * PRIME + ($first == null ? 43 : $first.hashCode());
-        final Object $second = this.getSecond();
-        result = result * PRIME + ($second == null ? 43 : $second.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "Pair(first=" + this.getFirst() + ", second=" + this.getSecond() + ")";
-    }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/collection/Triple.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/collection/Triple.java
@@ -1,5 +1,8 @@
 package de.dytanic.cloudnet.common.collection;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * This class can capture 3 references of 3 types and set or
  * clear the data using setFirst() / getFirst() and setSecond() / getSecond().
@@ -10,6 +13,8 @@ package de.dytanic.cloudnet.common.collection;
  * @param <S> the second type which you want to defined
  * @param <T> the third type which you want to defined
  */
+@ToString
+@EqualsAndHashCode
 public class Triple<F, S, T> {
 
     /**
@@ -66,40 +71,4 @@ public class Triple<F, S, T> {
         this.third = third;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof Triple)) return false;
-        final Triple<?, ?, ?> other = (Triple<?, ?, ?>) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$first = this.getFirst();
-        final Object other$first = other.getFirst();
-        if (this$first == null ? other$first != null : !this$first.equals(other$first)) return false;
-        final Object this$second = this.getSecond();
-        final Object other$second = other.getSecond();
-        if (this$second == null ? other$second != null : !this$second.equals(other$second)) return false;
-        final Object this$third = this.getThird();
-        final Object other$third = other.getThird();
-        if (this$third == null ? other$third != null : !this$third.equals(other$third)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof Triple;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $first = this.getFirst();
-        result = result * PRIME + ($first == null ? 43 : $first.hashCode());
-        final Object $second = this.getSecond();
-        result = result * PRIME + ($second == null ? 43 : $second.hashCode());
-        final Object $third = this.getThird();
-        result = result * PRIME + ($third == null ? 43 : $third.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "Triple(first=" + this.getFirst() + ", second=" + this.getSecond() + ", third=" + this.getThird() + ")";
-    }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/collection/Triple.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/collection/Triple.java
@@ -1,9 +1,5 @@
 package de.dytanic.cloudnet.common.collection;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
  * This class can capture 3 references of 3 types and set or
  * clear the data using setFirst() / getFirst() and setSecond() / getSecond().
@@ -14,9 +10,6 @@ import lombok.NoArgsConstructor;
  * @param <S> the second type which you want to defined
  * @param <T> the third type which you want to defined
  */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class Triple<F, S, T> {
 
     /**
@@ -40,4 +33,73 @@ public class Triple<F, S, T> {
      */
     protected T third;
 
+    public Triple(F first, S second, T third) {
+        this.first = first;
+        this.second = second;
+        this.third = third;
+    }
+
+    public Triple() {
+    }
+
+    public F getFirst() {
+        return this.first;
+    }
+
+    public S getSecond() {
+        return this.second;
+    }
+
+    public T getThird() {
+        return this.third;
+    }
+
+    public void setFirst(F first) {
+        this.first = first;
+    }
+
+    public void setSecond(S second) {
+        this.second = second;
+    }
+
+    public void setThird(T third) {
+        this.third = third;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Triple)) return false;
+        final Triple<?, ?, ?> other = (Triple<?, ?, ?>) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$first = this.getFirst();
+        final Object other$first = other.getFirst();
+        if (this$first == null ? other$first != null : !this$first.equals(other$first)) return false;
+        final Object this$second = this.getSecond();
+        final Object other$second = other.getSecond();
+        if (this$second == null ? other$second != null : !this$second.equals(other$second)) return false;
+        final Object this$third = this.getThird();
+        final Object other$third = other.getThird();
+        if (this$third == null ? other$third != null : !this$third.equals(other$third)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof Triple;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $first = this.getFirst();
+        result = result * PRIME + ($first == null ? 43 : $first.hashCode());
+        final Object $second = this.getSecond();
+        result = result * PRIME + ($second == null ? 43 : $second.hashCode());
+        final Object $third = this.getThird();
+        result = result * PRIME + ($third == null ? 43 : $third.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "Triple(first=" + this.getFirst() + ", second=" + this.getSecond() + ", third=" + this.getThird() + ")";
+    }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/DefaultScheduledTask.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/DefaultScheduledTask.java
@@ -1,31 +1,37 @@
 package de.dytanic.cloudnet.common.concurrent;
 
 import de.dytanic.cloudnet.common.Validate;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.Collection;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 
-@Getter
 public final class DefaultScheduledTask<V> implements IScheduledTask<V> {
 
     private static final AtomicLong TASK_ID_COUNTER = new AtomicLong();
 
     private final long taskId = TASK_ID_COUNTER.incrementAndGet();
 
-    @Getter
     private Collection<ITaskListener<V>> listeners;
 
     private volatile V value;
 
-    @Setter
     private volatile boolean wait, done, cancelled;
+
+    public void setWait(boolean wait) {
+        this.wait = wait;
+    }
+
+    public void setDone(boolean done) {
+        this.done = done;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
 
     private long delay, repeat, repeats, delayedTimeStamp;
 
-    @Getter
     private Callable<V> callable;
 
     public DefaultScheduledTask(Callable<V> callable, long delay, long repeat, long repeats, TimeUnit timeUnit) {
@@ -50,6 +56,56 @@ public final class DefaultScheduledTask<V> implements IScheduledTask<V> {
                 this.listeners.add(listener);
 
         return this;
+    }
+
+    @Override
+    public long getTaskId() {
+        return taskId;
+    }
+
+    @Override
+    public Collection<ITaskListener<V>> getListeners() {
+        return listeners;
+    }
+
+    public V getValue() {
+        return value;
+    }
+
+    public boolean isWait() {
+        return wait;
+    }
+
+    @Override
+    public boolean isDone() {
+        return done;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public long getDelay() {
+        return delay;
+    }
+
+    public long getRepeat() {
+        return repeat;
+    }
+
+    public long getRepeats() {
+        return repeats;
+    }
+
+    @Override
+    public long getDelayedTimeStamp() {
+        return delayedTimeStamp;
+    }
+
+    @Override
+    public Callable<V> getCallable() {
+        return callable;
     }
 
     @Override
@@ -103,6 +159,8 @@ public final class DefaultScheduledTask<V> implements IScheduledTask<V> {
 
         return this.value;
     }
+
+
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/DefaultTaskScheduler.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/DefaultTaskScheduler.java
@@ -1,9 +1,5 @@
 package de.dytanic.cloudnet.common.concurrent;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.Collection;
 import java.util.Deque;
 import java.util.Queue;
@@ -14,7 +10,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-@Getter
 public class DefaultTaskScheduler implements ITaskScheduler {
 
     protected static final long DEFAULT_THREAD_LIFE_MILLIS = 60000, DEFAULT_THREAD_PAUSE_MILLIS = 5;
@@ -29,14 +24,59 @@ public class DefaultTaskScheduler implements ITaskScheduler {
 
     protected final AtomicLong THREAD_COUNT = new AtomicLong();
 
-    @Setter
     protected volatile int maxThreadSize;
 
-    @Setter
+    public void setMaxThreadSize(int maxThreadSize) {
+        this.maxThreadSize = maxThreadSize;
+    }
+
     protected volatile long threadLifeMillis;
 
-    @Setter
+    public void setThreadLifeMillis(long threadLifeMillis) {
+        this.threadLifeMillis = threadLifeMillis;
+    }
+
     protected volatile long threadPauseDelayMillis;
+
+    public void setThreadPauseDelayMillis(long threadPauseDelayMillis) {
+        this.threadPauseDelayMillis = threadPauseDelayMillis;
+    }
+
+    public static long getDefaultThreadLifeMillis() {
+        return DEFAULT_THREAD_LIFE_MILLIS;
+    }
+
+    public static long getDefaultThreadPauseMillis() {
+        return DEFAULT_THREAD_PAUSE_MILLIS;
+    }
+
+    public static AtomicInteger getGroupCount() {
+        return GROUP_COUNT;
+    }
+
+    public Deque<IScheduledTask<?>> getTaskEntries() {
+        return taskEntries;
+    }
+
+    public ThreadGroup getThreadGroup() {
+        return threadGroup;
+    }
+
+    public AtomicLong getTHREAD_COUNT() {
+        return THREAD_COUNT;
+    }
+
+    public int getMaxThreadSize() {
+        return maxThreadSize;
+    }
+
+    public long getThreadLifeMillis() {
+        return threadLifeMillis;
+    }
+
+    public long getThreadPauseDelayMillis() {
+        return threadPauseDelayMillis;
+    }
 
     public DefaultTaskScheduler() {
         this(Runtime.getRuntime().availableProcessors() * 2, DEFAULT_THREAD_LIFE_MILLIS, DEFAULT_THREAD_PAUSE_MILLIS);
@@ -198,10 +238,13 @@ public class DefaultTaskScheduler implements ITaskScheduler {
 
     /*= ------------------------------------------------------------- =*/
 
-    @AllArgsConstructor
     private final class VoidCallable implements Callable<Void> {
 
         private final Runnable runnable;
+
+        public VoidCallable(Runnable runnable) {
+            this.runnable = runnable;
+        }
 
         @Override
         public Void call() throws Exception {

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/ListenableTask.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/ListenableTask.java
@@ -1,17 +1,13 @@
 package de.dytanic.cloudnet.common.concurrent;
 
 import de.dytanic.cloudnet.common.Validate;
-import lombok.Getter;
 
 import java.util.Collection;
 import java.util.concurrent.*;
 
-@Getter
 public class ListenableTask<V> implements ITask<V> {
 
-    @Getter
     private final Callable<V> callable;
-    @Getter
     private Collection<ITaskListener<V>> listeners;
     private volatile V value;
     private volatile boolean done, cancelled;
@@ -26,6 +22,30 @@ public class ListenableTask<V> implements ITask<V> {
         this.callable = callable;
 
         if (listener != null) this.addListener(listener);
+    }
+
+    @Override
+    public Callable<V> getCallable() {
+        return callable;
+    }
+
+    @Override
+    public Collection<ITaskListener<V>> getListeners() {
+        return listeners;
+    }
+
+    public V getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean isDone() {
+        return done;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
     }
 
     @Override

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/WorkerThread.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/WorkerThread.java
@@ -1,7 +1,5 @@
 package de.dytanic.cloudnet.common.concurrent;
 
-import lombok.Getter;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -11,9 +9,12 @@ public class WorkerThread extends Thread implements ExecutorService {
 
     protected final BlockingQueue<ITask<?>> tasks = new LinkedBlockingQueue<>();
     protected final long lifeMillis;
-    @Getter
     protected volatile boolean available = true;
     protected long destinationTime;
+
+    public boolean isAvailable() {
+        return available;
+    }
 
     public WorkerThread() {
         super();

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/scheduler/TaskEntryFuture.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/concurrent/scheduler/TaskEntryFuture.java
@@ -1,8 +1,6 @@
 package de.dytanic.cloudnet.common.concurrent.scheduler;
 
 import de.dytanic.cloudnet.common.annotation.UnsafeClass;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -18,12 +16,23 @@ import java.util.concurrent.TimeoutException;
  */
 @Deprecated
 @UnsafeClass
-@Getter
-@AllArgsConstructor
 public class TaskEntryFuture<T> implements Future<T> {
 
     protected volatile boolean waits;
     private TaskEntry<T> entry;
+
+    public TaskEntryFuture(boolean waits, TaskEntry<T> entry) {
+        this.waits = waits;
+        this.entry = entry;
+    }
+
+    public boolean isWaits() {
+        return waits;
+    }
+
+    public TaskEntry<T> getEntry() {
+        return entry;
+    }
 
     @Override
     public boolean cancel(boolean pMayInterruptIfRunning) {

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/BasicJsonDocPropertyable.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/BasicJsonDocPropertyable.java
@@ -1,10 +1,7 @@
 package de.dytanic.cloudnet.common.document.gson;
 
-import lombok.Getter;
-
 public class BasicJsonDocPropertyable implements IJsonDocPropertyable {
 
-    @Getter
     protected JsonDocument properties = new JsonDocument();
 
     @Override
@@ -27,5 +24,9 @@ public class BasicJsonDocPropertyable implements IJsonDocPropertyable {
     @Override
     public <E> boolean hasProperty(JsonDocProperty<E> docProperty) {
         return docProperty.tester.test(properties);
+    }
+
+    public JsonDocument getProperties() {
+        return this.properties;
     }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocProperty.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocProperty.java
@@ -1,8 +1,5 @@
 package de.dytanic.cloudnet.common.document.gson;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -11,8 +8,6 @@ import java.util.function.Predicate;
 /**
  * Created by Tareko on 20.12.2017.
  */
-@Getter
-@AllArgsConstructor
 public class JsonDocProperty<E> {
 
     protected final BiConsumer<E, JsonDocument> appender;
@@ -23,4 +18,26 @@ public class JsonDocProperty<E> {
 
     protected final Predicate<JsonDocument> tester;
 
+    public JsonDocProperty(BiConsumer<E, JsonDocument> appender, Function<JsonDocument, E> resolver, Consumer<JsonDocument> remover, Predicate<JsonDocument> tester) {
+        this.appender = appender;
+        this.resolver = resolver;
+        this.remover = remover;
+        this.tester = tester;
+    }
+
+    public BiConsumer<E, JsonDocument> getAppender() {
+        return this.appender;
+    }
+
+    public Function<JsonDocument, E> getResolver() {
+        return this.resolver;
+    }
+
+    public Consumer<JsonDocument> getRemover() {
+        return this.remover;
+    }
+
+    public Predicate<JsonDocument> getTester() {
+        return this.tester;
+    }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/language/LanguageManager.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/language/LanguageManager.java
@@ -1,8 +1,6 @@
 package de.dytanic.cloudnet.common.language;
 
 import de.dytanic.cloudnet.common.Properties;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -21,8 +19,6 @@ public final class LanguageManager {
     /**
      * The current language, which the getMessage() method will the message return
      */
-    @Getter
-    @Setter
     private static volatile String language;
 
     private LanguageManager() {
@@ -96,5 +92,13 @@ public final class LanguageManager {
         }
 
         addLanguageFile(language, properties);
+    }
+
+    public static String getLanguage() {
+        return LanguageManager.language;
+    }
+
+    public static void setLanguage(String language) {
+        LanguageManager.language = language;
     }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/AbstractLogHandler.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/AbstractLogHandler.java
@@ -1,15 +1,9 @@
 package de.dytanic.cloudnet.common.logging;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 /**
  * This is a basic abstract implementation of the ILogHandler class.
  * It should help, to create a simple
  */
-@NoArgsConstructor
-@AllArgsConstructor
 public abstract class AbstractLogHandler implements ILogHandler {
 
     /**
@@ -17,8 +11,17 @@ public abstract class AbstractLogHandler implements ILogHandler {
      *
      * @see DefaultLogFormatter
      */
-    @Getter
     protected IFormatter formatter = new DefaultLogFormatter();
+
+    public IFormatter getFormatter() {
+        return formatter;
+    }
+
+    public AbstractLogHandler() {}
+
+    public AbstractLogHandler(IFormatter formatter) {
+        this.formatter = formatter;
+    }
 
     /**
      * Set the new formatter

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/AsyncPrintStream.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/AsyncPrintStream.java
@@ -4,8 +4,6 @@
 
 package de.dytanic.cloudnet.common.logging;
 
-import lombok.Getter;
-
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
@@ -21,10 +19,13 @@ import java.util.concurrent.LinkedBlockingQueue;
  * The actual console output is still executed in a thread where its priority
  * is as low as possible to affect the program even less
  */
-@Getter
 public class AsyncPrintStream extends PrintStream {
 
     static final BlockingQueue<Runnable> ASYNC_QUEUE = new LinkedBlockingQueue<>();
+
+    public static BlockingQueue<Runnable> getAsyncQueue() {
+        return ASYNC_QUEUE;
+    }
 
     private static final Thread worker = new Thread() {
 

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/DefaultAsyncLogger.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/DefaultAsyncLogger.java
@@ -1,9 +1,6 @@
 package de.dytanic.cloudnet.common.logging;
 
 import de.dytanic.cloudnet.common.collection.Iterables;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,9 +34,17 @@ public class DefaultAsyncLogger implements ILogger {
                 entries.poll().call();
         }
     };
-    @Getter
-    @Setter
     protected int level = -1;
+
+    @Override
+    public int getLevel() {
+        return level;
+    }
+
+    @Override
+    public void setLevel(int level) {
+        this.level = level;
+    }
 
     public DefaultAsyncLogger() {
         logThread.setPriority(Thread.MIN_PRIORITY);
@@ -146,10 +151,13 @@ public class DefaultAsyncLogger implements ILogger {
         }
     }
 
-    @AllArgsConstructor
     public class LogHandlerRunnable implements Callable<Void> {
 
         private final LogEntry logEntry;
+
+        public LogHandlerRunnable(LogEntry logEntry) {
+            this.logEntry = logEntry;
+        }
 
         @Override
         public Void call() {

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/DefaultFileLogHandler.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/DefaultFileLogHandler.java
@@ -1,7 +1,5 @@
 package de.dytanic.cloudnet.common.logging;
 
-import lombok.Getter;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
@@ -10,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 /**
  * A standard file logger for this LoggingAPI. All important configurations can be made in the constructor
  */
-@Getter
 public final class DefaultFileLogHandler extends AbstractLogHandler {
 
     public static final long SIZE_8MB = 8000000L;
@@ -73,6 +70,34 @@ public final class DefaultFileLogHandler extends AbstractLogHandler {
 
         index = 0;
         printWriter.close();
+    }
+
+    public File getDirectory() {
+        return directory;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public long getMaxBytes() {
+        return maxBytes;
+    }
+
+    public File getEntry() {
+        return entry;
+    }
+
+    public PrintWriter getPrintWriter() {
+        return printWriter;
+    }
+
+    public long getWritternBytes() {
+        return writternBytes;
+    }
+
+    public int getIndex() {
+        return index;
     }
 
     private void selectLogFile() {

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogEntry.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogEntry.java
@@ -1,8 +1,5 @@
 package de.dytanic.cloudnet.common.logging;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 /**
  * Represents a full log record from the logger.
  * Important for the most loggers are the following information
@@ -13,8 +10,6 @@ import lombok.RequiredArgsConstructor;
  * <li>thread: the Thread in that the record was created</li>
  * </ol>
  */
-@Getter
-@RequiredArgsConstructor
 public class LogEntry {
 
     /**
@@ -54,4 +49,37 @@ public class LogEntry {
      * The Thread instance in that the LogEntry was created
      */
     protected final Thread thread;
+
+    public LogEntry(long timeStamp, Class<?> clazz, String[] messages, LogLevel logLevel, Throwable throwable, Thread thread) {
+        this.timeStamp = timeStamp;
+        this.clazz = clazz;
+        this.messages = messages;
+        this.logLevel = logLevel;
+        this.throwable = throwable;
+        this.thread = thread;
+    }
+
+    public long getTimeStamp() {
+        return timeStamp;
+    }
+
+    public Class<?> getClazz() {
+        return clazz;
+    }
+
+    public String[] getMessages() {
+        return messages;
+    }
+
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
+
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    public Thread getThread() {
+        return thread;
+    }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogLevel.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogLevel.java
@@ -1,9 +1,6 @@
 package de.dytanic.cloudnet.common.logging;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import java.util.Objects;
 
 /**
  * The LogLevel indicates how relevant and essential information is to be output.
@@ -14,10 +11,6 @@ import lombok.ToString;
  *
  * @see LogEntry
  */
-@Getter
-@ToString
-@EqualsAndHashCode
-@AllArgsConstructor
 public class LogLevel implements ILevelable {
 
     /**
@@ -90,4 +83,56 @@ public class LogLevel implements ILevelable {
      * Defines the permission, to execute the LogEntries on this Level asynchronously or not.
      */
     protected boolean async;
+
+    public LogLevel(String lowerName, String upperName, int level, boolean async) {
+        this.lowerName = lowerName;
+        this.upperName = upperName;
+        this.level = level;
+        this.async = async;
+    }
+
+    public String getLowerName() {
+        return lowerName;
+    }
+
+    public String getUpperName() {
+        return upperName;
+    }
+
+    @Override
+    public int getLevel() {
+        return level;
+    }
+
+    public boolean isAsync() {
+        return async;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("LogLevel{");
+        sb.append("lowerName='").append(lowerName).append('\'');
+        sb.append(", upperName='").append(upperName).append('\'');
+        sb.append(", level=").append(level);
+        sb.append(", async=").append(async);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LogLevel logLevel = (LogLevel) o;
+        return level == logLevel.level &&
+                async == logLevel.async &&
+                Objects.equals(lowerName, logLevel.lowerName) &&
+                Objects.equals(upperName, logLevel.upperName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lowerName, upperName, level, async);
+    }
+
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogLevel.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogLevel.java
@@ -1,5 +1,8 @@
 package de.dytanic.cloudnet.common.logging;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.Objects;
 
 /**
@@ -11,6 +14,8 @@ import java.util.Objects;
  *
  * @see LogEntry
  */
+@ToString
+@EqualsAndHashCode
 public class LogLevel implements ILevelable {
 
     /**
@@ -106,33 +111,6 @@ public class LogLevel implements ILevelable {
 
     public boolean isAsync() {
         return async;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("LogLevel{");
-        sb.append("lowerName='").append(lowerName).append('\'');
-        sb.append(", upperName='").append(upperName).append('\'');
-        sb.append(", level=").append(level);
-        sb.append(", async=").append(async);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        LogLevel logLevel = (LogLevel) o;
-        return level == logLevel.level &&
-                async == logLevel.async &&
-                Objects.equals(lowerName, logLevel.lowerName) &&
-                Objects.equals(upperName, logLevel.upperName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(lowerName, upperName, level, async);
     }
 
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogOutputStream.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogOutputStream.java
@@ -1,8 +1,5 @@
 package de.dytanic.cloudnet.common.logging;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -11,8 +8,6 @@ import java.nio.charset.StandardCharsets;
  * Defines a new ByteArrayOutputStream that convert the bytes into a message and
  * invokes the in constructor exist logger
  */
-@Getter
-@RequiredArgsConstructor
 public class LogOutputStream extends ByteArrayOutputStream {
 
     /**
@@ -24,6 +19,25 @@ public class LogOutputStream extends ByteArrayOutputStream {
      * The LogLevel in that the logger should log the incoming message
      */
     protected final LogLevel logLevel;
+
+    public LogOutputStream(ILogger logger, LogLevel logLevel) {
+        this.logger = logger;
+        this.logLevel = logLevel;
+    }
+
+    public LogOutputStream(int size, ILogger logger, LogLevel logLevel) {
+        super(size);
+        this.logger = logger;
+        this.logLevel = logLevel;
+    }
+
+    public ILogger getLogger() {
+        return logger;
+    }
+
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
 
     @Override
     public void flush() throws IOException {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
@@ -21,10 +21,6 @@ import de.dytanic.cloudnet.driver.network.def.internal.InternalSyncPacketChannel
 import de.dytanic.cloudnet.driver.permission.IPermissionGroup;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.driver.service.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 import java.util.Collection;
 import java.util.List;
@@ -33,12 +29,8 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 
-@Getter
-@RequiredArgsConstructor
 public abstract class CloudNetDriver {
 
-    @Getter
-    @Setter(AccessLevel.PROTECTED)
     private static CloudNetDriver instance;
 
     protected final IServicesRegistry servicesRegistry = new DefaultServicesRegistry();
@@ -50,6 +42,18 @@ public abstract class CloudNetDriver {
     protected final ITaskScheduler taskScheduler = new DefaultTaskScheduler();
     protected final ILogger logger;
     protected DriverEnvironment driverEnvironment = DriverEnvironment.EMBEDDED;
+
+    public CloudNetDriver(ILogger logger) {
+        this.logger = logger;
+    }
+
+    public static CloudNetDriver getInstance() {
+        return CloudNetDriver.instance;
+    }
+
+    protected static void setInstance(CloudNetDriver instance) {
+        CloudNetDriver.instance = instance;
+    }
 
     /*= ------------------------------------------------- =*/
 
@@ -415,5 +419,29 @@ public abstract class CloudNetDriver {
         });
 
         return listenableTask;
+    }
+
+    public IServicesRegistry getServicesRegistry() {
+        return this.servicesRegistry;
+    }
+
+    public IEventManager getEventManager() {
+        return this.eventManager;
+    }
+
+    public IModuleProvider getModuleProvider() {
+        return this.moduleProvider;
+    }
+
+    public ITaskScheduler getTaskScheduler() {
+        return this.taskScheduler;
+    }
+
+    public ILogger getLogger() {
+        return this.logger;
+    }
+
+    public DriverEnvironment getDriverEnvironment() {
+        return this.driverEnvironment;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/DefaultRegisteredEventListener.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/DefaultRegisteredEventListener.java
@@ -1,12 +1,7 @@
 package de.dytanic.cloudnet.driver.event;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.lang.reflect.Method;
 
-@Getter
-@AllArgsConstructor
 public class DefaultRegisteredEventListener implements IRegisteredEventListener {
 
     protected EventListener eventListener;
@@ -19,4 +14,31 @@ public class DefaultRegisteredEventListener implements IRegisteredEventListener 
 
     protected Class<? extends Event> eventClass;
 
+    public DefaultRegisteredEventListener(EventListener eventListener, EventPriority priority, Object instance, Method handlerMethod, Class<? extends Event> eventClass) {
+        this.eventListener = eventListener;
+        this.priority = priority;
+        this.instance = instance;
+        this.handlerMethod = handlerMethod;
+        this.eventClass = eventClass;
+    }
+
+    public EventListener getEventListener() {
+        return this.eventListener;
+    }
+
+    public EventPriority getPriority() {
+        return this.priority;
+    }
+
+    public Object getInstance() {
+        return this.instance;
+    }
+
+    public Method getHandlerMethod() {
+        return this.handlerMethod;
+    }
+
+    public Class<? extends Event> getEventClass() {
+        return this.eventClass;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/EventPriority.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/EventPriority.java
@@ -1,12 +1,7 @@
 package de.dytanic.cloudnet.driver.event;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.util.Comparator;
 
-@Getter
-@AllArgsConstructor
 public enum EventPriority implements Comparator<EventPriority> {
 
     HIGHEST(128),
@@ -17,8 +12,16 @@ public enum EventPriority implements Comparator<EventPriority> {
 
     private int value;
 
+    private EventPriority(int value) {
+        this.value = value;
+    }
+
     @Override
     public int compare(EventPriority o1, EventPriority o2) {
         return o1.value - o2.value;
+    }
+
+    public int getValue() {
+        return this.value;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/channel/ChannelMessageReceiveEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/channel/ChannelMessageReceiveEvent.java
@@ -2,11 +2,7 @@ package de.dytanic.cloudnet.driver.event.events.channel;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.event.Event;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ChannelMessageReceiveEvent extends Event {
 
     private final String channel;
@@ -15,4 +11,21 @@ public final class ChannelMessageReceiveEvent extends Event {
 
     private final JsonDocument data;
 
+    public ChannelMessageReceiveEvent(String channel, String message, JsonDocument data) {
+        this.channel = channel;
+        this.message = message;
+        this.data = data;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public JsonDocument getData() {
+        return this.data;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/module/ModuleEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/module/ModuleEvent.java
@@ -3,15 +3,23 @@ package de.dytanic.cloudnet.driver.event.events.module;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.module.IModuleProvider;
 import de.dytanic.cloudnet.driver.module.IModuleWrapper;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
 public abstract class ModuleEvent extends DriverEvent {
 
     private IModuleProvider moduleProvider;
 
     private IModuleWrapper module;
 
+    public ModuleEvent(IModuleProvider moduleProvider, IModuleWrapper module) {
+        this.moduleProvider = moduleProvider;
+        this.module = module;
+    }
+
+    public IModuleProvider getModuleProvider() {
+        return this.moduleProvider;
+    }
+
+    public IModuleWrapper getModule() {
+        return this.module;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/module/ModulePostInstallDependencyEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/module/ModulePostInstallDependencyEvent.java
@@ -3,9 +3,7 @@ package de.dytanic.cloudnet.driver.event.events.module;
 import de.dytanic.cloudnet.driver.module.IModuleProvider;
 import de.dytanic.cloudnet.driver.module.IModuleWrapper;
 import de.dytanic.cloudnet.driver.module.ModuleDependency;
-import lombok.Getter;
 
-@Getter
 public final class ModulePostInstallDependencyEvent extends ModuleEvent {
 
     private final ModuleDependency moduleDependency;
@@ -14,5 +12,9 @@ public final class ModulePostInstallDependencyEvent extends ModuleEvent {
         super(moduleProvider, module);
 
         this.moduleDependency = moduleDependency;
+    }
+
+    public ModuleDependency getModuleDependency() {
+        return this.moduleDependency;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/module/ModulePreInstallDependencyEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/module/ModulePreInstallDependencyEvent.java
@@ -3,9 +3,7 @@ package de.dytanic.cloudnet.driver.event.events.module;
 import de.dytanic.cloudnet.driver.module.IModuleProvider;
 import de.dytanic.cloudnet.driver.module.IModuleWrapper;
 import de.dytanic.cloudnet.driver.module.ModuleDependency;
-import lombok.Getter;
 
-@Getter
 public final class ModulePreInstallDependencyEvent extends ModuleEvent {
 
     private final ModuleDependency moduleDependency;
@@ -14,5 +12,9 @@ public final class ModulePreInstallDependencyEvent extends ModuleEvent {
         super(moduleProvider, module);
 
         this.moduleDependency = moduleDependency;
+    }
+
+    public ModuleDependency getModuleDependency() {
+        return this.moduleDependency;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkChannelCloseEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkChannelCloseEvent.java
@@ -1,9 +1,7 @@
 package de.dytanic.cloudnet.driver.event.events.network;
 
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
-import lombok.Getter;
 
-@Getter
 public final class NetworkChannelCloseEvent extends NetworkEvent {
 
     private final ChannelType channelType;
@@ -11,5 +9,9 @@ public final class NetworkChannelCloseEvent extends NetworkEvent {
     public NetworkChannelCloseEvent(INetworkChannel channel, ChannelType channelType) {
         super(channel);
         this.channelType = channelType;
+    }
+
+    public ChannelType getChannelType() {
+        return this.channelType;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkChannelInitEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkChannelInitEvent.java
@@ -2,19 +2,27 @@ package de.dytanic.cloudnet.driver.event.events.network;
 
 import de.dytanic.cloudnet.driver.event.ICancelable;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
 public class NetworkChannelInitEvent extends NetworkEvent implements ICancelable {
 
     private final ChannelType channelType;
 
-    @Setter
     private boolean cancelled;
 
     public NetworkChannelInitEvent(INetworkChannel channel, ChannelType channelType) {
         super(channel);
         this.channelType = channelType;
+    }
+
+    public ChannelType getChannelType() {
+        return this.channelType;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkChannelPacketReceiveEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkChannelPacketReceiveEvent.java
@@ -3,18 +3,26 @@ package de.dytanic.cloudnet.driver.event.events.network;
 import de.dytanic.cloudnet.driver.event.ICancelable;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
 public class NetworkChannelPacketReceiveEvent extends NetworkEvent implements ICancelable {
 
     private final IPacket packet;
-    @Setter
     private boolean cancelled;
 
     public NetworkChannelPacketReceiveEvent(INetworkChannel channel, IPacket packet) {
         super(channel);
         this.packet = packet;
+    }
+
+    public IPacket getPacket() {
+        return this.packet;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkClusterNodeInfoUpdateEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkClusterNodeInfoUpdateEvent.java
@@ -2,9 +2,7 @@ package de.dytanic.cloudnet.driver.event.events.network;
 
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNodeInfoSnapshot;
-import lombok.Getter;
 
-@Getter
 public final class NetworkClusterNodeInfoUpdateEvent extends NetworkEvent {
 
     private final NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot;
@@ -13,5 +11,9 @@ public final class NetworkClusterNodeInfoUpdateEvent extends NetworkEvent {
         super(channel);
 
         this.networkClusterNodeInfoSnapshot = networkClusterNodeInfoSnapshot;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNetworkClusterNodeInfoSnapshot() {
+        return this.networkClusterNodeInfoSnapshot;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/network/NetworkEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.driver.event.events.network;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public abstract class NetworkEvent extends DriverEvent {
 
     private final INetworkChannel channel;
 
+    public NetworkEvent(INetworkChannel channel) {
+        this.channel = channel;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.driver.event.events.permission;
 
 import de.dytanic.cloudnet.driver.event.Event;
 import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public abstract class PermissionEvent extends Event {
 
     private final IPermissionManagement permissionManagement;
 
+    public PermissionEvent(IPermissionManagement permissionManagement) {
+        this.permissionManagement = permissionManagement;
+    }
+
+    public IPermissionManagement getPermissionManagement() {
+        return this.permissionManagement;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionGroupEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionGroupEvent.java
@@ -2,9 +2,7 @@ package de.dytanic.cloudnet.driver.event.events.permission;
 
 import de.dytanic.cloudnet.driver.permission.IPermissionGroup;
 import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
-import lombok.Getter;
 
-@Getter
 abstract class PermissionGroupEvent extends PermissionEvent {
 
     private final IPermissionGroup permissionGroup;
@@ -13,5 +11,9 @@ abstract class PermissionGroupEvent extends PermissionEvent {
         super(permissionManagement);
 
         this.permissionGroup = permissionGroup;
+    }
+
+    public IPermissionGroup getPermissionGroup() {
+        return this.permissionGroup;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionSetGroupsEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionSetGroupsEvent.java
@@ -2,11 +2,9 @@ package de.dytanic.cloudnet.driver.event.events.permission;
 
 import de.dytanic.cloudnet.driver.permission.IPermissionGroup;
 import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
-import lombok.Getter;
 
 import java.util.Collection;
 
-@Getter
 public final class PermissionSetGroupsEvent extends PermissionEvent {
 
     private final Collection<? extends IPermissionGroup> groups;
@@ -15,5 +13,9 @@ public final class PermissionSetGroupsEvent extends PermissionEvent {
         super(permissionManagement);
 
         this.groups = groups;
+    }
+
+    public Collection<? extends IPermissionGroup> getGroups() {
+        return this.groups;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionSetUsersEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionSetUsersEvent.java
@@ -2,11 +2,9 @@ package de.dytanic.cloudnet.driver.event.events.permission;
 
 import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
-import lombok.Getter;
 
 import java.util.Collection;
 
-@Getter
 public final class PermissionSetUsersEvent extends PermissionEvent {
 
     private final Collection<? extends IPermissionUser> users;
@@ -15,5 +13,9 @@ public final class PermissionSetUsersEvent extends PermissionEvent {
         super(permissionManagement);
 
         this.users = users;
+    }
+
+    public Collection<? extends IPermissionUser> getUsers() {
+        return this.users;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionUserEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/permission/PermissionUserEvent.java
@@ -2,9 +2,7 @@ package de.dytanic.cloudnet.driver.event.events.permission;
 
 import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
-import lombok.Getter;
 
-@Getter
 abstract class PermissionUserEvent extends PermissionEvent {
 
     private final IPermissionUser permissionUser;
@@ -13,5 +11,9 @@ abstract class PermissionUserEvent extends PermissionEvent {
         super(permissionManagement);
 
         this.permissionUser = permissionUser;
+    }
+
+    public IPermissionUser getPermissionUser() {
+        return this.permissionUser;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/service/CloudServiceEvent.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/events/service/CloudServiceEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.driver.event.events.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public abstract class CloudServiceEvent extends DriverEvent {
 
     private final ServiceInfoSnapshot serviceInfo;
 
+    public CloudServiceEvent(ServiceInfoSnapshot serviceInfo) {
+        this.serviceInfo = serviceInfo;
+    }
+
+    public ServiceInfoSnapshot getServiceInfo() {
+        return this.serviceInfo;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModule.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModule.java
@@ -1,8 +1,5 @@
 package de.dytanic.cloudnet.driver.module;
 
-import lombok.Getter;
-
-@Getter
 public class DefaultModule implements IModule {
 
     IModuleWrapper moduleWrapper;
@@ -11,4 +8,15 @@ public class DefaultModule implements IModule {
 
     ModuleConfiguration moduleConfig;
 
+    public IModuleWrapper getModuleWrapper() {
+        return this.moduleWrapper;
+    }
+
+    public ClassLoader getClassLoader() {
+        return this.classLoader;
+    }
+
+    public ModuleConfiguration getModuleConfig() {
+        return this.moduleConfig;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModuleProvider.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModuleProvider.java
@@ -2,8 +2,6 @@ package de.dytanic.cloudnet.driver.module;
 
 import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.collection.Iterables;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -17,12 +15,8 @@ public final class DefaultModuleProvider implements IModuleProvider {
 
     protected Collection<DefaultModuleWrapper> moduleWrappers = Iterables.newCopyOnWriteArrayList();
 
-    @Getter
-    @Setter
     protected IModuleProviderHandler moduleProviderHandler = new ModuleProviderHandlerAdapter();
 
-    @Getter
-    @Setter
     protected IModuleDependencyLoader moduleDependencyLoader = new DefaultMemoryModuleDependencyLoader();
 
     @Override
@@ -154,5 +148,21 @@ public final class DefaultModuleProvider implements IModuleProvider {
             moduleWrapper.unloadModule();
 
         return this;
+    }
+
+    public IModuleProviderHandler getModuleProviderHandler() {
+        return this.moduleProviderHandler;
+    }
+
+    public IModuleDependencyLoader getModuleDependencyLoader() {
+        return this.moduleDependencyLoader;
+    }
+
+    public void setModuleProviderHandler(IModuleProviderHandler moduleProviderHandler) {
+        this.moduleProviderHandler = moduleProviderHandler;
+    }
+
+    public void setModuleDependencyLoader(IModuleDependencyLoader moduleDependencyLoader) {
+        this.moduleDependencyLoader = moduleDependencyLoader;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModuleTaskEntry.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModuleTaskEntry.java
@@ -1,12 +1,7 @@
 package de.dytanic.cloudnet.driver.module;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.lang.reflect.Method;
 
-@Getter
-@AllArgsConstructor
 public final class DefaultModuleTaskEntry implements IModuleTaskEntry {
 
     private IModuleWrapper moduleWrapper;
@@ -15,8 +10,26 @@ public final class DefaultModuleTaskEntry implements IModuleTaskEntry {
 
     private Method handler;
 
+    public DefaultModuleTaskEntry(IModuleWrapper moduleWrapper, ModuleTask taskInfo, Method handler) {
+        this.moduleWrapper = moduleWrapper;
+        this.taskInfo = taskInfo;
+        this.handler = handler;
+    }
+
     @Override
     public IModule getModule() {
         return this.moduleWrapper.getModule();
+    }
+
+    public IModuleWrapper getModuleWrapper() {
+        return this.moduleWrapper;
+    }
+
+    public ModuleTask getTaskInfo() {
+        return this.taskInfo;
+    }
+
+    public Method getHandler() {
+        return this.handler;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModuleWrapper.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModuleWrapper.java
@@ -10,7 +10,6 @@ import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.common.collection.Maps;
 import de.dytanic.cloudnet.common.collection.Pair;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -37,19 +36,12 @@ public class DefaultModuleWrapper implements IModuleWrapper {
 
     private static final String MODULE_CONFIG_PATH = "module.json";
     private final EnumMap<ModuleLifeCycle, List<IModuleTaskEntry>> moduleTasks = Maps.newEnumMap(ModuleLifeCycle.class);
-    @Getter
     private ModuleLifeCycle moduleLifeCycle = ModuleLifeCycle.UNLOADED;
-    @Getter
     private URL url;
-    @Getter
     private DefaultModule module;
-    @Getter
     private DefaultModuleProvider moduleProvider;
-    @Getter
     private FinalizeURLClassLoader classLoader;
-    @Getter
     private ModuleConfiguration moduleConfiguration;
-    @Getter
     private JsonDocument moduleConfigurationSource;
 
     public DefaultModuleWrapper(DefaultModuleProvider moduleProvider, URL url) throws Exception {
@@ -250,5 +242,33 @@ public class DefaultModuleWrapper implements IModuleWrapper {
                 th.printStackTrace();
             }
         }
+    }
+
+    public ModuleLifeCycle getModuleLifeCycle() {
+        return this.moduleLifeCycle;
+    }
+
+    public URL getUrl() {
+        return this.url;
+    }
+
+    public DefaultModule getModule() {
+        return this.module;
+    }
+
+    public DefaultModuleProvider getModuleProvider() {
+        return this.moduleProvider;
+    }
+
+    public FinalizeURLClassLoader getClassLoader() {
+        return this.classLoader;
+    }
+
+    public ModuleConfiguration getModuleConfiguration() {
+        return this.moduleConfiguration;
+    }
+
+    public JsonDocument getModuleConfigurationSource() {
+        return this.moduleConfigurationSource;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultPersistableModuleDependencyLoader.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultPersistableModuleDependencyLoader.java
@@ -1,7 +1,6 @@
 package de.dytanic.cloudnet.driver.module;
 
 import de.dytanic.cloudnet.common.io.FileUtils;
-import lombok.Getter;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -10,7 +9,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Map;
 
-@Getter
 public class DefaultPersistableModuleDependencyLoader implements IModuleDependencyLoader {
 
     protected File baseDirectory;
@@ -55,5 +53,9 @@ public class DefaultPersistableModuleDependencyLoader implements IModuleDependen
         }
 
         return destFile.toURI().toURL();
+    }
+
+    public File getBaseDirectory() {
+        return this.baseDirectory;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleConfiguration.java
@@ -1,7 +1,11 @@
 package de.dytanic.cloudnet.driver.module;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
+@ToString
+@EqualsAndHashCode
 public class ModuleConfiguration {
 
     protected boolean runtimeModule;
@@ -88,73 +92,4 @@ public class ModuleConfiguration {
         return this.properties;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ModuleConfiguration)) return false;
-        final ModuleConfiguration other = (ModuleConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (this.isRuntimeModule() != other.isRuntimeModule()) return false;
-        final Object this$group = this.getGroup();
-        final Object other$group = other.getGroup();
-        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$version = this.getVersion();
-        final Object other$version = other.getVersion();
-        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
-        final Object this$main = this.getMain();
-        final Object other$main = other.getMain();
-        if (this$main == null ? other$main != null : !this$main.equals(other$main)) return false;
-        final Object this$description = this.getDescription();
-        final Object other$description = other.getDescription();
-        if (this$description == null ? other$description != null : !this$description.equals(other$description))
-            return false;
-        final Object this$author = this.getAuthor();
-        final Object other$author = other.getAuthor();
-        if (this$author == null ? other$author != null : !this$author.equals(other$author)) return false;
-        final Object this$website = this.getWebsite();
-        final Object other$website = other.getWebsite();
-        if (this$website == null ? other$website != null : !this$website.equals(other$website)) return false;
-        if (!java.util.Arrays.deepEquals(this.getRepos(), other.getRepos())) return false;
-        if (!java.util.Arrays.deepEquals(this.getDependencies(), other.getDependencies())) return false;
-        final Object this$properties = this.getProperties();
-        final Object other$properties = other.getProperties();
-        if (this$properties == null ? other$properties != null : !this$properties.equals(other$properties))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ModuleConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        result = result * PRIME + (this.isRuntimeModule() ? 79 : 97);
-        final Object $group = this.getGroup();
-        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $version = this.getVersion();
-        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
-        final Object $main = this.getMain();
-        result = result * PRIME + ($main == null ? 43 : $main.hashCode());
-        final Object $description = this.getDescription();
-        result = result * PRIME + ($description == null ? 43 : $description.hashCode());
-        final Object $author = this.getAuthor();
-        result = result * PRIME + ($author == null ? 43 : $author.hashCode());
-        final Object $website = this.getWebsite();
-        result = result * PRIME + ($website == null ? 43 : $website.hashCode());
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getRepos());
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getDependencies());
-        final Object $properties = this.getProperties();
-        result = result * PRIME + ($properties == null ? 43 : $properties.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "ModuleConfiguration(runtimeModule=" + this.isRuntimeModule() + ", group=" + this.getGroup() + ", name=" + this.getName() + ", version=" + this.getVersion() + ", main=" + this.getMain() + ", description=" + this.getDescription() + ", author=" + this.getAuthor() + ", website=" + this.getWebsite() + ", repos=" + java.util.Arrays.deepToString(this.getRepos()) + ", dependencies=" + java.util.Arrays.deepToString(this.getDependencies()) + ", properties=" + this.getProperties() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleConfiguration.java
@@ -1,13 +1,7 @@
 package de.dytanic.cloudnet.driver.module;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.*;
 
-@Getter
-@ToString
-@EqualsAndHashCode
-@NoArgsConstructor
-@AllArgsConstructor
 public class ModuleConfiguration {
 
     protected boolean runtimeModule;
@@ -29,8 +23,138 @@ public class ModuleConfiguration {
 
     protected JsonDocument properties;
 
+    public ModuleConfiguration(boolean runtimeModule, String group, String name, String version, String main, String description, String author, String website, ModuleRepository[] repos, ModuleDependency[] dependencies, JsonDocument properties) {
+        this.runtimeModule = runtimeModule;
+        this.group = group;
+        this.name = name;
+        this.version = version;
+        this.main = main;
+        this.description = description;
+        this.author = author;
+        this.website = website;
+        this.repos = repos;
+        this.dependencies = dependencies;
+        this.properties = properties;
+    }
+
+    public ModuleConfiguration() {
+    }
+
     public String getMainClass() {
         return this.main;
     }
 
+    public boolean isRuntimeModule() {
+        return this.runtimeModule;
+    }
+
+    public String getGroup() {
+        return this.group;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public String getMain() {
+        return this.main;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public String getAuthor() {
+        return this.author;
+    }
+
+    public String getWebsite() {
+        return this.website;
+    }
+
+    public ModuleRepository[] getRepos() {
+        return this.repos;
+    }
+
+    public ModuleDependency[] getDependencies() {
+        return this.dependencies;
+    }
+
+    public JsonDocument getProperties() {
+        return this.properties;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ModuleConfiguration)) return false;
+        final ModuleConfiguration other = (ModuleConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (this.isRuntimeModule() != other.isRuntimeModule()) return false;
+        final Object this$group = this.getGroup();
+        final Object other$group = other.getGroup();
+        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$version = this.getVersion();
+        final Object other$version = other.getVersion();
+        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
+        final Object this$main = this.getMain();
+        final Object other$main = other.getMain();
+        if (this$main == null ? other$main != null : !this$main.equals(other$main)) return false;
+        final Object this$description = this.getDescription();
+        final Object other$description = other.getDescription();
+        if (this$description == null ? other$description != null : !this$description.equals(other$description))
+            return false;
+        final Object this$author = this.getAuthor();
+        final Object other$author = other.getAuthor();
+        if (this$author == null ? other$author != null : !this$author.equals(other$author)) return false;
+        final Object this$website = this.getWebsite();
+        final Object other$website = other.getWebsite();
+        if (this$website == null ? other$website != null : !this$website.equals(other$website)) return false;
+        if (!java.util.Arrays.deepEquals(this.getRepos(), other.getRepos())) return false;
+        if (!java.util.Arrays.deepEquals(this.getDependencies(), other.getDependencies())) return false;
+        final Object this$properties = this.getProperties();
+        final Object other$properties = other.getProperties();
+        if (this$properties == null ? other$properties != null : !this$properties.equals(other$properties))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ModuleConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + (this.isRuntimeModule() ? 79 : 97);
+        final Object $group = this.getGroup();
+        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $version = this.getVersion();
+        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
+        final Object $main = this.getMain();
+        result = result * PRIME + ($main == null ? 43 : $main.hashCode());
+        final Object $description = this.getDescription();
+        result = result * PRIME + ($description == null ? 43 : $description.hashCode());
+        final Object $author = this.getAuthor();
+        result = result * PRIME + ($author == null ? 43 : $author.hashCode());
+        final Object $website = this.getWebsite();
+        result = result * PRIME + ($website == null ? 43 : $website.hashCode());
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getRepos());
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getDependencies());
+        final Object $properties = this.getProperties();
+        result = result * PRIME + ($properties == null ? 43 : $properties.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "ModuleConfiguration(runtimeModule=" + this.isRuntimeModule() + ", group=" + this.getGroup() + ", name=" + this.getName() + ", version=" + this.getVersion() + ", main=" + this.getMain() + ", description=" + this.getDescription() + ", author=" + this.getAuthor() + ", website=" + this.getWebsite() + ", repos=" + java.util.Arrays.deepToString(this.getRepos()) + ", dependencies=" + java.util.Arrays.deepToString(this.getDependencies()) + ", properties=" + this.getProperties() + ")";
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleDependency.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleDependency.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.driver.module;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class ModuleDependency {
 
     private String repo, url, group, name, version;
@@ -35,50 +40,4 @@ public class ModuleDependency {
         return this.version;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ModuleDependency)) return false;
-        final ModuleDependency other = (ModuleDependency) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$repo = this.getRepo();
-        final Object other$repo = other.getRepo();
-        if (this$repo == null ? other$repo != null : !this$repo.equals(other$repo)) return false;
-        final Object this$url = this.getUrl();
-        final Object other$url = other.getUrl();
-        if (this$url == null ? other$url != null : !this$url.equals(other$url)) return false;
-        final Object this$group = this.getGroup();
-        final Object other$group = other.getGroup();
-        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$version = this.getVersion();
-        final Object other$version = other.getVersion();
-        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ModuleDependency;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $repo = this.getRepo();
-        result = result * PRIME + ($repo == null ? 43 : $repo.hashCode());
-        final Object $url = this.getUrl();
-        result = result * PRIME + ($url == null ? 43 : $url.hashCode());
-        final Object $group = this.getGroup();
-        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $version = this.getVersion();
-        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "ModuleDependency(repo=" + this.getRepo() + ", url=" + this.getUrl() + ", group=" + this.getGroup() + ", name=" + this.getName() + ", version=" + this.getVersion() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleDependency.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleDependency.java
@@ -1,14 +1,84 @@
 package de.dytanic.cloudnet.driver.module;
 
-import lombok.*;
-
-@Getter
-@ToString
-@EqualsAndHashCode
-@NoArgsConstructor
-@AllArgsConstructor
 public class ModuleDependency {
 
     private String repo, url, group, name, version;
 
+    public ModuleDependency(String repo, String url, String group, String name, String version) {
+        this.repo = repo;
+        this.url = url;
+        this.group = group;
+        this.name = name;
+        this.version = version;
+    }
+
+    public ModuleDependency() {
+    }
+
+    public String getRepo() {
+        return this.repo;
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    public String getGroup() {
+        return this.group;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ModuleDependency)) return false;
+        final ModuleDependency other = (ModuleDependency) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$repo = this.getRepo();
+        final Object other$repo = other.getRepo();
+        if (this$repo == null ? other$repo != null : !this$repo.equals(other$repo)) return false;
+        final Object this$url = this.getUrl();
+        final Object other$url = other.getUrl();
+        if (this$url == null ? other$url != null : !this$url.equals(other$url)) return false;
+        final Object this$group = this.getGroup();
+        final Object other$group = other.getGroup();
+        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$version = this.getVersion();
+        final Object other$version = other.getVersion();
+        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ModuleDependency;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $repo = this.getRepo();
+        result = result * PRIME + ($repo == null ? 43 : $repo.hashCode());
+        final Object $url = this.getUrl();
+        result = result * PRIME + ($url == null ? 43 : $url.hashCode());
+        final Object $group = this.getGroup();
+        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $version = this.getVersion();
+        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "ModuleDependency(repo=" + this.getRepo() + ", url=" + this.getUrl() + ", group=" + this.getGroup() + ", name=" + this.getName() + ", version=" + this.getVersion() + ")";
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleRepository.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleRepository.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.driver.module;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class ModuleRepository {
 
     private String name, url;
@@ -20,35 +25,4 @@ public class ModuleRepository {
         return this.url;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ModuleRepository)) return false;
-        final ModuleRepository other = (ModuleRepository) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$url = this.getUrl();
-        final Object other$url = other.getUrl();
-        if (this$url == null ? other$url != null : !this$url.equals(other$url)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ModuleRepository;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $url = this.getUrl();
-        result = result * PRIME + ($url == null ? 43 : $url.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "ModuleRepository(name=" + this.getName() + ", url=" + this.getUrl() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleRepository.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleRepository.java
@@ -1,14 +1,54 @@
 package de.dytanic.cloudnet.driver.module;
 
-import lombok.*;
-
-@Getter
-@ToString
-@EqualsAndHashCode
-@NoArgsConstructor
-@AllArgsConstructor
 public class ModuleRepository {
 
     private String name, url;
 
+    public ModuleRepository(String name, String url) {
+        this.name = name;
+        this.url = url;
+    }
+
+    public ModuleRepository() {
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ModuleRepository)) return false;
+        final ModuleRepository other = (ModuleRepository) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$url = this.getUrl();
+        final Object other$url = other.getUrl();
+        if (this$url == null ? other$url != null : !this$url.equals(other$url)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ModuleRepository;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $url = this.getUrl();
+        result = result * PRIME + ($url == null ? 43 : $url.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "ModuleRepository(name=" + this.getName() + ", url=" + this.getUrl() + ")";
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleUpdateServiceConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleUpdateServiceConfiguration.java
@@ -1,16 +1,91 @@
 package de.dytanic.cloudnet.driver.module;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class ModuleUpdateServiceConfiguration {
 
     protected boolean autoInstall;
 
     protected String url, currentVersion, infoMessage;
 
+    public ModuleUpdateServiceConfiguration(boolean autoInstall, String url, String currentVersion, String infoMessage) {
+        this.autoInstall = autoInstall;
+        this.url = url;
+        this.currentVersion = currentVersion;
+        this.infoMessage = infoMessage;
+    }
+
+    public ModuleUpdateServiceConfiguration() {
+    }
+
+    public boolean isAutoInstall() {
+        return this.autoInstall;
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    public String getCurrentVersion() {
+        return this.currentVersion;
+    }
+
+    public String getInfoMessage() {
+        return this.infoMessage;
+    }
+
+    public void setAutoInstall(boolean autoInstall) {
+        this.autoInstall = autoInstall;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public void setCurrentVersion(String currentVersion) {
+        this.currentVersion = currentVersion;
+    }
+
+    public void setInfoMessage(String infoMessage) {
+        this.infoMessage = infoMessage;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ModuleUpdateServiceConfiguration)) return false;
+        final ModuleUpdateServiceConfiguration other = (ModuleUpdateServiceConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (this.isAutoInstall() != other.isAutoInstall()) return false;
+        final Object this$url = this.getUrl();
+        final Object other$url = other.getUrl();
+        if (this$url == null ? other$url != null : !this$url.equals(other$url)) return false;
+        final Object this$currentVersion = this.getCurrentVersion();
+        final Object other$currentVersion = other.getCurrentVersion();
+        if (this$currentVersion == null ? other$currentVersion != null : !this$currentVersion.equals(other$currentVersion))
+            return false;
+        final Object this$infoMessage = this.getInfoMessage();
+        final Object other$infoMessage = other.getInfoMessage();
+        if (this$infoMessage == null ? other$infoMessage != null : !this$infoMessage.equals(other$infoMessage))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ModuleUpdateServiceConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + (this.isAutoInstall() ? 79 : 97);
+        final Object $url = this.getUrl();
+        result = result * PRIME + ($url == null ? 43 : $url.hashCode());
+        final Object $currentVersion = this.getCurrentVersion();
+        result = result * PRIME + ($currentVersion == null ? 43 : $currentVersion.hashCode());
+        final Object $infoMessage = this.getInfoMessage();
+        result = result * PRIME + ($infoMessage == null ? 43 : $infoMessage.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "ModuleUpdateServiceConfiguration(autoInstall=" + this.isAutoInstall() + ", url=" + this.getUrl() + ", currentVersion=" + this.getCurrentVersion() + ", infoMessage=" + this.getInfoMessage() + ")";
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleUpdateServiceConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/ModuleUpdateServiceConfiguration.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.driver.module;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class ModuleUpdateServiceConfiguration {
 
     protected boolean autoInstall;
@@ -48,44 +53,4 @@ public class ModuleUpdateServiceConfiguration {
         this.infoMessage = infoMessage;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ModuleUpdateServiceConfiguration)) return false;
-        final ModuleUpdateServiceConfiguration other = (ModuleUpdateServiceConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (this.isAutoInstall() != other.isAutoInstall()) return false;
-        final Object this$url = this.getUrl();
-        final Object other$url = other.getUrl();
-        if (this$url == null ? other$url != null : !this$url.equals(other$url)) return false;
-        final Object this$currentVersion = this.getCurrentVersion();
-        final Object other$currentVersion = other.getCurrentVersion();
-        if (this$currentVersion == null ? other$currentVersion != null : !this$currentVersion.equals(other$currentVersion))
-            return false;
-        final Object this$infoMessage = this.getInfoMessage();
-        final Object other$infoMessage = other.getInfoMessage();
-        if (this$infoMessage == null ? other$infoMessage != null : !this$infoMessage.equals(other$infoMessage))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ModuleUpdateServiceConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        result = result * PRIME + (this.isAutoInstall() ? 79 : 97);
-        final Object $url = this.getUrl();
-        result = result * PRIME + ($url == null ? 43 : $url.hashCode());
-        final Object $currentVersion = this.getCurrentVersion();
-        result = result * PRIME + ($currentVersion == null ? 43 : $currentVersion.hashCode());
-        final Object $infoMessage = this.getInfoMessage();
-        result = result * PRIME + ($infoMessage == null ? 43 : $infoMessage.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "ModuleUpdateServiceConfiguration(autoInstall=" + this.isAutoInstall() + ", url=" + this.getUrl() + ", currentVersion=" + this.getCurrentVersion() + ", infoMessage=" + this.getInfoMessage() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/HostAndPort.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/HostAndPort.java
@@ -1,5 +1,7 @@
 package de.dytanic.cloudnet.driver.network;
 
+import lombok.EqualsAndHashCode;
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
@@ -7,6 +9,7 @@ import java.net.SocketAddress;
  * This class holds a easy IP/Hostname and port configuration
  * for a server or a client bind address
  */
+@EqualsAndHashCode
 public class HostAndPort {
 
     /**
@@ -54,28 +57,4 @@ public class HostAndPort {
         return this.port;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof HostAndPort)) return false;
-        final HostAndPort other = (HostAndPort) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$host = this.getHost();
-        final Object other$host = other.getHost();
-        if (this$host == null ? other$host != null : !this$host.equals(other$host)) return false;
-        if (this.getPort() != other.getPort()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof HostAndPort;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $host = this.getHost();
-        result = result * PRIME + ($host == null ? 43 : $host.hashCode());
-        result = result * PRIME + this.getPort();
-        return result;
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/HostAndPort.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/HostAndPort.java
@@ -1,9 +1,5 @@
 package de.dytanic.cloudnet.driver.network;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
@@ -11,9 +7,6 @@ import java.net.SocketAddress;
  * This class holds a easy IP/Hostname and port configuration
  * for a server or a client bind address
  */
-@Getter
-@EqualsAndHashCode
-@AllArgsConstructor
 public class HostAndPort {
 
     /**
@@ -43,8 +36,46 @@ public class HostAndPort {
         this.port = Integer.parseInt(address[1]);
     }
 
+    public HostAndPort(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
     @Override
     public String toString() {
         return host + ":" + port;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
+
+    public int getPort() {
+        return this.port;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof HostAndPort)) return false;
+        final HostAndPort other = (HostAndPort) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$host = this.getHost();
+        final Object other$host = other.getHost();
+        if (this$host == null ? other$host != null : !this$host.equals(other$host)) return false;
+        if (this.getPort() != other.getPort()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof HostAndPort;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $host = this.getHost();
+        result = result * PRIME + ($host == null ? 43 : $host.hashCode());
+        result = result * PRIME + this.getPort();
+        return result;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkCluster.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkCluster.java
@@ -1,19 +1,67 @@
 package de.dytanic.cloudnet.driver.network.cluster;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.Collection;
 import java.util.UUID;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class NetworkCluster {
 
     private UUID clusterId;
 
     private Collection<NetworkClusterNode> nodes;
 
+    public NetworkCluster(UUID clusterId, Collection<NetworkClusterNode> nodes) {
+        this.clusterId = clusterId;
+        this.nodes = nodes;
+    }
+
+    public NetworkCluster() {
+    }
+
+    public UUID getClusterId() {
+        return this.clusterId;
+    }
+
+    public Collection<NetworkClusterNode> getNodes() {
+        return this.nodes;
+    }
+
+    public void setClusterId(UUID clusterId) {
+        this.clusterId = clusterId;
+    }
+
+    public void setNodes(Collection<NetworkClusterNode> nodes) {
+        this.nodes = nodes;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NetworkCluster)) return false;
+        final NetworkCluster other = (NetworkCluster) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$clusterId = this.getClusterId();
+        final Object other$clusterId = other.getClusterId();
+        if (this$clusterId == null ? other$clusterId != null : !this$clusterId.equals(other$clusterId)) return false;
+        final Object this$nodes = this.getNodes();
+        final Object other$nodes = other.getNodes();
+        if (this$nodes == null ? other$nodes != null : !this$nodes.equals(other$nodes)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof NetworkCluster;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $clusterId = this.getClusterId();
+        result = result * PRIME + ($clusterId == null ? 43 : $clusterId.hashCode());
+        final Object $nodes = this.getNodes();
+        result = result * PRIME + ($nodes == null ? 43 : $nodes.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "NetworkCluster(clusterId=" + this.getClusterId() + ", nodes=" + this.getNodes() + ")";
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkCluster.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkCluster.java
@@ -1,8 +1,13 @@
 package de.dytanic.cloudnet.driver.network.cluster;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.Collection;
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 public class NetworkCluster {
 
     private UUID clusterId;
@@ -33,35 +38,4 @@ public class NetworkCluster {
         this.nodes = nodes;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NetworkCluster)) return false;
-        final NetworkCluster other = (NetworkCluster) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$clusterId = this.getClusterId();
-        final Object other$clusterId = other.getClusterId();
-        if (this$clusterId == null ? other$clusterId != null : !this$clusterId.equals(other$clusterId)) return false;
-        final Object this$nodes = this.getNodes();
-        final Object other$nodes = other.getNodes();
-        if (this$nodes == null ? other$nodes != null : !this$nodes.equals(other$nodes)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof NetworkCluster;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $clusterId = this.getClusterId();
-        result = result * PRIME + ($clusterId == null ? 43 : $clusterId.hashCode());
-        final Object $nodes = this.getNodes();
-        result = result * PRIME + ($nodes == null ? 43 : $nodes.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "NetworkCluster(clusterId=" + this.getClusterId() + ", nodes=" + this.getNodes() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNode.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNode.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.driver.network.cluster;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
 public class NetworkClusterNode extends BasicJsonDocPropertyable {
 
     private final String uniqueId;
 
     private final HostAndPort[] listeners;
 
+    public NetworkClusterNode(String uniqueId, HostAndPort[] listeners) {
+        this.uniqueId = uniqueId;
+        this.listeners = listeners;
+    }
+
+    public String getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public HostAndPort[] getListeners() {
+        return this.listeners;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNodeExtensionSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNodeExtensionSnapshot.java
@@ -1,7 +1,11 @@
 package de.dytanic.cloudnet.driver.network.cluster;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public class NetworkClusterNodeExtensionSnapshot extends BasicJsonDocPropertyable {
 
     protected String group, name, version, author, website, description;
@@ -66,57 +70,4 @@ public class NetworkClusterNodeExtensionSnapshot extends BasicJsonDocPropertyabl
         this.description = description;
     }
 
-    public String toString() {
-        return "NetworkClusterNodeExtensionSnapshot(group=" + this.getGroup() + ", name=" + this.getName() + ", version=" + this.getVersion() + ", author=" + this.getAuthor() + ", website=" + this.getWebsite() + ", description=" + this.getDescription() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NetworkClusterNodeExtensionSnapshot))
-            return false;
-        final NetworkClusterNodeExtensionSnapshot other = (NetworkClusterNodeExtensionSnapshot) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$group = this.getGroup();
-        final Object other$group = other.getGroup();
-        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$version = this.getVersion();
-        final Object other$version = other.getVersion();
-        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
-        final Object this$author = this.getAuthor();
-        final Object other$author = other.getAuthor();
-        if (this$author == null ? other$author != null : !this$author.equals(other$author)) return false;
-        final Object this$website = this.getWebsite();
-        final Object other$website = other.getWebsite();
-        if (this$website == null ? other$website != null : !this$website.equals(other$website)) return false;
-        final Object this$description = this.getDescription();
-        final Object other$description = other.getDescription();
-        if (this$description == null ? other$description != null : !this$description.equals(other$description))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof NetworkClusterNodeExtensionSnapshot;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $group = this.getGroup();
-        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $version = this.getVersion();
-        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
-        final Object $author = this.getAuthor();
-        result = result * PRIME + ($author == null ? 43 : $author.hashCode());
-        final Object $website = this.getWebsite();
-        result = result * PRIME + ($website == null ? 43 : $website.hashCode());
-        final Object $description = this.getDescription();
-        result = result * PRIME + ($description == null ? 43 : $description.hashCode());
-        return result;
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNodeExtensionSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNodeExtensionSnapshot.java
@@ -1,17 +1,122 @@
 package de.dytanic.cloudnet.driver.network.cluster;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public class NetworkClusterNodeExtensionSnapshot extends BasicJsonDocPropertyable {
 
     protected String group, name, version, author, website, description;
 
+    public NetworkClusterNodeExtensionSnapshot(String group, String name, String version, String author, String website, String description) {
+        this.group = group;
+        this.name = name;
+        this.version = version;
+        this.author = author;
+        this.website = website;
+        this.description = description;
+    }
+
+    public NetworkClusterNodeExtensionSnapshot() {
+    }
+
+    public String getGroup() {
+        return this.group;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public String getAuthor() {
+        return this.author;
+    }
+
+    public String getWebsite() {
+        return this.website;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public void setWebsite(String website) {
+        this.website = website;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String toString() {
+        return "NetworkClusterNodeExtensionSnapshot(group=" + this.getGroup() + ", name=" + this.getName() + ", version=" + this.getVersion() + ", author=" + this.getAuthor() + ", website=" + this.getWebsite() + ", description=" + this.getDescription() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NetworkClusterNodeExtensionSnapshot))
+            return false;
+        final NetworkClusterNodeExtensionSnapshot other = (NetworkClusterNodeExtensionSnapshot) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$group = this.getGroup();
+        final Object other$group = other.getGroup();
+        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$version = this.getVersion();
+        final Object other$version = other.getVersion();
+        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
+        final Object this$author = this.getAuthor();
+        final Object other$author = other.getAuthor();
+        if (this$author == null ? other$author != null : !this$author.equals(other$author)) return false;
+        final Object this$website = this.getWebsite();
+        final Object other$website = other.getWebsite();
+        if (this$website == null ? other$website != null : !this$website.equals(other$website)) return false;
+        final Object this$description = this.getDescription();
+        final Object other$description = other.getDescription();
+        if (this$description == null ? other$description != null : !this$description.equals(other$description))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof NetworkClusterNodeExtensionSnapshot;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $group = this.getGroup();
+        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $version = this.getVersion();
+        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
+        final Object $author = this.getAuthor();
+        result = result * PRIME + ($author == null ? 43 : $author.hashCode());
+        final Object $website = this.getWebsite();
+        result = result * PRIME + ($website == null ? 43 : $website.hashCode());
+        final Object $description = this.getDescription();
+        result = result * PRIME + ($description == null ? 43 : $description.hashCode());
+        return result;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNodeInfoSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNodeInfoSnapshot.java
@@ -3,10 +3,14 @@ package de.dytanic.cloudnet.driver.network.cluster;
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
 import de.dytanic.cloudnet.driver.service.ProcessSnapshot;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public class NetworkClusterNodeInfoSnapshot extends BasicJsonDocPropertyable {
 
     public static final Type TYPE = new TypeToken<NetworkClusterNodeInfoSnapshot>() {
@@ -111,58 +115,4 @@ public class NetworkClusterNodeInfoSnapshot extends BasicJsonDocPropertyable {
         this.extensions = extensions;
     }
 
-    public String toString() {
-        return "NetworkClusterNodeInfoSnapshot(creationTime=" + this.getCreationTime() + ", node=" + this.getNode() + ", version=" + this.getVersion() + ", currentServicesCount=" + this.getCurrentServicesCount() + ", usedMemory=" + this.getUsedMemory() + ", reservedMemory=" + this.getReservedMemory() + ", maxMemory=" + this.getMaxMemory() + ", processSnapshot=" + this.getProcessSnapshot() + ", extensions=" + this.getExtensions() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NetworkClusterNodeInfoSnapshot)) return false;
-        final NetworkClusterNodeInfoSnapshot other = (NetworkClusterNodeInfoSnapshot) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (this.getCreationTime() != other.getCreationTime()) return false;
-        final Object this$node = this.getNode();
-        final Object other$node = other.getNode();
-        if (this$node == null ? other$node != null : !this$node.equals(other$node)) return false;
-        final Object this$version = this.getVersion();
-        final Object other$version = other.getVersion();
-        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
-        if (this.getCurrentServicesCount() != other.getCurrentServicesCount()) return false;
-        if (this.getUsedMemory() != other.getUsedMemory()) return false;
-        if (this.getReservedMemory() != other.getReservedMemory()) return false;
-        if (this.getMaxMemory() != other.getMaxMemory()) return false;
-        final Object this$processSnapshot = this.getProcessSnapshot();
-        final Object other$processSnapshot = other.getProcessSnapshot();
-        if (this$processSnapshot == null ? other$processSnapshot != null : !this$processSnapshot.equals(other$processSnapshot))
-            return false;
-        final Object this$extensions = this.getExtensions();
-        final Object other$extensions = other.getExtensions();
-        if (this$extensions == null ? other$extensions != null : !this$extensions.equals(other$extensions))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof NetworkClusterNodeInfoSnapshot;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final long $creationTime = this.getCreationTime();
-        result = result * PRIME + (int) ($creationTime >>> 32 ^ $creationTime);
-        final Object $node = this.getNode();
-        result = result * PRIME + ($node == null ? 43 : $node.hashCode());
-        final Object $version = this.getVersion();
-        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
-        result = result * PRIME + this.getCurrentServicesCount();
-        result = result * PRIME + this.getUsedMemory();
-        result = result * PRIME + this.getReservedMemory();
-        result = result * PRIME + this.getMaxMemory();
-        final Object $processSnapshot = this.getProcessSnapshot();
-        result = result * PRIME + ($processSnapshot == null ? 43 : $processSnapshot.hashCode());
-        final Object $extensions = this.getExtensions();
-        result = result * PRIME + ($extensions == null ? 43 : $extensions.hashCode());
-        return result;
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNodeInfoSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/cluster/NetworkClusterNodeInfoSnapshot.java
@@ -3,18 +3,10 @@ package de.dytanic.cloudnet.driver.network.cluster;
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
 import de.dytanic.cloudnet.driver.service.ProcessSnapshot;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public class NetworkClusterNodeInfoSnapshot extends BasicJsonDocPropertyable {
 
     public static final Type TYPE = new TypeToken<NetworkClusterNodeInfoSnapshot>() {
@@ -32,4 +24,145 @@ public class NetworkClusterNodeInfoSnapshot extends BasicJsonDocPropertyable {
 
     protected Collection<NetworkClusterNodeExtensionSnapshot> extensions;
 
+    public NetworkClusterNodeInfoSnapshot(long creationTime, NetworkClusterNode node, String version, int currentServicesCount, int usedMemory, int reservedMemory, int maxMemory, ProcessSnapshot processSnapshot, Collection<NetworkClusterNodeExtensionSnapshot> extensions) {
+        this.creationTime = creationTime;
+        this.node = node;
+        this.version = version;
+        this.currentServicesCount = currentServicesCount;
+        this.usedMemory = usedMemory;
+        this.reservedMemory = reservedMemory;
+        this.maxMemory = maxMemory;
+        this.processSnapshot = processSnapshot;
+        this.extensions = extensions;
+    }
+
+    public NetworkClusterNodeInfoSnapshot() {
+    }
+
+    public long getCreationTime() {
+        return this.creationTime;
+    }
+
+    public NetworkClusterNode getNode() {
+        return this.node;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public int getCurrentServicesCount() {
+        return this.currentServicesCount;
+    }
+
+    public int getUsedMemory() {
+        return this.usedMemory;
+    }
+
+    public int getReservedMemory() {
+        return this.reservedMemory;
+    }
+
+    public int getMaxMemory() {
+        return this.maxMemory;
+    }
+
+    public ProcessSnapshot getProcessSnapshot() {
+        return this.processSnapshot;
+    }
+
+    public Collection<NetworkClusterNodeExtensionSnapshot> getExtensions() {
+        return this.extensions;
+    }
+
+    public void setCreationTime(long creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    public void setNode(NetworkClusterNode node) {
+        this.node = node;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public void setCurrentServicesCount(int currentServicesCount) {
+        this.currentServicesCount = currentServicesCount;
+    }
+
+    public void setUsedMemory(int usedMemory) {
+        this.usedMemory = usedMemory;
+    }
+
+    public void setReservedMemory(int reservedMemory) {
+        this.reservedMemory = reservedMemory;
+    }
+
+    public void setMaxMemory(int maxMemory) {
+        this.maxMemory = maxMemory;
+    }
+
+    public void setProcessSnapshot(ProcessSnapshot processSnapshot) {
+        this.processSnapshot = processSnapshot;
+    }
+
+    public void setExtensions(Collection<NetworkClusterNodeExtensionSnapshot> extensions) {
+        this.extensions = extensions;
+    }
+
+    public String toString() {
+        return "NetworkClusterNodeInfoSnapshot(creationTime=" + this.getCreationTime() + ", node=" + this.getNode() + ", version=" + this.getVersion() + ", currentServicesCount=" + this.getCurrentServicesCount() + ", usedMemory=" + this.getUsedMemory() + ", reservedMemory=" + this.getReservedMemory() + ", maxMemory=" + this.getMaxMemory() + ", processSnapshot=" + this.getProcessSnapshot() + ", extensions=" + this.getExtensions() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NetworkClusterNodeInfoSnapshot)) return false;
+        final NetworkClusterNodeInfoSnapshot other = (NetworkClusterNodeInfoSnapshot) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (this.getCreationTime() != other.getCreationTime()) return false;
+        final Object this$node = this.getNode();
+        final Object other$node = other.getNode();
+        if (this$node == null ? other$node != null : !this$node.equals(other$node)) return false;
+        final Object this$version = this.getVersion();
+        final Object other$version = other.getVersion();
+        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
+        if (this.getCurrentServicesCount() != other.getCurrentServicesCount()) return false;
+        if (this.getUsedMemory() != other.getUsedMemory()) return false;
+        if (this.getReservedMemory() != other.getReservedMemory()) return false;
+        if (this.getMaxMemory() != other.getMaxMemory()) return false;
+        final Object this$processSnapshot = this.getProcessSnapshot();
+        final Object other$processSnapshot = other.getProcessSnapshot();
+        if (this$processSnapshot == null ? other$processSnapshot != null : !this$processSnapshot.equals(other$processSnapshot))
+            return false;
+        final Object this$extensions = this.getExtensions();
+        final Object other$extensions = other.getExtensions();
+        if (this$extensions == null ? other$extensions != null : !this$extensions.equals(other$extensions))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof NetworkClusterNodeInfoSnapshot;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final long $creationTime = this.getCreationTime();
+        result = result * PRIME + (int) ($creationTime >>> 32 ^ $creationTime);
+        final Object $node = this.getNode();
+        result = result * PRIME + ($node == null ? 43 : $node.hashCode());
+        final Object $version = this.getVersion();
+        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
+        result = result * PRIME + this.getCurrentServicesCount();
+        result = result * PRIME + this.getUsedMemory();
+        result = result * PRIME + this.getReservedMemory();
+        result = result * PRIME + this.getMaxMemory();
+        final Object $processSnapshot = this.getProcessSnapshot();
+        result = result * PRIME + ($processSnapshot == null ? 43 : $processSnapshot.hashCode());
+        final Object $extensions = this.getExtensions();
+        result = result * PRIME + ($extensions == null ? 43 : $extensions.hashCode());
+        return result;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/def/packet/PacketClientAuthorization.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/def/packet/PacketClientAuthorization.java
@@ -4,8 +4,6 @@ import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.network.def.PacketConstants;
 import de.dytanic.cloudnet.driver.network.protocol.Packet;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 public final class PacketClientAuthorization extends Packet {
 
@@ -18,8 +16,6 @@ public final class PacketClientAuthorization extends Packet {
         this.header.append("authorization", packetAuthorizationType).append("credentials", credentials);
     }
 
-    @Getter
-    @AllArgsConstructor
     public enum PacketAuthorizationType {
 
         NODE_TO_NODE(0),
@@ -27,5 +23,12 @@ public final class PacketClientAuthorization extends Packet {
 
         private int value;
 
+        private PacketAuthorizationType(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return this.value;
+        }
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/http/HttpCookie.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/http/HttpCookie.java
@@ -1,15 +1,104 @@
 package de.dytanic.cloudnet.driver.network.http;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class HttpCookie {
 
     protected String name, value, domain, path;
 
     protected long maxAge;
+
+    public HttpCookie(String name, String value, String domain, String path, long maxAge) {
+        this.name = name;
+        this.value = value;
+        this.domain = domain;
+        this.path = path;
+        this.maxAge = maxAge;
+    }
+
+    public HttpCookie() {
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public String getDomain() {
+        return this.domain;
+    }
+
+    public String getPath() {
+        return this.path;
+    }
+
+    public long getMaxAge() {
+        return this.maxAge;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public void setMaxAge(long maxAge) {
+        this.maxAge = maxAge;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof HttpCookie)) return false;
+        final HttpCookie other = (HttpCookie) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$value = this.getValue();
+        final Object other$value = other.getValue();
+        if (this$value == null ? other$value != null : !this$value.equals(other$value)) return false;
+        final Object this$domain = this.getDomain();
+        final Object other$domain = other.getDomain();
+        if (this$domain == null ? other$domain != null : !this$domain.equals(other$domain)) return false;
+        final Object this$path = this.getPath();
+        final Object other$path = other.getPath();
+        if (this$path == null ? other$path != null : !this$path.equals(other$path)) return false;
+        if (this.getMaxAge() != other.getMaxAge()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof HttpCookie;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $value = this.getValue();
+        result = result * PRIME + ($value == null ? 43 : $value.hashCode());
+        final Object $domain = this.getDomain();
+        result = result * PRIME + ($domain == null ? 43 : $domain.hashCode());
+        final Object $path = this.getPath();
+        result = result * PRIME + ($path == null ? 43 : $path.hashCode());
+        final long $maxAge = this.getMaxAge();
+        result = result * PRIME + (int) ($maxAge >>> 32 ^ $maxAge);
+        return result;
+    }
+
+    public String toString() {
+        return "HttpCookie(name=" + this.getName() + ", value=" + this.getValue() + ", domain=" + this.getDomain() + ", path=" + this.getPath() + ", maxAge=" + this.getMaxAge() + ")";
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/http/HttpCookie.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/http/HttpCookie.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.driver.network.http;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class HttpCookie {
 
     protected String name, value, domain, path;
@@ -57,48 +62,4 @@ public class HttpCookie {
         this.maxAge = maxAge;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof HttpCookie)) return false;
-        final HttpCookie other = (HttpCookie) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$value = this.getValue();
-        final Object other$value = other.getValue();
-        if (this$value == null ? other$value != null : !this$value.equals(other$value)) return false;
-        final Object this$domain = this.getDomain();
-        final Object other$domain = other.getDomain();
-        if (this$domain == null ? other$domain != null : !this$domain.equals(other$domain)) return false;
-        final Object this$path = this.getPath();
-        final Object other$path = other.getPath();
-        if (this$path == null ? other$path != null : !this$path.equals(other$path)) return false;
-        if (this.getMaxAge() != other.getMaxAge()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof HttpCookie;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $value = this.getValue();
-        result = result * PRIME + ($value == null ? 43 : $value.hashCode());
-        final Object $domain = this.getDomain();
-        result = result * PRIME + ($domain == null ? 43 : $domain.hashCode());
-        final Object $path = this.getPath();
-        result = result * PRIME + ($path == null ? 43 : $path.hashCode());
-        final long $maxAge = this.getMaxAge();
-        result = result * PRIME + (int) ($maxAge >>> 32 ^ $maxAge);
-        return result;
-    }
-
-    public String toString() {
-        return "HttpCookie(name=" + this.getName() + ", value=" + this.getValue() + ", domain=" + this.getDomain() + ", path=" + this.getPath() + ", maxAge=" + this.getMaxAge() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpChannel.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpChannel.java
@@ -3,16 +3,18 @@ package de.dytanic.cloudnet.driver.network.netty;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.driver.network.http.IHttpChannel;
 import io.netty.channel.Channel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 final class NettyHttpChannel implements IHttpChannel {
 
     protected final Channel channel;
 
     protected final HostAndPort serverAddress, clientAddress;
+
+    public NettyHttpChannel(Channel channel, HostAndPort serverAddress, HostAndPort clientAddress) {
+        this.channel = channel;
+        this.serverAddress = serverAddress;
+        this.clientAddress = clientAddress;
+    }
 
     @Override
     public HostAndPort serverAddress() {
@@ -27,5 +29,17 @@ final class NettyHttpChannel implements IHttpChannel {
     @Override
     public void close() throws Exception {
         channel.close();
+    }
+
+    public Channel getChannel() {
+        return this.channel;
+    }
+
+    public HostAndPort getServerAddress() {
+        return this.serverAddress;
+    }
+
+    public HostAndPort getClientAddress() {
+        return this.clientAddress;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServer.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServer.java
@@ -14,9 +14,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 import java.util.Collection;
 import java.util.List;
@@ -178,9 +175,6 @@ public final class NettyHttpServer extends NettySSLServer implements IHttpServer
 
     /*= ---------------------------------------------------------- =*/
 
-    @ToString
-    @EqualsAndHashCode
-    @RequiredArgsConstructor
     public class HttpHandlerEntry implements Comparable<HttpHandlerEntry> {
 
         public final String path;
@@ -191,11 +185,58 @@ public final class NettyHttpServer extends NettySSLServer implements IHttpServer
 
         public final int priority;
 
+        public HttpHandlerEntry(String path, IHttpHandler httpHandler, Integer port, int priority) {
+            this.path = path;
+            this.httpHandler = httpHandler;
+            this.port = port;
+            this.priority = priority;
+        }
+
         @Override
         public int compareTo(HttpHandlerEntry httpHandlerEntry) {
             Validate.checkNotNull(httpHandlerEntry);
 
             return this.priority + httpHandlerEntry.priority;
+        }
+
+        public boolean equals(final Object o) {
+            if (o == this) return true;
+            if (!(o instanceof HttpHandlerEntry)) return false;
+            final HttpHandlerEntry other = (HttpHandlerEntry) o;
+            if (!other.canEqual((Object) this)) return false;
+            final Object this$path = this.path;
+            final Object other$path = other.path;
+            if (this$path == null ? other$path != null : !this$path.equals(other$path)) return false;
+            final Object this$httpHandler = this.httpHandler;
+            final Object other$httpHandler = other.httpHandler;
+            if (this$httpHandler == null ? other$httpHandler != null : !this$httpHandler.equals(other$httpHandler))
+                return false;
+            final Object this$port = this.port;
+            final Object other$port = other.port;
+            if (this$port == null ? other$port != null : !this$port.equals(other$port)) return false;
+            if (this.priority != other.priority) return false;
+            return true;
+        }
+
+        protected boolean canEqual(final Object other) {
+            return other instanceof HttpHandlerEntry;
+        }
+
+        public int hashCode() {
+            final int PRIME = 59;
+            int result = 1;
+            final Object $path = this.path;
+            result = result * PRIME + ($path == null ? 43 : $path.hashCode());
+            final Object $httpHandler = this.httpHandler;
+            result = result * PRIME + ($httpHandler == null ? 43 : $httpHandler.hashCode());
+            final Object $port = this.port;
+            result = result * PRIME + ($port == null ? 43 : $port.hashCode());
+            result = result * PRIME + this.priority;
+            return result;
+        }
+
+        public String toString() {
+            return "NettyHttpServer.HttpHandlerEntry(path=" + this.path + ", httpHandler=" + this.httpHandler + ", port=" + this.port + ", priority=" + this.priority + ")";
         }
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServer.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServer.java
@@ -14,6 +14,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Collection;
 import java.util.List;
@@ -175,6 +177,8 @@ public final class NettyHttpServer extends NettySSLServer implements IHttpServer
 
     /*= ---------------------------------------------------------- =*/
 
+    @ToString
+    @EqualsAndHashCode
     public class HttpHandlerEntry implements Comparable<HttpHandlerEntry> {
 
         public final String path;
@@ -197,46 +201,6 @@ public final class NettyHttpServer extends NettySSLServer implements IHttpServer
             Validate.checkNotNull(httpHandlerEntry);
 
             return this.priority + httpHandlerEntry.priority;
-        }
-
-        public boolean equals(final Object o) {
-            if (o == this) return true;
-            if (!(o instanceof HttpHandlerEntry)) return false;
-            final HttpHandlerEntry other = (HttpHandlerEntry) o;
-            if (!other.canEqual((Object) this)) return false;
-            final Object this$path = this.path;
-            final Object other$path = other.path;
-            if (this$path == null ? other$path != null : !this$path.equals(other$path)) return false;
-            final Object this$httpHandler = this.httpHandler;
-            final Object other$httpHandler = other.httpHandler;
-            if (this$httpHandler == null ? other$httpHandler != null : !this$httpHandler.equals(other$httpHandler))
-                return false;
-            final Object this$port = this.port;
-            final Object other$port = other.port;
-            if (this$port == null ? other$port != null : !this$port.equals(other$port)) return false;
-            if (this.priority != other.priority) return false;
-            return true;
-        }
-
-        protected boolean canEqual(final Object other) {
-            return other instanceof HttpHandlerEntry;
-        }
-
-        public int hashCode() {
-            final int PRIME = 59;
-            int result = 1;
-            final Object $path = this.path;
-            result = result * PRIME + ($path == null ? 43 : $path.hashCode());
-            final Object $httpHandler = this.httpHandler;
-            result = result * PRIME + ($httpHandler == null ? 43 : $httpHandler.hashCode());
-            final Object $port = this.port;
-            result = result * PRIME + ($port == null ? 43 : $port.hashCode());
-            result = result * PRIME + this.priority;
-            return result;
-        }
-
-        public String toString() {
-            return "NettyHttpServer.HttpHandlerEntry(path=" + this.path + ", httpHandler=" + this.httpHandler + ", port=" + this.port + ", priority=" + this.priority + ")";
         }
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServerContext.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServerContext.java
@@ -12,7 +12,6 @@ import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
-import lombok.Setter;
 
 import java.net.URI;
 import java.util.Collection;
@@ -40,7 +39,6 @@ final class NettyHttpServerContext implements IHttpContext {
 
     protected volatile NettyWebSocketServerChannel webSocketServerChannel;
 
-    @Setter
     protected IHttpHandler lastHandler;
 
     public NettyHttpServerContext(NettyHttpServer nettyHttpServer, NettyHttpChannel channel, URI uri, Map<String, String> pathParameters, HttpRequest httpRequest) {
@@ -226,5 +224,9 @@ final class NettyHttpServerContext implements IHttpContext {
                             return cookie;
                         }
                     })));
+    }
+
+    public void setLastHandler(IHttpHandler lastHandler) {
+        this.lastHandler = lastHandler;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServerHandler.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServerHandler.java
@@ -6,7 +6,6 @@ import de.dytanic.cloudnet.driver.network.HostAndPort;
 import io.netty.channel.*;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.HttpRequest;
-import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 import java.net.URI;
@@ -14,7 +13,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-@RequiredArgsConstructor
 final class NettyHttpServerHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
     private final NettyHttpServer nettyHttpServer;
@@ -22,6 +20,11 @@ final class NettyHttpServerHandler extends SimpleChannelInboundHandler<HttpReque
     private final HostAndPort connectedAddress;
 
     private NettyHttpChannel channel;
+
+    public NettyHttpServerHandler(NettyHttpServer nettyHttpServer, HostAndPort connectedAddress) {
+        this.nettyHttpServer = nettyHttpServer;
+        this.connectedAddress = connectedAddress;
+    }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServerInitializer.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyHttpServerInitializer.java
@@ -5,14 +5,17 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 final class NettyHttpServerInitializer extends ChannelInitializer<Channel> {
 
     private final NettyHttpServer nettyHttpServer;
 
     private final HostAndPort hostAndPort;
+
+    public NettyHttpServerInitializer(NettyHttpServer nettyHttpServer, HostAndPort hostAndPort) {
+        this.nettyHttpServer = nettyHttpServer;
+        this.hostAndPort = hostAndPort;
+    }
 
     @Override
     protected void initChannel(Channel ch) throws Exception {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkChannel.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkChannel.java
@@ -8,13 +8,10 @@ import de.dytanic.cloudnet.driver.network.protocol.DefaultPacketListenerRegistry
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
 import de.dytanic.cloudnet.driver.network.protocol.IPacketListenerRegistry;
 import io.netty.channel.Channel;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;
 
-@Getter
 final class NettyNetworkChannel implements INetworkChannel {
 
     private static final Callable<Void> EMPTY_TASK = new Callable<Void>() {
@@ -38,7 +35,6 @@ final class NettyNetworkChannel implements INetworkChannel {
 
     private final boolean clientProvidedChannel;
 
-    @Setter
     private INetworkChannelHandler handler;
 
     public NettyNetworkChannel(Channel channel, IPacketListenerRegistry packetRegistry, INetworkChannelHandler handler,
@@ -84,4 +80,35 @@ final class NettyNetworkChannel implements INetworkChannel {
         this.channel.close();
     }
 
+    public long getChannelId() {
+        return this.channelId;
+    }
+
+    public Channel getChannel() {
+        return this.channel;
+    }
+
+    public IPacketListenerRegistry getPacketRegistry() {
+        return this.packetRegistry;
+    }
+
+    public HostAndPort getServerAddress() {
+        return this.serverAddress;
+    }
+
+    public HostAndPort getClientAddress() {
+        return this.clientAddress;
+    }
+
+    public boolean isClientProvidedChannel() {
+        return this.clientProvidedChannel;
+    }
+
+    public INetworkChannelHandler getHandler() {
+        return this.handler;
+    }
+
+    public void setHandler(INetworkChannelHandler handler) {
+        this.handler = handler;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkClient.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkClient.java
@@ -21,7 +21,6 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
-import lombok.Getter;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -31,7 +30,6 @@ public final class NettyNetworkClient implements INetworkClient {
 
     protected final Collection<INetworkChannel> channels = Iterables.newConcurrentLinkedQueue();
 
-    @Getter
     protected final IPacketListenerRegistry packetRegistry = new DefaultPacketListenerRegistry();
 
     protected final EventLoopGroup eventLoopGroup = NettyUtils.newEventLoopGroup();
@@ -161,5 +159,9 @@ public final class NettyNetworkClient implements INetworkClient {
 
         for (INetworkChannel channel : this.channels)
             channel.sendPacket(packets);
+    }
+
+    public IPacketListenerRegistry getPacketRegistry() {
+        return this.packetRegistry;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkClientHandler.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkClientHandler.java
@@ -4,13 +4,11 @@ import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.driver.network.protocol.Packet;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.Callable;
 
-@RequiredArgsConstructor
 final class NettyNetworkClientHandler extends SimpleChannelInboundHandler<Packet> {
 
     private final NettyNetworkClient nettyNetworkClient;
@@ -18,6 +16,11 @@ final class NettyNetworkClientHandler extends SimpleChannelInboundHandler<Packet
     private final HostAndPort connectedAddress;
 
     private NettyNetworkChannel channel;
+
+    public NettyNetworkClientHandler(NettyNetworkClient nettyNetworkClient, HostAndPort connectedAddress) {
+        this.nettyNetworkClient = nettyNetworkClient;
+        this.connectedAddress = connectedAddress;
+    }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkClientInitializer.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkClientInitializer.java
@@ -3,14 +3,17 @@ package de.dytanic.cloudnet.driver.network.netty;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 final class NettyNetworkClientInitializer extends ChannelInitializer<Channel> {
 
     private final NettyNetworkClient nettyNetworkClient;
 
     private final HostAndPort hostAndPort;
+
+    public NettyNetworkClientInitializer(NettyNetworkClient nettyNetworkClient, HostAndPort hostAndPort) {
+        this.nettyNetworkClient = nettyNetworkClient;
+        this.hostAndPort = hostAndPort;
+    }
 
     @Override
     protected void initChannel(Channel ch) throws Exception {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkServer.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkServer.java
@@ -19,7 +19,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import lombok.Getter;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,7 +31,6 @@ public final class NettyNetworkServer extends NettySSLServer implements INetwork
 
     protected final Collection<INetworkChannel> channels = Iterables.newConcurrentLinkedQueue();
 
-    @Getter
     protected final IPacketListenerRegistry packetRegistry = new DefaultPacketListenerRegistry();
 
     protected final EventLoopGroup bossEventLoopGroup = NettyUtils.newEventLoopGroup(), workerEventLoopGroup = NettyUtils.newEventLoopGroup();
@@ -147,5 +145,9 @@ public final class NettyNetworkServer extends NettySSLServer implements INetwork
 
         for (INetworkChannel channel : this.channels)
             channel.sendPacket(packets);
+    }
+
+    public IPacketListenerRegistry getPacketRegistry() {
+        return this.packetRegistry;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkServerHandler.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkServerHandler.java
@@ -4,13 +4,11 @@ import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.driver.network.protocol.Packet;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.Callable;
 
-@RequiredArgsConstructor
 final class NettyNetworkServerHandler extends SimpleChannelInboundHandler<Packet> {
 
     private final NettyNetworkServer nettyNetworkServer;
@@ -18,6 +16,11 @@ final class NettyNetworkServerHandler extends SimpleChannelInboundHandler<Packet
     private final HostAndPort connectedAddress;
 
     private NettyNetworkChannel channel;
+
+    public NettyNetworkServerHandler(NettyNetworkServer nettyNetworkServer, HostAndPort connectedAddress) {
+        this.nettyNetworkServer = nettyNetworkServer;
+        this.connectedAddress = connectedAddress;
+    }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkServerInitializer.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyNetworkServerInitializer.java
@@ -3,14 +3,17 @@ package de.dytanic.cloudnet.driver.network.netty;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 final class NettyNetworkServerInitializer extends ChannelInitializer<Channel> {
 
     private final NettyNetworkServer nettyNetworkServer;
 
     private final HostAndPort hostAndPort;
+
+    public NettyNetworkServerInitializer(NettyNetworkServer nettyNetworkServer, HostAndPort hostAndPort) {
+        this.nettyNetworkServer = nettyNetworkServer;
+        this.hostAndPort = hostAndPort;
+    }
 
     @Override
     protected void initChannel(Channel ch) throws Exception {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyWebSocketServerChannel.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyWebSocketServerChannel.java
@@ -11,16 +11,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http.websocketx.*;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
-@Getter
-@RequiredArgsConstructor
 final class NettyWebSocketServerChannel implements IWebSocketChannel {
 
     private final List<IWebSocketListener> webSocketListeners = Iterables.newCopyOnWriteArrayList();
@@ -30,6 +26,12 @@ final class NettyWebSocketServerChannel implements IWebSocketChannel {
     private final Channel channel;
 
     private final WebSocketServerHandshaker webSocketServerHandshaker;
+
+    public NettyWebSocketServerChannel(IHttpChannel httpChannel, Channel channel, WebSocketServerHandshaker webSocketServerHandshaker) {
+        this.httpChannel = httpChannel;
+        this.channel = channel;
+        this.webSocketServerHandshaker = webSocketServerHandshaker;
+    }
 
     @Override
     public IWebSocketChannel addListener(IWebSocketListener... listeners) {
@@ -145,5 +147,21 @@ final class NettyWebSocketServerChannel implements IWebSocketChannel {
     @Override
     public void close() throws Exception {
         this.close(200, "default closing");
+    }
+
+    public List<IWebSocketListener> getWebSocketListeners() {
+        return this.webSocketListeners;
+    }
+
+    public IHttpChannel getHttpChannel() {
+        return this.httpChannel;
+    }
+
+    public Channel getChannel() {
+        return this.channel;
+    }
+
+    public WebSocketServerHandshaker getWebSocketServerHandshaker() {
+        return this.webSocketServerHandshaker;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyWebSocketServerChannelHandler.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyWebSocketServerChannelHandler.java
@@ -5,14 +5,14 @@ import de.dytanic.cloudnet.driver.network.http.websocket.WebSocketFrameType;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.websocketx.*;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 final class NettyWebSocketServerChannelHandler extends SimpleChannelInboundHandler<WebSocketFrame> {
 
     private final NettyWebSocketServerChannel webSocketServerChannel;
+
+    public NettyWebSocketServerChannelHandler(NettyWebSocketServerChannel webSocketServerChannel) {
+        this.webSocketServerChannel = webSocketServerChannel;
+    }
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, WebSocketFrame webSocketFrame) throws Exception {
@@ -54,5 +54,9 @@ final class NettyWebSocketServerChannelHandler extends SimpleChannelInboundHandl
             frame.content().getBytes(frame.content().readerIndex(), bytes);
             return bytes;
         }
+    }
+
+    public NettyWebSocketServerChannel getWebSocketServerChannel() {
+        return this.webSocketServerChannel;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/protocol/DefaultPacketListenerRegistry.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/protocol/DefaultPacketListenerRegistry.java
@@ -4,24 +4,24 @@ import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.common.collection.Maps;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.*;
 
 /**
  * Default IPacketListenerRegistry implementation
  */
-@RequiredArgsConstructor
 public final class DefaultPacketListenerRegistry implements IPacketListenerRegistry {
 
     private final Map<Integer, List<IPacketListener>> listeners = Maps.newConcurrentHashMap();
 
-    @Getter
     private final IPacketListenerRegistry parent;
 
     public DefaultPacketListenerRegistry() {
         this.parent = null;
+    }
+
+    public DefaultPacketListenerRegistry(IPacketListenerRegistry parent) {
+        this.parent = parent;
     }
 
     @Override
@@ -108,5 +108,9 @@ public final class DefaultPacketListenerRegistry implements IPacketListenerRegis
                 } catch (Exception ex) {
                     ex.printStackTrace();
                 }
+    }
+
+    public IPacketListenerRegistry getParent() {
+        return this.parent;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/protocol/Packet.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/protocol/Packet.java
@@ -1,9 +1,6 @@
 package de.dytanic.cloudnet.driver.network.protocol;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
@@ -18,9 +15,6 @@ import java.util.UUID;
  * has the specify information or the data that is important The body has binary
  * packet information like for files, or zip compressed data
  */
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class Packet implements IPacket {
 
     /**
@@ -47,4 +41,29 @@ public class Packet implements IPacket {
         this.uniqueId = UUID.randomUUID();
     }
 
+    public Packet(int channel, UUID uniqueId, JsonDocument header, byte[] body) {
+        this.channel = channel;
+        this.uniqueId = uniqueId;
+        this.header = header;
+        this.body = body;
+    }
+
+    public Packet() {
+    }
+
+    public int getChannel() {
+        return this.channel;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public JsonDocument getHeader() {
+        return this.header;
+    }
+
+    public byte[] getBody() {
+        return this.body;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/ssl/SSLConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/ssl/SSLConfiguration.java
@@ -1,16 +1,33 @@
 package de.dytanic.cloudnet.driver.network.ssl;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.io.File;
 
-@Getter
-@AllArgsConstructor
 public class SSLConfiguration {
 
     protected final boolean clientAuth;
 
     protected final File trustCertificatePath, certificatePath, privateKeyPath;
 
+    public SSLConfiguration(boolean clientAuth, File trustCertificatePath, File certificatePath, File privateKeyPath) {
+        this.clientAuth = clientAuth;
+        this.trustCertificatePath = trustCertificatePath;
+        this.certificatePath = certificatePath;
+        this.privateKeyPath = privateKeyPath;
+    }
+
+    public boolean isClientAuth() {
+        return this.clientAuth;
+    }
+
+    public File getTrustCertificatePath() {
+        return this.trustCertificatePath;
+    }
+
+    public File getCertificatePath() {
+        return this.certificatePath;
+    }
+
+    public File getPrivateKeyPath() {
+        return this.privateKeyPath;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/AbstractPermissible.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/AbstractPermissible.java
@@ -3,23 +3,17 @@ package de.dytanic.cloudnet.driver.permission;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.common.collection.Maps;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
-@Getter
 public abstract class AbstractPermissible extends BasicJsonDocPropertyable implements IPermissible {
 
     protected final long createdTime;
-    @Setter
     protected String name;
-    @Setter
     protected int potency;
-    @Setter
     protected List<Permission> permissions;
 
     protected Map<String, Collection<Permission>> groupPermissions;
@@ -82,5 +76,37 @@ public abstract class AbstractPermissible extends BasicJsonDocPropertyable imple
         }
 
         return true;
+    }
+
+    public long getCreatedTime() {
+        return this.createdTime;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getPotency() {
+        return this.potency;
+    }
+
+    public List<Permission> getPermissions() {
+        return this.permissions;
+    }
+
+    public Map<String, Collection<Permission>> getGroupPermissions() {
+        return this.groupPermissions;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setPotency(int potency) {
+        this.potency = potency;
+    }
+
+    public void setPermissions(List<Permission> permissions) {
+        this.permissions = permissions;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/DefaultJsonFilePermissionManagement.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/DefaultJsonFilePermissionManagement.java
@@ -5,8 +5,6 @@ import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.common.collection.Maps;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.io.File;
 import java.util.Collection;
@@ -23,8 +21,6 @@ public final class DefaultJsonFilePermissionManagement implements IPermissionMan
 
     private final Map<String, IPermissionGroup> permissionGroups = Maps.newConcurrentHashMap();
 
-    @Getter
-    @Setter
     private IPermissionManagementHandler permissionManagementHandler;
 
     public DefaultJsonFilePermissionManagement(File file) {
@@ -300,5 +296,13 @@ public final class DefaultJsonFilePermissionManagement implements IPermissionMan
 
         setGroups(document.get("groups", new TypeToken<Collection<PermissionGroup>>() {
         }.getType()));
+    }
+
+    public IPermissionManagementHandler getPermissionManagementHandler() {
+        return this.permissionManagementHandler;
+    }
+
+    public void setPermissionManagementHandler(IPermissionManagementHandler permissionManagementHandler) {
+        this.permissionManagementHandler = permissionManagementHandler;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/Permission.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/Permission.java
@@ -1,14 +1,7 @@
 package de.dytanic.cloudnet.driver.permission;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 import java.util.concurrent.TimeUnit;
 
-@Data
-@AllArgsConstructor
-@RequiredArgsConstructor
 public final class Permission {
 
     private final String name;
@@ -26,5 +19,62 @@ public final class Permission {
         this.name = name;
         this.potency = potency;
         this.timeOutMillis = System.currentTimeMillis() + timeUnit.toMillis(time);
+    }
+
+    public Permission(String name) {
+        this.name = name;
+    }
+
+    public Permission(String name, int potency, long timeOutMillis) {
+        this.name = name;
+        this.potency = potency;
+        this.timeOutMillis = timeOutMillis;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getPotency() {
+        return this.potency;
+    }
+
+    public long getTimeOutMillis() {
+        return this.timeOutMillis;
+    }
+
+    public void setPotency(int potency) {
+        this.potency = potency;
+    }
+
+    public void setTimeOutMillis(long timeOutMillis) {
+        this.timeOutMillis = timeOutMillis;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Permission)) return false;
+        final Permission other = (Permission) o;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        if (this.getPotency() != other.getPotency()) return false;
+        if (this.getTimeOutMillis() != other.getTimeOutMillis()) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        result = result * PRIME + this.getPotency();
+        final long $timeOutMillis = this.getTimeOutMillis();
+        result = result * PRIME + (int) ($timeOutMillis >>> 32 ^ $timeOutMillis);
+        return result;
+    }
+
+    public String toString() {
+        return "Permission(name=" + this.getName() + ", potency=" + this.getPotency() + ", timeOutMillis=" + this.getTimeOutMillis() + ")";
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/Permission.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/Permission.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.driver.permission;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.concurrent.TimeUnit;
 
+@ToString
+@EqualsAndHashCode
 public final class Permission {
 
     private final String name;
@@ -51,30 +56,4 @@ public final class Permission {
         this.timeOutMillis = timeOutMillis;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof Permission)) return false;
-        final Permission other = (Permission) o;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        if (this.getPotency() != other.getPotency()) return false;
-        if (this.getTimeOutMillis() != other.getTimeOutMillis()) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        result = result * PRIME + this.getPotency();
-        final long $timeOutMillis = this.getTimeOutMillis();
-        result = result * PRIME + (int) ($timeOutMillis >>> 32 ^ $timeOutMillis);
-        return result;
-    }
-
-    public String toString() {
-        return "Permission(name=" + this.getName() + ", potency=" + this.getPotency() + ", timeOutMillis=" + this.getTimeOutMillis() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionCheckResult.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionCheckResult.java
@@ -1,11 +1,8 @@
 package de.dytanic.cloudnet.driver.permission;
 
-import lombok.RequiredArgsConstructor;
-
 /**
  * A response, if a permissible has to check his permission that contains and allow and element
  */
-@RequiredArgsConstructor
 public enum PermissionCheckResult {
 
     /**
@@ -24,6 +21,10 @@ public enum PermissionCheckResult {
     FORBIDDEN(false);
 
     private final boolean value;
+
+    private PermissionCheckResult(boolean value) {
+        this.value = value;
+    }
 
     /**
      * Returns the result as boolean

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionGroup.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionGroup.java
@@ -2,8 +2,6 @@ package de.dytanic.cloudnet.driver.permission;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.collection.Iterables;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -12,8 +10,6 @@ import java.util.Collection;
  * The default implementation of the IPermissionGroup class. This class should use if you want to
  * add new PermissionGroups into the IPermissionManagement implementation
  */
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class PermissionGroup extends AbstractPermissible implements IPermissionGroup {
 
     /**
@@ -54,5 +50,100 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
         this.display = display;
         this.sortId = sortId;
         this.defaultGroup = defaultGroup;
+    }
+
+    public Collection<String> getGroups() {
+        return this.groups;
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+    public String getSuffix() {
+        return this.suffix;
+    }
+
+    public String getDisplay() {
+        return this.display;
+    }
+
+    public int getSortId() {
+        return this.sortId;
+    }
+
+    public boolean isDefaultGroup() {
+        return this.defaultGroup;
+    }
+
+    public void setGroups(Collection<String> groups) {
+        this.groups = groups;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public void setSuffix(String suffix) {
+        this.suffix = suffix;
+    }
+
+    public void setDisplay(String display) {
+        this.display = display;
+    }
+
+    public void setSortId(int sortId) {
+        this.sortId = sortId;
+    }
+
+    public void setDefaultGroup(boolean defaultGroup) {
+        this.defaultGroup = defaultGroup;
+    }
+
+    public String toString() {
+        return "PermissionGroup(groups=" + this.getGroups() + ", prefix=" + this.getPrefix() + ", suffix=" + this.getSuffix() + ", display=" + this.getDisplay() + ", sortId=" + this.getSortId() + ", defaultGroup=" + this.isDefaultGroup() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof PermissionGroup)) return false;
+        final PermissionGroup other = (PermissionGroup) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (!super.equals(o)) return false;
+        final Object this$groups = this.getGroups();
+        final Object other$groups = other.getGroups();
+        if (this$groups == null ? other$groups != null : !this$groups.equals(other$groups)) return false;
+        final Object this$prefix = this.getPrefix();
+        final Object other$prefix = other.getPrefix();
+        if (this$prefix == null ? other$prefix != null : !this$prefix.equals(other$prefix)) return false;
+        final Object this$suffix = this.getSuffix();
+        final Object other$suffix = other.getSuffix();
+        if (this$suffix == null ? other$suffix != null : !this$suffix.equals(other$suffix)) return false;
+        final Object this$display = this.getDisplay();
+        final Object other$display = other.getDisplay();
+        if (this$display == null ? other$display != null : !this$display.equals(other$display)) return false;
+        if (this.getSortId() != other.getSortId()) return false;
+        if (this.isDefaultGroup() != other.isDefaultGroup()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof PermissionGroup;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = super.hashCode();
+        final Object $groups = this.getGroups();
+        result = result * PRIME + ($groups == null ? 43 : $groups.hashCode());
+        final Object $prefix = this.getPrefix();
+        result = result * PRIME + ($prefix == null ? 43 : $prefix.hashCode());
+        final Object $suffix = this.getSuffix();
+        result = result * PRIME + ($suffix == null ? 43 : $suffix.hashCode());
+        final Object $display = this.getDisplay();
+        result = result * PRIME + ($display == null ? 43 : $display.hashCode());
+        result = result * PRIME + this.getSortId();
+        result = result * PRIME + (this.isDefaultGroup() ? 79 : 97);
+        return result;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionGroup.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionGroup.java
@@ -2,6 +2,8 @@ package de.dytanic.cloudnet.driver.permission;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.collection.Iterables;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -10,6 +12,8 @@ import java.util.Collection;
  * The default implementation of the IPermissionGroup class. This class should use if you want to
  * add new PermissionGroups into the IPermissionManagement implementation
  */
+@ToString
+@EqualsAndHashCode
 public class PermissionGroup extends AbstractPermissible implements IPermissionGroup {
 
     /**
@@ -100,50 +104,4 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
         this.defaultGroup = defaultGroup;
     }
 
-    public String toString() {
-        return "PermissionGroup(groups=" + this.getGroups() + ", prefix=" + this.getPrefix() + ", suffix=" + this.getSuffix() + ", display=" + this.getDisplay() + ", sortId=" + this.getSortId() + ", defaultGroup=" + this.isDefaultGroup() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof PermissionGroup)) return false;
-        final PermissionGroup other = (PermissionGroup) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (!super.equals(o)) return false;
-        final Object this$groups = this.getGroups();
-        final Object other$groups = other.getGroups();
-        if (this$groups == null ? other$groups != null : !this$groups.equals(other$groups)) return false;
-        final Object this$prefix = this.getPrefix();
-        final Object other$prefix = other.getPrefix();
-        if (this$prefix == null ? other$prefix != null : !this$prefix.equals(other$prefix)) return false;
-        final Object this$suffix = this.getSuffix();
-        final Object other$suffix = other.getSuffix();
-        if (this$suffix == null ? other$suffix != null : !this$suffix.equals(other$suffix)) return false;
-        final Object this$display = this.getDisplay();
-        final Object other$display = other.getDisplay();
-        if (this$display == null ? other$display != null : !this$display.equals(other$display)) return false;
-        if (this.getSortId() != other.getSortId()) return false;
-        if (this.isDefaultGroup() != other.isDefaultGroup()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof PermissionGroup;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = super.hashCode();
-        final Object $groups = this.getGroups();
-        result = result * PRIME + ($groups == null ? 43 : $groups.hashCode());
-        final Object $prefix = this.getPrefix();
-        result = result * PRIME + ($prefix == null ? 43 : $prefix.hashCode());
-        final Object $suffix = this.getSuffix();
-        result = result * PRIME + ($suffix == null ? 43 : $suffix.hashCode());
-        final Object $display = this.getDisplay();
-        result = result * PRIME + ($display == null ? 43 : $display.hashCode());
-        result = result * PRIME + this.getSortId();
-        result = result * PRIME + (this.isDefaultGroup() ? 79 : 97);
-        return result;
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionUser.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionUser.java
@@ -3,7 +3,6 @@ package de.dytanic.cloudnet.driver.permission;
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.common.encrypt.EncryptTo;
-import lombok.Getter;
 
 import java.lang.reflect.Type;
 import java.util.Base64;
@@ -22,13 +21,10 @@ public class PermissionUser extends AbstractPermissible implements IPermissionUs
     public static final Type TYPE = new TypeToken<PermissionUser>() {
     }.getType();
 
-    @Getter
     protected final UUID uniqueId;
 
-    @Getter
     protected final Collection<PermissionUserGroupInfo> groups;
 
-    @Getter
     private String hashedPassword;
 
     public PermissionUser(UUID uniqueId, String name, String password, int potency) {
@@ -45,5 +41,17 @@ public class PermissionUser extends AbstractPermissible implements IPermissionUs
 
     public boolean checkPassword(String password) {
         return this.hashedPassword != null && password != null && this.hashedPassword.equals(Base64.getEncoder().encodeToString(EncryptTo.encryptToSHA256(password)));
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public Collection<PermissionUserGroupInfo> getGroups() {
+        return this.groups;
+    }
+
+    public String getHashedPassword() {
+        return this.hashedPassword;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionUserGroupInfo.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionUserGroupInfo.java
@@ -1,7 +1,11 @@
 package de.dytanic.cloudnet.driver.permission;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
+@ToString
+@EqualsAndHashCode
 public class PermissionUserGroupInfo extends BasicJsonDocPropertyable {
 
     protected String group;
@@ -29,34 +33,4 @@ public class PermissionUserGroupInfo extends BasicJsonDocPropertyable {
         this.timeOutMillis = timeOutMillis;
     }
 
-    public String toString() {
-        return "PermissionUserGroupInfo(group=" + this.getGroup() + ", timeOutMillis=" + this.getTimeOutMillis() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof PermissionUserGroupInfo)) return false;
-        final PermissionUserGroupInfo other = (PermissionUserGroupInfo) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (!super.equals(o)) return false;
-        final Object this$group = this.getGroup();
-        final Object other$group = other.getGroup();
-        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
-        if (this.getTimeOutMillis() != other.getTimeOutMillis()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof PermissionUserGroupInfo;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = super.hashCode();
-        final Object $group = this.getGroup();
-        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
-        final long $timeOutMillis = this.getTimeOutMillis();
-        result = result * PRIME + (int) ($timeOutMillis >>> 32 ^ $timeOutMillis);
-        return result;
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionUserGroupInfo.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionUserGroupInfo.java
@@ -1,17 +1,62 @@
 package de.dytanic.cloudnet.driver.permission;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
-@Data
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
 public class PermissionUserGroupInfo extends BasicJsonDocPropertyable {
 
     protected String group;
 
     protected long timeOutMillis;
 
+    public PermissionUserGroupInfo(String group, long timeOutMillis) {
+        this.group = group;
+        this.timeOutMillis = timeOutMillis;
+    }
+
+    public String getGroup() {
+        return this.group;
+    }
+
+    public long getTimeOutMillis() {
+        return this.timeOutMillis;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public void setTimeOutMillis(long timeOutMillis) {
+        this.timeOutMillis = timeOutMillis;
+    }
+
+    public String toString() {
+        return "PermissionUserGroupInfo(group=" + this.getGroup() + ", timeOutMillis=" + this.getTimeOutMillis() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof PermissionUserGroupInfo)) return false;
+        final PermissionUserGroupInfo other = (PermissionUserGroupInfo) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (!super.equals(o)) return false;
+        final Object this$group = this.getGroup();
+        final Object other$group = other.getGroup();
+        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
+        if (this.getTimeOutMillis() != other.getTimeOutMillis()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof PermissionUserGroupInfo;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = super.hashCode();
+        final Object $group = this.getGroup();
+        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
+        final long $timeOutMillis = this.getTimeOutMillis();
+        result = result * PRIME + (int) ($timeOutMillis >>> 32 ^ $timeOutMillis);
+        return result;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/GroupConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/GroupConfiguration.java
@@ -1,13 +1,9 @@
 package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.INameable;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 import java.util.Collection;
 
-@Getter
-@AllArgsConstructor
 public class GroupConfiguration extends ServiceConfigurationBase implements INameable {
 
     protected String name;
@@ -15,5 +11,13 @@ public class GroupConfiguration extends ServiceConfigurationBase implements INam
     public GroupConfiguration(Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments, String name) {
         super(includes, templates, deployments);
         this.name = name;
+    }
+
+    public GroupConfiguration(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ProcessConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ProcessConfiguration.java
@@ -1,16 +1,7 @@
 package de.dytanic.cloudnet.driver.service;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-
 import java.util.Collection;
 
-@Data
-@ToString
-@EqualsAndHashCode
-@AllArgsConstructor
 public final class ProcessConfiguration {
 
     protected ServiceEnvironmentType environment;
@@ -19,4 +10,64 @@ public final class ProcessConfiguration {
 
     protected Collection<String> jvmOptions;
 
+    public ProcessConfiguration(ServiceEnvironmentType environment, int maxHeapMemorySize, Collection<String> jvmOptions) {
+        this.environment = environment;
+        this.maxHeapMemorySize = maxHeapMemorySize;
+        this.jvmOptions = jvmOptions;
+    }
+
+    public ServiceEnvironmentType getEnvironment() {
+        return this.environment;
+    }
+
+    public int getMaxHeapMemorySize() {
+        return this.maxHeapMemorySize;
+    }
+
+    public Collection<String> getJvmOptions() {
+        return this.jvmOptions;
+    }
+
+    public void setEnvironment(ServiceEnvironmentType environment) {
+        this.environment = environment;
+    }
+
+    public void setMaxHeapMemorySize(int maxHeapMemorySize) {
+        this.maxHeapMemorySize = maxHeapMemorySize;
+    }
+
+    public void setJvmOptions(Collection<String> jvmOptions) {
+        this.jvmOptions = jvmOptions;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ProcessConfiguration)) return false;
+        final ProcessConfiguration other = (ProcessConfiguration) o;
+        final Object this$environment = this.getEnvironment();
+        final Object other$environment = other.getEnvironment();
+        if (this$environment == null ? other$environment != null : !this$environment.equals(other$environment))
+            return false;
+        if (this.getMaxHeapMemorySize() != other.getMaxHeapMemorySize()) return false;
+        final Object this$jvmOptions = this.getJvmOptions();
+        final Object other$jvmOptions = other.getJvmOptions();
+        if (this$jvmOptions == null ? other$jvmOptions != null : !this$jvmOptions.equals(other$jvmOptions))
+            return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $environment = this.getEnvironment();
+        result = result * PRIME + ($environment == null ? 43 : $environment.hashCode());
+        result = result * PRIME + this.getMaxHeapMemorySize();
+        final Object $jvmOptions = this.getJvmOptions();
+        result = result * PRIME + ($jvmOptions == null ? 43 : $jvmOptions.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "ProcessConfiguration(environment=" + this.getEnvironment() + ", maxHeapMemorySize=" + this.getMaxHeapMemorySize() + ", jvmOptions=" + this.getJvmOptions() + ")";
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ProcessConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ProcessConfiguration.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.driver.service;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.Collection;
 
+@ToString
+@EqualsAndHashCode
 public final class ProcessConfiguration {
 
     protected ServiceEnvironmentType environment;
@@ -40,34 +45,4 @@ public final class ProcessConfiguration {
         this.jvmOptions = jvmOptions;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ProcessConfiguration)) return false;
-        final ProcessConfiguration other = (ProcessConfiguration) o;
-        final Object this$environment = this.getEnvironment();
-        final Object other$environment = other.getEnvironment();
-        if (this$environment == null ? other$environment != null : !this$environment.equals(other$environment))
-            return false;
-        if (this.getMaxHeapMemorySize() != other.getMaxHeapMemorySize()) return false;
-        final Object this$jvmOptions = this.getJvmOptions();
-        final Object other$jvmOptions = other.getJvmOptions();
-        if (this$jvmOptions == null ? other$jvmOptions != null : !this$jvmOptions.equals(other$jvmOptions))
-            return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $environment = this.getEnvironment();
-        result = result * PRIME + ($environment == null ? 43 : $environment.hashCode());
-        result = result * PRIME + this.getMaxHeapMemorySize();
-        final Object $jvmOptions = this.getJvmOptions();
-        result = result * PRIME + ($jvmOptions == null ? 43 : $jvmOptions.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "ProcessConfiguration(environment=" + this.getEnvironment() + ", maxHeapMemorySize=" + this.getMaxHeapMemorySize() + ", jvmOptions=" + this.getJvmOptions() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ProcessSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ProcessSnapshot.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.driver.service;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.Collection;
 
+@ToString
+@EqualsAndHashCode
 public class ProcessSnapshot {
 
     private long heapUsageMemory, noHeapUsageMemory, maxHeapMemory;
@@ -57,50 +62,4 @@ public class ProcessSnapshot {
         return this.cpuUsage;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ProcessSnapshot)) return false;
-        final ProcessSnapshot other = (ProcessSnapshot) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (this.getHeapUsageMemory() != other.getHeapUsageMemory()) return false;
-        if (this.getNoHeapUsageMemory() != other.getNoHeapUsageMemory()) return false;
-        if (this.getMaxHeapMemory() != other.getMaxHeapMemory()) return false;
-        if (this.getCurrentLoadedClassCount() != other.getCurrentLoadedClassCount()) return false;
-        if (this.getTotalLoadedClassCount() != other.getTotalLoadedClassCount()) return false;
-        if (this.getUnloadedClassCount() != other.getUnloadedClassCount()) return false;
-        final Object this$threads = this.getThreads();
-        final Object other$threads = other.getThreads();
-        if (this$threads == null ? other$threads != null : !this$threads.equals(other$threads)) return false;
-        if (Double.compare(this.getCpuUsage(), other.getCpuUsage()) != 0) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ProcessSnapshot;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final long $heapUsageMemory = this.getHeapUsageMemory();
-        result = result * PRIME + (int) ($heapUsageMemory >>> 32 ^ $heapUsageMemory);
-        final long $noHeapUsageMemory = this.getNoHeapUsageMemory();
-        result = result * PRIME + (int) ($noHeapUsageMemory >>> 32 ^ $noHeapUsageMemory);
-        final long $maxHeapMemory = this.getMaxHeapMemory();
-        result = result * PRIME + (int) ($maxHeapMemory >>> 32 ^ $maxHeapMemory);
-        result = result * PRIME + this.getCurrentLoadedClassCount();
-        final long $totalLoadedClassCount = this.getTotalLoadedClassCount();
-        result = result * PRIME + (int) ($totalLoadedClassCount >>> 32 ^ $totalLoadedClassCount);
-        final long $unloadedClassCount = this.getUnloadedClassCount();
-        result = result * PRIME + (int) ($unloadedClassCount >>> 32 ^ $unloadedClassCount);
-        final Object $threads = this.getThreads();
-        result = result * PRIME + ($threads == null ? 43 : $threads.hashCode());
-        final long $cpuUsage = Double.doubleToLongBits(this.getCpuUsage());
-        result = result * PRIME + (int) ($cpuUsage >>> 32 ^ $cpuUsage);
-        return result;
-    }
-
-    public String toString() {
-        return "ProcessSnapshot(heapUsageMemory=" + this.getHeapUsageMemory() + ", noHeapUsageMemory=" + this.getNoHeapUsageMemory() + ", maxHeapMemory=" + this.getMaxHeapMemory() + ", currentLoadedClassCount=" + this.getCurrentLoadedClassCount() + ", totalLoadedClassCount=" + this.getTotalLoadedClassCount() + ", unloadedClassCount=" + this.getUnloadedClassCount() + ", threads=" + this.getThreads() + ", cpuUsage=" + this.getCpuUsage() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ProcessSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ProcessSnapshot.java
@@ -1,16 +1,7 @@
 package de.dytanic.cloudnet.driver.service;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-
 import java.util.Collection;
 
-@Getter
-@ToString
-@EqualsAndHashCode
-@AllArgsConstructor
 public class ProcessSnapshot {
 
     private long heapUsageMemory, noHeapUsageMemory, maxHeapMemory;
@@ -23,4 +14,93 @@ public class ProcessSnapshot {
 
     private double cpuUsage;
 
+    public ProcessSnapshot(long heapUsageMemory, long noHeapUsageMemory, long maxHeapMemory, int currentLoadedClassCount, long totalLoadedClassCount, long unloadedClassCount, Collection<ThreadSnapshot> threads, double cpuUsage) {
+        this.heapUsageMemory = heapUsageMemory;
+        this.noHeapUsageMemory = noHeapUsageMemory;
+        this.maxHeapMemory = maxHeapMemory;
+        this.currentLoadedClassCount = currentLoadedClassCount;
+        this.totalLoadedClassCount = totalLoadedClassCount;
+        this.unloadedClassCount = unloadedClassCount;
+        this.threads = threads;
+        this.cpuUsage = cpuUsage;
+    }
+
+    public long getHeapUsageMemory() {
+        return this.heapUsageMemory;
+    }
+
+    public long getNoHeapUsageMemory() {
+        return this.noHeapUsageMemory;
+    }
+
+    public long getMaxHeapMemory() {
+        return this.maxHeapMemory;
+    }
+
+    public int getCurrentLoadedClassCount() {
+        return this.currentLoadedClassCount;
+    }
+
+    public long getTotalLoadedClassCount() {
+        return this.totalLoadedClassCount;
+    }
+
+    public long getUnloadedClassCount() {
+        return this.unloadedClassCount;
+    }
+
+    public Collection<ThreadSnapshot> getThreads() {
+        return this.threads;
+    }
+
+    public double getCpuUsage() {
+        return this.cpuUsage;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ProcessSnapshot)) return false;
+        final ProcessSnapshot other = (ProcessSnapshot) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (this.getHeapUsageMemory() != other.getHeapUsageMemory()) return false;
+        if (this.getNoHeapUsageMemory() != other.getNoHeapUsageMemory()) return false;
+        if (this.getMaxHeapMemory() != other.getMaxHeapMemory()) return false;
+        if (this.getCurrentLoadedClassCount() != other.getCurrentLoadedClassCount()) return false;
+        if (this.getTotalLoadedClassCount() != other.getTotalLoadedClassCount()) return false;
+        if (this.getUnloadedClassCount() != other.getUnloadedClassCount()) return false;
+        final Object this$threads = this.getThreads();
+        final Object other$threads = other.getThreads();
+        if (this$threads == null ? other$threads != null : !this$threads.equals(other$threads)) return false;
+        if (Double.compare(this.getCpuUsage(), other.getCpuUsage()) != 0) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ProcessSnapshot;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final long $heapUsageMemory = this.getHeapUsageMemory();
+        result = result * PRIME + (int) ($heapUsageMemory >>> 32 ^ $heapUsageMemory);
+        final long $noHeapUsageMemory = this.getNoHeapUsageMemory();
+        result = result * PRIME + (int) ($noHeapUsageMemory >>> 32 ^ $noHeapUsageMemory);
+        final long $maxHeapMemory = this.getMaxHeapMemory();
+        result = result * PRIME + (int) ($maxHeapMemory >>> 32 ^ $maxHeapMemory);
+        result = result * PRIME + this.getCurrentLoadedClassCount();
+        final long $totalLoadedClassCount = this.getTotalLoadedClassCount();
+        result = result * PRIME + (int) ($totalLoadedClassCount >>> 32 ^ $totalLoadedClassCount);
+        final long $unloadedClassCount = this.getUnloadedClassCount();
+        result = result * PRIME + (int) ($unloadedClassCount >>> 32 ^ $unloadedClassCount);
+        final Object $threads = this.getThreads();
+        result = result * PRIME + ($threads == null ? 43 : $threads.hashCode());
+        final long $cpuUsage = Double.doubleToLongBits(this.getCpuUsage());
+        result = result * PRIME + (int) ($cpuUsage >>> 32 ^ $cpuUsage);
+        return result;
+    }
+
+    public String toString() {
+        return "ProcessSnapshot(heapUsageMemory=" + this.getHeapUsageMemory() + ", noHeapUsageMemory=" + this.getNoHeapUsageMemory() + ", maxHeapMemory=" + this.getMaxHeapMemory() + ", currentLoadedClassCount=" + this.getCurrentLoadedClassCount() + ", totalLoadedClassCount=" + this.getTotalLoadedClassCount() + ", unloadedClassCount=" + this.getUnloadedClassCount() + ", threads=" + this.getThreads() + ", cpuUsage=" + this.getCpuUsage() + ")";
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
@@ -1,12 +1,7 @@
 package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.*;
 
-@Getter
-@ToString
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public final class ServiceConfiguration extends BasicJsonDocPropertyable {
 
     private final ServiceId serviceId;
@@ -25,7 +20,114 @@ public final class ServiceConfiguration extends BasicJsonDocPropertyable {
 
     private final ProcessConfiguration processConfig;
 
-    @Setter
     private int port;
 
+    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, int port) {
+        this.serviceId = serviceId;
+        this.runtime = runtime;
+        this.autoDeleteOnStop = autoDeleteOnStop;
+        this.staticService = staticService;
+        this.groups = groups;
+        this.includes = includes;
+        this.templates = templates;
+        this.deployments = deployments;
+        this.processConfig = processConfig;
+        this.port = port;
+    }
+
+    public ServiceId getServiceId() {
+        return this.serviceId;
+    }
+
+    public String getRuntime() {
+        return this.runtime;
+    }
+
+    public boolean isAutoDeleteOnStop() {
+        return this.autoDeleteOnStop;
+    }
+
+    public boolean isStaticService() {
+        return this.staticService;
+    }
+
+    public String[] getGroups() {
+        return this.groups;
+    }
+
+    public ServiceRemoteInclusion[] getIncludes() {
+        return this.includes;
+    }
+
+    public ServiceTemplate[] getTemplates() {
+        return this.templates;
+    }
+
+    public ServiceDeployment[] getDeployments() {
+        return this.deployments;
+    }
+
+    public ProcessConfiguration getProcessConfig() {
+        return this.processConfig;
+    }
+
+    public int getPort() {
+        return this.port;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ServiceConfiguration)) return false;
+        final ServiceConfiguration other = (ServiceConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$serviceId = this.getServiceId();
+        final Object other$serviceId = other.getServiceId();
+        if (this$serviceId == null ? other$serviceId != null : !this$serviceId.equals(other$serviceId)) return false;
+        final Object this$runtime = this.getRuntime();
+        final Object other$runtime = other.getRuntime();
+        if (this$runtime == null ? other$runtime != null : !this$runtime.equals(other$runtime)) return false;
+        if (this.isAutoDeleteOnStop() != other.isAutoDeleteOnStop()) return false;
+        if (this.isStaticService() != other.isStaticService()) return false;
+        if (!java.util.Arrays.deepEquals(this.getGroups(), other.getGroups())) return false;
+        if (!java.util.Arrays.deepEquals(this.getIncludes(), other.getIncludes())) return false;
+        if (!java.util.Arrays.deepEquals(this.getTemplates(), other.getTemplates())) return false;
+        if (!java.util.Arrays.deepEquals(this.getDeployments(), other.getDeployments())) return false;
+        final Object this$processConfig = this.getProcessConfig();
+        final Object other$processConfig = other.getProcessConfig();
+        if (this$processConfig == null ? other$processConfig != null : !this$processConfig.equals(other$processConfig))
+            return false;
+        if (this.getPort() != other.getPort()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ServiceConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $serviceId = this.getServiceId();
+        result = result * PRIME + ($serviceId == null ? 43 : $serviceId.hashCode());
+        final Object $runtime = this.getRuntime();
+        result = result * PRIME + ($runtime == null ? 43 : $runtime.hashCode());
+        result = result * PRIME + (this.isAutoDeleteOnStop() ? 79 : 97);
+        result = result * PRIME + (this.isStaticService() ? 79 : 97);
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getGroups());
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getIncludes());
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getTemplates());
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getDeployments());
+        final Object $processConfig = this.getProcessConfig();
+        result = result * PRIME + ($processConfig == null ? 43 : $processConfig.hashCode());
+        result = result * PRIME + this.getPort();
+        return result;
+    }
+
+    public String toString() {
+        return "ServiceConfiguration(serviceId=" + this.getServiceId() + ", runtime=" + this.getRuntime() + ", autoDeleteOnStop=" + this.isAutoDeleteOnStop() + ", staticService=" + this.isStaticService() + ", groups=" + java.util.Arrays.deepToString(this.getGroups()) + ", includes=" + java.util.Arrays.deepToString(this.getIncludes()) + ", templates=" + java.util.Arrays.deepToString(this.getTemplates()) + ", deployments=" + java.util.Arrays.deepToString(this.getDeployments()) + ", processConfig=" + this.getProcessConfig() + ", port=" + this.getPort() + ")";
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
@@ -1,7 +1,11 @@
 package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
+@ToString
+@EqualsAndHashCode
 public final class ServiceConfiguration extends BasicJsonDocPropertyable {
 
     private final ServiceId serviceId;
@@ -73,58 +77,6 @@ public final class ServiceConfiguration extends BasicJsonDocPropertyable {
 
     public int getPort() {
         return this.port;
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ServiceConfiguration)) return false;
-        final ServiceConfiguration other = (ServiceConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$serviceId = this.getServiceId();
-        final Object other$serviceId = other.getServiceId();
-        if (this$serviceId == null ? other$serviceId != null : !this$serviceId.equals(other$serviceId)) return false;
-        final Object this$runtime = this.getRuntime();
-        final Object other$runtime = other.getRuntime();
-        if (this$runtime == null ? other$runtime != null : !this$runtime.equals(other$runtime)) return false;
-        if (this.isAutoDeleteOnStop() != other.isAutoDeleteOnStop()) return false;
-        if (this.isStaticService() != other.isStaticService()) return false;
-        if (!java.util.Arrays.deepEquals(this.getGroups(), other.getGroups())) return false;
-        if (!java.util.Arrays.deepEquals(this.getIncludes(), other.getIncludes())) return false;
-        if (!java.util.Arrays.deepEquals(this.getTemplates(), other.getTemplates())) return false;
-        if (!java.util.Arrays.deepEquals(this.getDeployments(), other.getDeployments())) return false;
-        final Object this$processConfig = this.getProcessConfig();
-        final Object other$processConfig = other.getProcessConfig();
-        if (this$processConfig == null ? other$processConfig != null : !this$processConfig.equals(other$processConfig))
-            return false;
-        if (this.getPort() != other.getPort()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ServiceConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $serviceId = this.getServiceId();
-        result = result * PRIME + ($serviceId == null ? 43 : $serviceId.hashCode());
-        final Object $runtime = this.getRuntime();
-        result = result * PRIME + ($runtime == null ? 43 : $runtime.hashCode());
-        result = result * PRIME + (this.isAutoDeleteOnStop() ? 79 : 97);
-        result = result * PRIME + (this.isStaticService() ? 79 : 97);
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getGroups());
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getIncludes());
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getTemplates());
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getDeployments());
-        final Object $processConfig = this.getProcessConfig();
-        result = result * PRIME + ($processConfig == null ? 43 : $processConfig.hashCode());
-        result = result * PRIME + this.getPort();
-        return result;
-    }
-
-    public String toString() {
-        return "ServiceConfiguration(serviceId=" + this.getServiceId() + ", runtime=" + this.getRuntime() + ", autoDeleteOnStop=" + this.isAutoDeleteOnStop() + ", staticService=" + this.isStaticService() + ", groups=" + java.util.Arrays.deepToString(this.getGroups()) + ", includes=" + java.util.Arrays.deepToString(this.getIncludes()) + ", templates=" + java.util.Arrays.deepToString(this.getTemplates()) + ", deployments=" + java.util.Arrays.deepToString(this.getDeployments()) + ", processConfig=" + this.getProcessConfig() + ", port=" + this.getPort() + ")";
     }
 
     public void setPort(int port) {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfigurationBase.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfigurationBase.java
@@ -1,15 +1,9 @@
 package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 import java.util.Collection;
 
-@Data
-@NoArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 abstract class ServiceConfigurationBase extends BasicJsonDocPropertyable {
 
     protected Collection<ServiceRemoteInclusion> includes;
@@ -22,5 +16,70 @@ abstract class ServiceConfigurationBase extends BasicJsonDocPropertyable {
         this.includes = includes;
         this.templates = templates;
         this.deployments = deployments;
+    }
+
+    public ServiceConfigurationBase() {
+    }
+
+    public Collection<ServiceRemoteInclusion> getIncludes() {
+        return this.includes;
+    }
+
+    public Collection<ServiceTemplate> getTemplates() {
+        return this.templates;
+    }
+
+    public Collection<ServiceDeployment> getDeployments() {
+        return this.deployments;
+    }
+
+    public void setIncludes(Collection<ServiceRemoteInclusion> includes) {
+        this.includes = includes;
+    }
+
+    public void setTemplates(Collection<ServiceTemplate> templates) {
+        this.templates = templates;
+    }
+
+    public void setDeployments(Collection<ServiceDeployment> deployments) {
+        this.deployments = deployments;
+    }
+
+    public String toString() {
+        return "ServiceConfigurationBase(includes=" + this.getIncludes() + ", templates=" + this.getTemplates() + ", deployments=" + this.getDeployments() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ServiceConfigurationBase)) return false;
+        final ServiceConfigurationBase other = (ServiceConfigurationBase) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$includes = this.getIncludes();
+        final Object other$includes = other.getIncludes();
+        if (this$includes == null ? other$includes != null : !this$includes.equals(other$includes)) return false;
+        final Object this$templates = this.getTemplates();
+        final Object other$templates = other.getTemplates();
+        if (this$templates == null ? other$templates != null : !this$templates.equals(other$templates)) return false;
+        final Object this$deployments = this.getDeployments();
+        final Object other$deployments = other.getDeployments();
+        if (this$deployments == null ? other$deployments != null : !this$deployments.equals(other$deployments))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ServiceConfigurationBase;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $includes = this.getIncludes();
+        result = result * PRIME + ($includes == null ? 43 : $includes.hashCode());
+        final Object $templates = this.getTemplates();
+        result = result * PRIME + ($templates == null ? 43 : $templates.hashCode());
+        final Object $deployments = this.getDeployments();
+        result = result * PRIME + ($deployments == null ? 43 : $deployments.hashCode());
+        return result;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfigurationBase.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfigurationBase.java
@@ -1,9 +1,13 @@
 package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Collection;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 abstract class ServiceConfigurationBase extends BasicJsonDocPropertyable {
 
     protected Collection<ServiceRemoteInclusion> includes;
@@ -45,41 +49,4 @@ abstract class ServiceConfigurationBase extends BasicJsonDocPropertyable {
         this.deployments = deployments;
     }
 
-    public String toString() {
-        return "ServiceConfigurationBase(includes=" + this.getIncludes() + ", templates=" + this.getTemplates() + ", deployments=" + this.getDeployments() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ServiceConfigurationBase)) return false;
-        final ServiceConfigurationBase other = (ServiceConfigurationBase) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$includes = this.getIncludes();
-        final Object other$includes = other.getIncludes();
-        if (this$includes == null ? other$includes != null : !this$includes.equals(other$includes)) return false;
-        final Object this$templates = this.getTemplates();
-        final Object other$templates = other.getTemplates();
-        if (this$templates == null ? other$templates != null : !this$templates.equals(other$templates)) return false;
-        final Object this$deployments = this.getDeployments();
-        final Object other$deployments = other.getDeployments();
-        if (this$deployments == null ? other$deployments != null : !this$deployments.equals(other$deployments))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ServiceConfigurationBase;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $includes = this.getIncludes();
-        result = result * PRIME + ($includes == null ? 43 : $includes.hashCode());
-        final Object $templates = this.getTemplates();
-        result = result * PRIME + ($templates == null ? 43 : $templates.hashCode());
-        final Object $deployments = this.getDeployments();
-        result = result * PRIME + ($deployments == null ? 43 : $deployments.hashCode());
-        return result;
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceDeployment.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceDeployment.java
@@ -1,19 +1,29 @@
 package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 import java.util.Collection;
 
-@Getter
-@ToString
-@RequiredArgsConstructor
 public final class ServiceDeployment extends BasicJsonDocPropertyable {
 
     private final ServiceTemplate template;
 
     private final Collection<String> excludes;
 
+    public ServiceDeployment(ServiceTemplate template, Collection<String> excludes) {
+        this.template = template;
+        this.excludes = excludes;
+    }
+
+    public ServiceTemplate getTemplate() {
+        return this.template;
+    }
+
+    public Collection<String> getExcludes() {
+        return this.excludes;
+    }
+
+    public String toString() {
+        return "ServiceDeployment(template=" + this.getTemplate() + ", excludes=" + this.getExcludes() + ")";
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceDeployment.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceDeployment.java
@@ -1,9 +1,13 @@
 package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Collection;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public final class ServiceDeployment extends BasicJsonDocPropertyable {
 
     private final ServiceTemplate template;
@@ -23,7 +27,4 @@ public final class ServiceDeployment extends BasicJsonDocPropertyable {
         return this.excludes;
     }
 
-    public String toString() {
-        return "ServiceDeployment(template=" + this.getTemplate() + ", excludes=" + this.getExcludes() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceEnvironment.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceEnvironment.java
@@ -1,10 +1,5 @@
 package de.dytanic.cloudnet.driver.service;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum ServiceEnvironment {
 
     //Minecraft Server
@@ -43,4 +38,11 @@ public enum ServiceEnvironment {
 
     private final String name;
 
+    private ServiceEnvironment(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceEnvironmentType.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceEnvironmentType.java
@@ -1,10 +1,5 @@
 package de.dytanic.cloudnet.driver.service;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum ServiceEnvironmentType {
 
     MINECRAFT_SERVER(new ServiceEnvironment[]{
@@ -48,4 +43,31 @@ public enum ServiceEnvironmentType {
 
     private final boolean minecraftJavaProxy, minecraftBedrockProxy, minecraftJavaServer, minecraftBedrockServer;
 
+    private ServiceEnvironmentType(ServiceEnvironment[] environments, boolean minecraftJavaProxy, boolean minecraftBedrockProxy, boolean minecraftJavaServer, boolean minecraftBedrockServer) {
+        this.environments = environments;
+        this.minecraftJavaProxy = minecraftJavaProxy;
+        this.minecraftBedrockProxy = minecraftBedrockProxy;
+        this.minecraftJavaServer = minecraftJavaServer;
+        this.minecraftBedrockServer = minecraftBedrockServer;
+    }
+
+    public ServiceEnvironment[] getEnvironments() {
+        return this.environments;
+    }
+
+    public boolean isMinecraftJavaProxy() {
+        return this.minecraftJavaProxy;
+    }
+
+    public boolean isMinecraftBedrockProxy() {
+        return this.minecraftBedrockProxy;
+    }
+
+    public boolean isMinecraftJavaServer() {
+        return this.minecraftJavaServer;
+    }
+
+    public boolean isMinecraftBedrockServer() {
+        return this.minecraftBedrockServer;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceId.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceId.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.driver.service;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 public final class ServiceId {
 
     private final UUID uniqueId;
@@ -44,44 +49,4 @@ public final class ServiceId {
         return this.environment;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ServiceId)) return false;
-        final ServiceId other = (ServiceId) o;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$nodeUniqueId = this.getNodeUniqueId();
-        final Object other$nodeUniqueId = other.getNodeUniqueId();
-        if (this$nodeUniqueId == null ? other$nodeUniqueId != null : !this$nodeUniqueId.equals(other$nodeUniqueId))
-            return false;
-        final Object this$taskName = this.getTaskName();
-        final Object other$taskName = other.getTaskName();
-        if (this$taskName == null ? other$taskName != null : !this$taskName.equals(other$taskName)) return false;
-        if (this.getTaskServiceId() != other.getTaskServiceId()) return false;
-        final Object this$environment = this.getEnvironment();
-        final Object other$environment = other.getEnvironment();
-        if (this$environment == null ? other$environment != null : !this$environment.equals(other$environment))
-            return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $nodeUniqueId = this.getNodeUniqueId();
-        result = result * PRIME + ($nodeUniqueId == null ? 43 : $nodeUniqueId.hashCode());
-        final Object $taskName = this.getTaskName();
-        result = result * PRIME + ($taskName == null ? 43 : $taskName.hashCode());
-        result = result * PRIME + this.getTaskServiceId();
-        final Object $environment = this.getEnvironment();
-        result = result * PRIME + ($environment == null ? 43 : $environment.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "ServiceId(uniqueId=" + this.getUniqueId() + ", nodeUniqueId=" + this.getNodeUniqueId() + ", taskName=" + this.getTaskName() + ", taskServiceId=" + this.getTaskServiceId() + ", environment=" + this.getEnvironment() + ")";
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceId.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceId.java
@@ -1,16 +1,7 @@
 package de.dytanic.cloudnet.driver.service;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-
 import java.util.UUID;
 
-@Getter
-@ToString
-@EqualsAndHashCode
-@AllArgsConstructor
 public final class ServiceId {
 
     private final UUID uniqueId;
@@ -21,7 +12,76 @@ public final class ServiceId {
 
     private final ServiceEnvironmentType environment;
 
+    public ServiceId(UUID uniqueId, String nodeUniqueId, String taskName, int taskServiceId, ServiceEnvironmentType environment) {
+        this.uniqueId = uniqueId;
+        this.nodeUniqueId = nodeUniqueId;
+        this.taskName = taskName;
+        this.taskServiceId = taskServiceId;
+        this.environment = environment;
+    }
+
     public String getName() {
         return taskName + "-" + taskServiceId;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getNodeUniqueId() {
+        return this.nodeUniqueId;
+    }
+
+    public String getTaskName() {
+        return this.taskName;
+    }
+
+    public int getTaskServiceId() {
+        return this.taskServiceId;
+    }
+
+    public ServiceEnvironmentType getEnvironment() {
+        return this.environment;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ServiceId)) return false;
+        final ServiceId other = (ServiceId) o;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$nodeUniqueId = this.getNodeUniqueId();
+        final Object other$nodeUniqueId = other.getNodeUniqueId();
+        if (this$nodeUniqueId == null ? other$nodeUniqueId != null : !this$nodeUniqueId.equals(other$nodeUniqueId))
+            return false;
+        final Object this$taskName = this.getTaskName();
+        final Object other$taskName = other.getTaskName();
+        if (this$taskName == null ? other$taskName != null : !this$taskName.equals(other$taskName)) return false;
+        if (this.getTaskServiceId() != other.getTaskServiceId()) return false;
+        final Object this$environment = this.getEnvironment();
+        final Object other$environment = other.getEnvironment();
+        if (this$environment == null ? other$environment != null : !this$environment.equals(other$environment))
+            return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $nodeUniqueId = this.getNodeUniqueId();
+        result = result * PRIME + ($nodeUniqueId == null ? 43 : $nodeUniqueId.hashCode());
+        final Object $taskName = this.getTaskName();
+        result = result * PRIME + ($taskName == null ? 43 : $taskName.hashCode());
+        result = result * PRIME + this.getTaskServiceId();
+        final Object $environment = this.getEnvironment();
+        result = result * PRIME + ($environment == null ? 43 : $environment.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "ServiceId(uniqueId=" + this.getUniqueId() + ", nodeUniqueId=" + this.getNodeUniqueId() + ", taskName=" + this.getTaskName() + ", taskServiceId=" + this.getTaskServiceId() + ", environment=" + this.getEnvironment() + ")";
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceInfoSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceInfoSnapshot.java
@@ -3,14 +3,9 @@ package de.dytanic.cloudnet.driver.service;
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
-import lombok.*;
 
 import java.lang.reflect.Type;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public class ServiceInfoSnapshot extends BasicJsonDocPropertyable {
 
     public static final Type TYPE = new TypeToken<ServiceInfoSnapshot>() {
@@ -22,15 +17,114 @@ public class ServiceInfoSnapshot extends BasicJsonDocPropertyable {
 
     protected HostAndPort address;
 
-    @Setter
     protected boolean connected;
 
-    @Setter
     protected ServiceLifeCycle lifeCycle;
 
-    @Setter
     protected ProcessSnapshot processSnapshot;
 
     protected ServiceConfiguration configuration;
 
+    public ServiceInfoSnapshot(long creationTime, ServiceId serviceId, HostAndPort address, boolean connected, ServiceLifeCycle lifeCycle, ProcessSnapshot processSnapshot, ServiceConfiguration configuration) {
+        this.creationTime = creationTime;
+        this.serviceId = serviceId;
+        this.address = address;
+        this.connected = connected;
+        this.lifeCycle = lifeCycle;
+        this.processSnapshot = processSnapshot;
+        this.configuration = configuration;
+    }
+
+    public ServiceInfoSnapshot() {
+    }
+
+    public long getCreationTime() {
+        return this.creationTime;
+    }
+
+    public ServiceId getServiceId() {
+        return this.serviceId;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public boolean isConnected() {
+        return this.connected;
+    }
+
+    public ServiceLifeCycle getLifeCycle() {
+        return this.lifeCycle;
+    }
+
+    public ProcessSnapshot getProcessSnapshot() {
+        return this.processSnapshot;
+    }
+
+    public ServiceConfiguration getConfiguration() {
+        return this.configuration;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ServiceInfoSnapshot)) return false;
+        final ServiceInfoSnapshot other = (ServiceInfoSnapshot) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (this.getCreationTime() != other.getCreationTime()) return false;
+        final Object this$serviceId = this.getServiceId();
+        final Object other$serviceId = other.getServiceId();
+        if (this$serviceId == null ? other$serviceId != null : !this$serviceId.equals(other$serviceId)) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        if (this.isConnected() != other.isConnected()) return false;
+        final Object this$lifeCycle = this.getLifeCycle();
+        final Object other$lifeCycle = other.getLifeCycle();
+        if (this$lifeCycle == null ? other$lifeCycle != null : !this$lifeCycle.equals(other$lifeCycle)) return false;
+        final Object this$processSnapshot = this.getProcessSnapshot();
+        final Object other$processSnapshot = other.getProcessSnapshot();
+        if (this$processSnapshot == null ? other$processSnapshot != null : !this$processSnapshot.equals(other$processSnapshot))
+            return false;
+        final Object this$configuration = this.getConfiguration();
+        final Object other$configuration = other.getConfiguration();
+        if (this$configuration == null ? other$configuration != null : !this$configuration.equals(other$configuration))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ServiceInfoSnapshot;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final long $creationTime = this.getCreationTime();
+        result = result * PRIME + (int) ($creationTime >>> 32 ^ $creationTime);
+        final Object $serviceId = this.getServiceId();
+        result = result * PRIME + ($serviceId == null ? 43 : $serviceId.hashCode());
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        result = result * PRIME + (this.isConnected() ? 79 : 97);
+        final Object $lifeCycle = this.getLifeCycle();
+        result = result * PRIME + ($lifeCycle == null ? 43 : $lifeCycle.hashCode());
+        final Object $processSnapshot = this.getProcessSnapshot();
+        result = result * PRIME + ($processSnapshot == null ? 43 : $processSnapshot.hashCode());
+        final Object $configuration = this.getConfiguration();
+        result = result * PRIME + ($configuration == null ? 43 : $configuration.hashCode());
+        return result;
+    }
+
+    public void setConnected(boolean connected) {
+        this.connected = connected;
+    }
+
+    public void setLifeCycle(ServiceLifeCycle lifeCycle) {
+        this.lifeCycle = lifeCycle;
+    }
+
+    public void setProcessSnapshot(ProcessSnapshot processSnapshot) {
+        this.processSnapshot = processSnapshot;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceInfoSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceInfoSnapshot.java
@@ -3,9 +3,13 @@ package de.dytanic.cloudnet.driver.service;
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 
+@ToString
+@EqualsAndHashCode
 public class ServiceInfoSnapshot extends BasicJsonDocPropertyable {
 
     public static final Type TYPE = new TypeToken<ServiceInfoSnapshot>() {
@@ -64,56 +68,6 @@ public class ServiceInfoSnapshot extends BasicJsonDocPropertyable {
 
     public ServiceConfiguration getConfiguration() {
         return this.configuration;
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ServiceInfoSnapshot)) return false;
-        final ServiceInfoSnapshot other = (ServiceInfoSnapshot) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (this.getCreationTime() != other.getCreationTime()) return false;
-        final Object this$serviceId = this.getServiceId();
-        final Object other$serviceId = other.getServiceId();
-        if (this$serviceId == null ? other$serviceId != null : !this$serviceId.equals(other$serviceId)) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        if (this.isConnected() != other.isConnected()) return false;
-        final Object this$lifeCycle = this.getLifeCycle();
-        final Object other$lifeCycle = other.getLifeCycle();
-        if (this$lifeCycle == null ? other$lifeCycle != null : !this$lifeCycle.equals(other$lifeCycle)) return false;
-        final Object this$processSnapshot = this.getProcessSnapshot();
-        final Object other$processSnapshot = other.getProcessSnapshot();
-        if (this$processSnapshot == null ? other$processSnapshot != null : !this$processSnapshot.equals(other$processSnapshot))
-            return false;
-        final Object this$configuration = this.getConfiguration();
-        final Object other$configuration = other.getConfiguration();
-        if (this$configuration == null ? other$configuration != null : !this$configuration.equals(other$configuration))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ServiceInfoSnapshot;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final long $creationTime = this.getCreationTime();
-        result = result * PRIME + (int) ($creationTime >>> 32 ^ $creationTime);
-        final Object $serviceId = this.getServiceId();
-        result = result * PRIME + ($serviceId == null ? 43 : $serviceId.hashCode());
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        result = result * PRIME + (this.isConnected() ? 79 : 97);
-        final Object $lifeCycle = this.getLifeCycle();
-        result = result * PRIME + ($lifeCycle == null ? 43 : $lifeCycle.hashCode());
-        final Object $processSnapshot = this.getProcessSnapshot();
-        result = result * PRIME + ($processSnapshot == null ? 43 : $processSnapshot.hashCode());
-        final Object $configuration = this.getConfiguration();
-        result = result * PRIME + ($configuration == null ? 43 : $configuration.hashCode());
-        return result;
     }
 
     public void setConnected(boolean connected) {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceRemoteInclusion.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceRemoteInclusion.java
@@ -1,15 +1,23 @@
 package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ServiceRemoteInclusion extends BasicJsonDocPropertyable {
 
     private final String url;
 
     private final String destination;
 
+    public ServiceRemoteInclusion(String url, String destination) {
+        this.url = url;
+        this.destination = destination;
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    public String getDestination() {
+        return this.destination;
+    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTask.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTask.java
@@ -1,14 +1,7 @@
 package de.dytanic.cloudnet.driver.service;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-
 import java.util.Collection;
 
-@Data
-@NoArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public class ServiceTask extends ServiceConfigurationBase {
 
     private String name;
@@ -47,5 +40,147 @@ public class ServiceTask extends ServiceConfigurationBase {
         this.startPort = startPort;
         this.minServiceCount = minServiceCount;
         this.staticServices = staticServices;
+    }
+
+    public ServiceTask() {
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getRuntime() {
+        return this.runtime;
+    }
+
+    public boolean isMaintenance() {
+        return this.maintenance;
+    }
+
+    public boolean isAutoDeleteOnStop() {
+        return this.autoDeleteOnStop;
+    }
+
+    public boolean isStaticServices() {
+        return this.staticServices;
+    }
+
+    public Collection<String> getAssociatedNodes() {
+        return this.associatedNodes;
+    }
+
+    public Collection<String> getGroups() {
+        return this.groups;
+    }
+
+    public ProcessConfiguration getProcessConfiguration() {
+        return this.processConfiguration;
+    }
+
+    public int getStartPort() {
+        return this.startPort;
+    }
+
+    public int getMinServiceCount() {
+        return this.minServiceCount;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setRuntime(String runtime) {
+        this.runtime = runtime;
+    }
+
+    public void setMaintenance(boolean maintenance) {
+        this.maintenance = maintenance;
+    }
+
+    public void setAutoDeleteOnStop(boolean autoDeleteOnStop) {
+        this.autoDeleteOnStop = autoDeleteOnStop;
+    }
+
+    public void setStaticServices(boolean staticServices) {
+        this.staticServices = staticServices;
+    }
+
+    public void setAssociatedNodes(Collection<String> associatedNodes) {
+        this.associatedNodes = associatedNodes;
+    }
+
+    public void setGroups(Collection<String> groups) {
+        this.groups = groups;
+    }
+
+    public void setProcessConfiguration(ProcessConfiguration processConfiguration) {
+        this.processConfiguration = processConfiguration;
+    }
+
+    public void setStartPort(int startPort) {
+        this.startPort = startPort;
+    }
+
+    public void setMinServiceCount(int minServiceCount) {
+        this.minServiceCount = minServiceCount;
+    }
+
+    public String toString() {
+        return "ServiceTask(name=" + this.getName() + ", runtime=" + this.getRuntime() + ", maintenance=" + this.isMaintenance() + ", autoDeleteOnStop=" + this.isAutoDeleteOnStop() + ", staticServices=" + this.isStaticServices() + ", associatedNodes=" + this.getAssociatedNodes() + ", groups=" + this.getGroups() + ", processConfiguration=" + this.getProcessConfiguration() + ", startPort=" + this.getStartPort() + ", minServiceCount=" + this.getMinServiceCount() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ServiceTask)) return false;
+        final ServiceTask other = (ServiceTask) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$runtime = this.getRuntime();
+        final Object other$runtime = other.getRuntime();
+        if (this$runtime == null ? other$runtime != null : !this$runtime.equals(other$runtime)) return false;
+        if (this.isMaintenance() != other.isMaintenance()) return false;
+        if (this.isAutoDeleteOnStop() != other.isAutoDeleteOnStop()) return false;
+        if (this.isStaticServices() != other.isStaticServices()) return false;
+        final Object this$associatedNodes = this.getAssociatedNodes();
+        final Object other$associatedNodes = other.getAssociatedNodes();
+        if (this$associatedNodes == null ? other$associatedNodes != null : !this$associatedNodes.equals(other$associatedNodes))
+            return false;
+        final Object this$groups = this.getGroups();
+        final Object other$groups = other.getGroups();
+        if (this$groups == null ? other$groups != null : !this$groups.equals(other$groups)) return false;
+        final Object this$processConfiguration = this.getProcessConfiguration();
+        final Object other$processConfiguration = other.getProcessConfiguration();
+        if (this$processConfiguration == null ? other$processConfiguration != null : !this$processConfiguration.equals(other$processConfiguration))
+            return false;
+        if (this.getStartPort() != other.getStartPort()) return false;
+        if (this.getMinServiceCount() != other.getMinServiceCount()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ServiceTask;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $runtime = this.getRuntime();
+        result = result * PRIME + ($runtime == null ? 43 : $runtime.hashCode());
+        result = result * PRIME + (this.isMaintenance() ? 79 : 97);
+        result = result * PRIME + (this.isAutoDeleteOnStop() ? 79 : 97);
+        result = result * PRIME + (this.isStaticServices() ? 79 : 97);
+        final Object $associatedNodes = this.getAssociatedNodes();
+        result = result * PRIME + ($associatedNodes == null ? 43 : $associatedNodes.hashCode());
+        final Object $groups = this.getGroups();
+        result = result * PRIME + ($groups == null ? 43 : $groups.hashCode());
+        final Object $processConfiguration = this.getProcessConfiguration();
+        result = result * PRIME + ($processConfiguration == null ? 43 : $processConfiguration.hashCode());
+        result = result * PRIME + this.getStartPort();
+        result = result * PRIME + this.getMinServiceCount();
+        return result;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTask.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTask.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.driver.service;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.Collection;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public class ServiceTask extends ServiceConfigurationBase {
 
     private String name;
@@ -125,62 +130,4 @@ public class ServiceTask extends ServiceConfigurationBase {
         this.minServiceCount = minServiceCount;
     }
 
-    public String toString() {
-        return "ServiceTask(name=" + this.getName() + ", runtime=" + this.getRuntime() + ", maintenance=" + this.isMaintenance() + ", autoDeleteOnStop=" + this.isAutoDeleteOnStop() + ", staticServices=" + this.isStaticServices() + ", associatedNodes=" + this.getAssociatedNodes() + ", groups=" + this.getGroups() + ", processConfiguration=" + this.getProcessConfiguration() + ", startPort=" + this.getStartPort() + ", minServiceCount=" + this.getMinServiceCount() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ServiceTask)) return false;
-        final ServiceTask other = (ServiceTask) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$runtime = this.getRuntime();
-        final Object other$runtime = other.getRuntime();
-        if (this$runtime == null ? other$runtime != null : !this$runtime.equals(other$runtime)) return false;
-        if (this.isMaintenance() != other.isMaintenance()) return false;
-        if (this.isAutoDeleteOnStop() != other.isAutoDeleteOnStop()) return false;
-        if (this.isStaticServices() != other.isStaticServices()) return false;
-        final Object this$associatedNodes = this.getAssociatedNodes();
-        final Object other$associatedNodes = other.getAssociatedNodes();
-        if (this$associatedNodes == null ? other$associatedNodes != null : !this$associatedNodes.equals(other$associatedNodes))
-            return false;
-        final Object this$groups = this.getGroups();
-        final Object other$groups = other.getGroups();
-        if (this$groups == null ? other$groups != null : !this$groups.equals(other$groups)) return false;
-        final Object this$processConfiguration = this.getProcessConfiguration();
-        final Object other$processConfiguration = other.getProcessConfiguration();
-        if (this$processConfiguration == null ? other$processConfiguration != null : !this$processConfiguration.equals(other$processConfiguration))
-            return false;
-        if (this.getStartPort() != other.getStartPort()) return false;
-        if (this.getMinServiceCount() != other.getMinServiceCount()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ServiceTask;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $runtime = this.getRuntime();
-        result = result * PRIME + ($runtime == null ? 43 : $runtime.hashCode());
-        result = result * PRIME + (this.isMaintenance() ? 79 : 97);
-        result = result * PRIME + (this.isAutoDeleteOnStop() ? 79 : 97);
-        result = result * PRIME + (this.isStaticServices() ? 79 : 97);
-        final Object $associatedNodes = this.getAssociatedNodes();
-        result = result * PRIME + ($associatedNodes == null ? 43 : $associatedNodes.hashCode());
-        final Object $groups = this.getGroups();
-        result = result * PRIME + ($groups == null ? 43 : $groups.hashCode());
-        final Object $processConfiguration = this.getProcessConfiguration();
-        result = result * PRIME + ($processConfiguration == null ? 43 : $processConfiguration.hashCode());
-        result = result * PRIME + this.getStartPort();
-        result = result * PRIME + this.getMinServiceCount();
-        return result;
-    }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTemplate.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTemplate.java
@@ -2,9 +2,7 @@ package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.INameable;
 import de.dytanic.cloudnet.common.Validate;
-import lombok.Getter;
 
-@Getter
 public class ServiceTemplate implements INameable {
 
     private final String prefix, name, storage;
@@ -21,5 +19,17 @@ public class ServiceTemplate implements INameable {
 
     public String getTemplatePath() {
         return prefix + "/" + name;
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getStorage() {
+        return this.storage;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ThreadSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ThreadSnapshot.java
@@ -1,10 +1,5 @@
 package de.dytanic.cloudnet.driver.service;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
 public class ThreadSnapshot {
 
     private long id;
@@ -17,4 +12,31 @@ public class ThreadSnapshot {
 
     private int priority;
 
+    public ThreadSnapshot(long id, String name, Thread.State threadState, boolean daemon, int priority) {
+        this.id = id;
+        this.name = name;
+        this.threadState = threadState;
+        this.daemon = daemon;
+        this.priority = priority;
+    }
+
+    public long getId() {
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public Thread.State getThreadState() {
+        return this.threadState;
+    }
+
+    public boolean isDaemon() {
+        return this.daemon;
+    }
+
+    public int getPriority() {
+        return this.priority;
+    }
 }

--- a/cloudnet-examples/src/main/java/de/dytanic/cloudnet/examples/ExampleOwnEvent.java
+++ b/cloudnet-examples/src/main/java/de/dytanic/cloudnet/examples/ExampleOwnEvent.java
@@ -2,13 +2,17 @@ package de.dytanic.cloudnet.examples;
 
 import de.dytanic.cloudnet.driver.event.Event;
 import de.dytanic.cloudnet.driver.module.IModuleWrapper;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor //Generates a constructor with the moduleWrapper as parameter
+//Generates a constructor with the moduleWrapper as parameter
 public final class ExampleOwnEvent extends Event { //Create a own event based of the Event class
 
     private final IModuleWrapper moduleWrapper;
 
+    public ExampleOwnEvent(IModuleWrapper moduleWrapper) {
+        this.moduleWrapper = moduleWrapper;
+    }
+
+    public IModuleWrapper getModuleWrapper() {
+        return this.moduleWrapper;
+    }
 }

--- a/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/cnl/CNLCommand.java
+++ b/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/cnl/CNLCommand.java
@@ -1,10 +1,7 @@
 package de.dytanic.cloudnet.launcher.cnl;
 
-import lombok.Getter;
-
 import java.util.Map;
 
-@Getter
 public abstract class CNLCommand {
 
     protected String name;
@@ -14,4 +11,8 @@ public abstract class CNLCommand {
     }
 
     public abstract void execute(Map<String, String> variables, String commandLine, String... args) throws Exception;
+
+    public String getName() {
+        return this.name;
+    }
 }

--- a/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/update/DefaultRepositoryUpdater.java
+++ b/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/update/DefaultRepositoryUpdater.java
@@ -3,7 +3,6 @@ package de.dytanic.cloudnet.launcher.update;
 import de.dytanic.cloudnet.launcher.Constants;
 import de.dytanic.cloudnet.launcher.util.CloudNetModule;
 import de.dytanic.cloudnet.launcher.util.IOUtils;
-import lombok.Getter;
 
 import java.io.File;
 import java.io.InputStream;
@@ -11,7 +10,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Properties;
 
-@Getter
 public final class DefaultRepositoryUpdater implements IUpdater {
 
     private String url;
@@ -139,5 +137,13 @@ public final class DefaultRepositoryUpdater implements IUpdater {
         urlConnection.setDoOutput(false);
 
         urlConnection.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.95 Safari/537.11");
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    public Properties getProperties() {
+        return this.properties;
     }
 }

--- a/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/util/CloudNetModule.java
+++ b/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/util/CloudNetModule.java
@@ -1,18 +1,48 @@
 package de.dytanic.cloudnet.launcher.util;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-
-@Getter
-@ToString
-@EqualsAndHashCode
-@RequiredArgsConstructor
 public final class CloudNetModule {
 
     protected final String name;
 
     protected final String fileName;
 
+    public CloudNetModule(String name, String fileName) {
+        this.name = name;
+        this.fileName = fileName;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getFileName() {
+        return this.fileName;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CloudNetModule)) return false;
+        final CloudNetModule other = (CloudNetModule) o;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$fileName = this.getFileName();
+        final Object other$fileName = other.getFileName();
+        if (this$fileName == null ? other$fileName != null : !this$fileName.equals(other$fileName)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $fileName = this.getFileName();
+        result = result * PRIME + ($fileName == null ? 43 : $fileName.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "CloudNetModule(name=" + this.getName() + ", fileName=" + this.getFileName() + ")";
+    }
 }

--- a/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/util/CloudNetModule.java
+++ b/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/util/CloudNetModule.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.launcher.util;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public final class CloudNetModule {
 
     protected final String name;
@@ -19,30 +24,4 @@ public final class CloudNetModule {
         return this.fileName;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof CloudNetModule)) return false;
-        final CloudNetModule other = (CloudNetModule) o;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$fileName = this.getFileName();
-        final Object other$fileName = other.getFileName();
-        if (this$fileName == null ? other$fileName != null : !this$fileName.equals(other$fileName)) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $fileName = this.getFileName();
-        result = result * PRIME + ($fileName == null ? 43 : $fileName.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "CloudNetModule(name=" + this.getName() + ", fileName=" + this.getFileName() + ")";
-    }
 }

--- a/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/util/Dependency.java
+++ b/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/util/Dependency.java
@@ -1,14 +1,5 @@
 package de.dytanic.cloudnet.launcher.util;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@EqualsAndHashCode
-@AllArgsConstructor
-@RequiredArgsConstructor
 public class Dependency {
 
     private final String repository, group, name, version;
@@ -16,4 +7,83 @@ public class Dependency {
     private String classifier;
 
 
+    public Dependency(String repository, String group, String name, String version) {
+        this.repository = repository;
+        this.group = group;
+        this.name = name;
+        this.version = version;
+    }
+
+    public Dependency(String repository, String group, String name, String version, String classifier) {
+        this.repository = repository;
+        this.group = group;
+        this.name = name;
+        this.version = version;
+        this.classifier = classifier;
+    }
+
+    public String getRepository() {
+        return this.repository;
+    }
+
+    public String getGroup() {
+        return this.group;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public String getClassifier() {
+        return this.classifier;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Dependency)) return false;
+        final Dependency other = (Dependency) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$repository = this.getRepository();
+        final Object other$repository = other.getRepository();
+        if (this$repository == null ? other$repository != null : !this$repository.equals(other$repository))
+            return false;
+        final Object this$group = this.getGroup();
+        final Object other$group = other.getGroup();
+        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$version = this.getVersion();
+        final Object other$version = other.getVersion();
+        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
+        final Object this$classifier = this.getClassifier();
+        final Object other$classifier = other.getClassifier();
+        if (this$classifier == null ? other$classifier != null : !this$classifier.equals(other$classifier))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof Dependency;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $repository = this.getRepository();
+        result = result * PRIME + ($repository == null ? 43 : $repository.hashCode());
+        final Object $group = this.getGroup();
+        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $version = this.getVersion();
+        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
+        final Object $classifier = this.getClassifier();
+        result = result * PRIME + ($classifier == null ? 43 : $classifier.hashCode());
+        return result;
+    }
 }

--- a/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/util/Dependency.java
+++ b/cloudnet-launcher/src/main/java/de/dytanic/cloudnet/launcher/util/Dependency.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.launcher.util;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class Dependency {
 
     private final String repository, group, name, version;
@@ -42,48 +47,4 @@ public class Dependency {
         return this.classifier;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof Dependency)) return false;
-        final Dependency other = (Dependency) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$repository = this.getRepository();
-        final Object other$repository = other.getRepository();
-        if (this$repository == null ? other$repository != null : !this$repository.equals(other$repository))
-            return false;
-        final Object this$group = this.getGroup();
-        final Object other$group = other.getGroup();
-        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$version = this.getVersion();
-        final Object other$version = other.getVersion();
-        if (this$version == null ? other$version != null : !this$version.equals(other$version)) return false;
-        final Object this$classifier = this.getClassifier();
-        final Object other$classifier = other.getClassifier();
-        if (this$classifier == null ? other$classifier != null : !this$classifier.equals(other$classifier))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof Dependency;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $repository = this.getRepository();
-        result = result * PRIME + ($repository == null ? 43 : $repository.hashCode());
-        final Object $group = this.getGroup();
-        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $version = this.getVersion();
-        result = result * PRIME + ($version == null ? 43 : $version.hashCode());
-        final Object $classifier = this.getClassifier();
-        result = result * PRIME + ($classifier == null ? 43 : $classifier.hashCode());
-        return result;
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/BridgeConfiguration.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/BridgeConfiguration.java
@@ -2,11 +2,15 @@ package de.dytanic.cloudnet.ext.bridge;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public final class BridgeConfiguration extends BasicJsonDocPropertyable {
 
     public static final Type TYPE = new TypeToken<BridgeConfiguration>() {
@@ -79,55 +83,4 @@ public final class BridgeConfiguration extends BasicJsonDocPropertyable {
         this.logPlayerConnections = logPlayerConnections;
     }
 
-    public String toString() {
-        return "BridgeConfiguration(prefix=" + this.getPrefix() + ", excludedOnlyProxyWalkableGroups=" + this.getExcludedOnlyProxyWalkableGroups() + ", excludedGroups=" + this.getExcludedGroups() + ", bungeeFallbackConfigurations=" + this.getBungeeFallbackConfigurations() + ", messages=" + this.getMessages() + ", logPlayerConnections=" + this.isLogPlayerConnections() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof BridgeConfiguration)) return false;
-        final BridgeConfiguration other = (BridgeConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$prefix = this.getPrefix();
-        final Object other$prefix = other.getPrefix();
-        if (this$prefix == null ? other$prefix != null : !this$prefix.equals(other$prefix)) return false;
-        final Object this$excludedOnlyProxyWalkableGroups = this.getExcludedOnlyProxyWalkableGroups();
-        final Object other$excludedOnlyProxyWalkableGroups = other.getExcludedOnlyProxyWalkableGroups();
-        if (this$excludedOnlyProxyWalkableGroups == null ? other$excludedOnlyProxyWalkableGroups != null : !this$excludedOnlyProxyWalkableGroups.equals(other$excludedOnlyProxyWalkableGroups))
-            return false;
-        final Object this$excludedGroups = this.getExcludedGroups();
-        final Object other$excludedGroups = other.getExcludedGroups();
-        if (this$excludedGroups == null ? other$excludedGroups != null : !this$excludedGroups.equals(other$excludedGroups))
-            return false;
-        final Object this$bungeeFallbackConfigurations = this.getBungeeFallbackConfigurations();
-        final Object other$bungeeFallbackConfigurations = other.getBungeeFallbackConfigurations();
-        if (this$bungeeFallbackConfigurations == null ? other$bungeeFallbackConfigurations != null : !this$bungeeFallbackConfigurations.equals(other$bungeeFallbackConfigurations))
-            return false;
-        final Object this$messages = this.getMessages();
-        final Object other$messages = other.getMessages();
-        if (this$messages == null ? other$messages != null : !this$messages.equals(other$messages)) return false;
-        if (this.isLogPlayerConnections() != other.isLogPlayerConnections()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof BridgeConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $prefix = this.getPrefix();
-        result = result * PRIME + ($prefix == null ? 43 : $prefix.hashCode());
-        final Object $excludedOnlyProxyWalkableGroups = this.getExcludedOnlyProxyWalkableGroups();
-        result = result * PRIME + ($excludedOnlyProxyWalkableGroups == null ? 43 : $excludedOnlyProxyWalkableGroups.hashCode());
-        final Object $excludedGroups = this.getExcludedGroups();
-        result = result * PRIME + ($excludedGroups == null ? 43 : $excludedGroups.hashCode());
-        final Object $bungeeFallbackConfigurations = this.getBungeeFallbackConfigurations();
-        result = result * PRIME + ($bungeeFallbackConfigurations == null ? 43 : $bungeeFallbackConfigurations.hashCode());
-        final Object $messages = this.getMessages();
-        result = result * PRIME + ($messages == null ? 43 : $messages.hashCode());
-        result = result * PRIME + (this.isLogPlayerConnections() ? 79 : 97);
-        return result;
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/BridgeConfiguration.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/BridgeConfiguration.java
@@ -2,17 +2,11 @@ package de.dytanic.cloudnet.ext.bridge;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
 
-@Data
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public final class BridgeConfiguration extends BasicJsonDocPropertyable {
 
     public static final Type TYPE = new TypeToken<BridgeConfiguration>() {
@@ -28,4 +22,112 @@ public final class BridgeConfiguration extends BasicJsonDocPropertyable {
 
     private boolean logPlayerConnections = true;
 
+    public BridgeConfiguration(String prefix, Collection<String> excludedOnlyProxyWalkableGroups, Collection<String> excludedGroups, Collection<ProxyFallbackConfiguration> bungeeFallbackConfigurations, Map<String, String> messages, boolean logPlayerConnections) {
+        this.prefix = prefix;
+        this.excludedOnlyProxyWalkableGroups = excludedOnlyProxyWalkableGroups;
+        this.excludedGroups = excludedGroups;
+        this.bungeeFallbackConfigurations = bungeeFallbackConfigurations;
+        this.messages = messages;
+        this.logPlayerConnections = logPlayerConnections;
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+    public Collection<String> getExcludedOnlyProxyWalkableGroups() {
+        return this.excludedOnlyProxyWalkableGroups;
+    }
+
+    public Collection<String> getExcludedGroups() {
+        return this.excludedGroups;
+    }
+
+    public Collection<ProxyFallbackConfiguration> getBungeeFallbackConfigurations() {
+        return this.bungeeFallbackConfigurations;
+    }
+
+    public Map<String, String> getMessages() {
+        return this.messages;
+    }
+
+    public boolean isLogPlayerConnections() {
+        return this.logPlayerConnections;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public void setExcludedOnlyProxyWalkableGroups(Collection<String> excludedOnlyProxyWalkableGroups) {
+        this.excludedOnlyProxyWalkableGroups = excludedOnlyProxyWalkableGroups;
+    }
+
+    public void setExcludedGroups(Collection<String> excludedGroups) {
+        this.excludedGroups = excludedGroups;
+    }
+
+    public void setBungeeFallbackConfigurations(Collection<ProxyFallbackConfiguration> bungeeFallbackConfigurations) {
+        this.bungeeFallbackConfigurations = bungeeFallbackConfigurations;
+    }
+
+    public void setMessages(Map<String, String> messages) {
+        this.messages = messages;
+    }
+
+    public void setLogPlayerConnections(boolean logPlayerConnections) {
+        this.logPlayerConnections = logPlayerConnections;
+    }
+
+    public String toString() {
+        return "BridgeConfiguration(prefix=" + this.getPrefix() + ", excludedOnlyProxyWalkableGroups=" + this.getExcludedOnlyProxyWalkableGroups() + ", excludedGroups=" + this.getExcludedGroups() + ", bungeeFallbackConfigurations=" + this.getBungeeFallbackConfigurations() + ", messages=" + this.getMessages() + ", logPlayerConnections=" + this.isLogPlayerConnections() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof BridgeConfiguration)) return false;
+        final BridgeConfiguration other = (BridgeConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$prefix = this.getPrefix();
+        final Object other$prefix = other.getPrefix();
+        if (this$prefix == null ? other$prefix != null : !this$prefix.equals(other$prefix)) return false;
+        final Object this$excludedOnlyProxyWalkableGroups = this.getExcludedOnlyProxyWalkableGroups();
+        final Object other$excludedOnlyProxyWalkableGroups = other.getExcludedOnlyProxyWalkableGroups();
+        if (this$excludedOnlyProxyWalkableGroups == null ? other$excludedOnlyProxyWalkableGroups != null : !this$excludedOnlyProxyWalkableGroups.equals(other$excludedOnlyProxyWalkableGroups))
+            return false;
+        final Object this$excludedGroups = this.getExcludedGroups();
+        final Object other$excludedGroups = other.getExcludedGroups();
+        if (this$excludedGroups == null ? other$excludedGroups != null : !this$excludedGroups.equals(other$excludedGroups))
+            return false;
+        final Object this$bungeeFallbackConfigurations = this.getBungeeFallbackConfigurations();
+        final Object other$bungeeFallbackConfigurations = other.getBungeeFallbackConfigurations();
+        if (this$bungeeFallbackConfigurations == null ? other$bungeeFallbackConfigurations != null : !this$bungeeFallbackConfigurations.equals(other$bungeeFallbackConfigurations))
+            return false;
+        final Object this$messages = this.getMessages();
+        final Object other$messages = other.getMessages();
+        if (this$messages == null ? other$messages != null : !this$messages.equals(other$messages)) return false;
+        if (this.isLogPlayerConnections() != other.isLogPlayerConnections()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof BridgeConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $prefix = this.getPrefix();
+        result = result * PRIME + ($prefix == null ? 43 : $prefix.hashCode());
+        final Object $excludedOnlyProxyWalkableGroups = this.getExcludedOnlyProxyWalkableGroups();
+        result = result * PRIME + ($excludedOnlyProxyWalkableGroups == null ? 43 : $excludedOnlyProxyWalkableGroups.hashCode());
+        final Object $excludedGroups = this.getExcludedGroups();
+        result = result * PRIME + ($excludedGroups == null ? 43 : $excludedGroups.hashCode());
+        final Object $bungeeFallbackConfigurations = this.getBungeeFallbackConfigurations();
+        result = result * PRIME + ($bungeeFallbackConfigurations == null ? 43 : $bungeeFallbackConfigurations.hashCode());
+        final Object $messages = this.getMessages();
+        result = result * PRIME + ($messages == null ? 43 : $messages.hashCode());
+        result = result * PRIME + (this.isLogPlayerConnections() ? 79 : 97);
+        return result;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/BridgePlayerManager.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/BridgePlayerManager.java
@@ -8,7 +8,6 @@ import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.service.ServiceEnvironmentType;
 import de.dytanic.cloudnet.ext.bridge.player.*;
-import lombok.Getter;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -20,7 +19,6 @@ import java.util.function.Function;
 
 public final class BridgePlayerManager implements IPlayerManager {
 
-    @Getter
     private static final IPlayerManager instance = new BridgePlayerManager();
 
     private static final Type
@@ -28,6 +26,10 @@ public final class BridgePlayerManager implements IPlayerManager {
     }.getType(),
             TYPE_LIST_CLOUD_OFFLINE_PLAYERS = new TypeToken<List<CloudOfflinePlayer>>() {
             }.getType();
+
+    public static IPlayerManager getInstance() {
+        return BridgePlayerManager.instance;
+    }
 
     @Override
     public ICloudPlayer getOnlinePlayer(UUID uniqueId) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/PluginInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/PluginInfo.java
@@ -1,13 +1,21 @@
 package de.dytanic.cloudnet.ext.bridge;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public class PluginInfo extends BasicJsonDocPropertyable {
 
     private final String name, version;
 
+    public PluginInfo(String name, String version) {
+        this.name = name;
+        this.version = version;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.ext.bridge;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class ProxyFallback implements Comparable<ProxyFallback> {
 
     protected String task, permission;
@@ -43,38 +48,4 @@ public class ProxyFallback implements Comparable<ProxyFallback> {
         this.priority = priority;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ProxyFallback)) return false;
-        final ProxyFallback other = (ProxyFallback) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$task = this.getTask();
-        final Object other$task = other.getTask();
-        if (this$task == null ? other$task != null : !this$task.equals(other$task)) return false;
-        final Object this$permission = this.getPermission();
-        final Object other$permission = other.getPermission();
-        if (this$permission == null ? other$permission != null : !this$permission.equals(other$permission))
-            return false;
-        if (this.getPriority() != other.getPriority()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ProxyFallback;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $task = this.getTask();
-        result = result * PRIME + ($task == null ? 43 : $task.hashCode());
-        final Object $permission = this.getPermission();
-        result = result * PRIME + ($permission == null ? 43 : $permission.hashCode());
-        result = result * PRIME + this.getPriority();
-        return result;
-    }
-
-    public String toString() {
-        return "ProxyFallback(task=" + this.getTask() + ", permission=" + this.getPermission() + ", priority=" + this.getPriority() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
@@ -1,19 +1,80 @@
 package de.dytanic.cloudnet.ext.bridge;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class ProxyFallback implements Comparable<ProxyFallback> {
 
     protected String task, permission;
     private int priority;
 
+    public ProxyFallback(String task, String permission, int priority) {
+        this.task = task;
+        this.permission = permission;
+        this.priority = priority;
+    }
+
+    public ProxyFallback() {
+    }
+
     @Override
     public int compareTo(ProxyFallback o) {
         return priority + o.priority;
+    }
+
+    public String getTask() {
+        return this.task;
+    }
+
+    public String getPermission() {
+        return this.permission;
+    }
+
+    public int getPriority() {
+        return this.priority;
+    }
+
+    public void setTask(String task) {
+        this.task = task;
+    }
+
+    public void setPermission(String permission) {
+        this.permission = permission;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ProxyFallback)) return false;
+        final ProxyFallback other = (ProxyFallback) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$task = this.getTask();
+        final Object other$task = other.getTask();
+        if (this$task == null ? other$task != null : !this$task.equals(other$task)) return false;
+        final Object this$permission = this.getPermission();
+        final Object other$permission = other.getPermission();
+        if (this$permission == null ? other$permission != null : !this$permission.equals(other$permission))
+            return false;
+        if (this.getPriority() != other.getPriority()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ProxyFallback;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $task = this.getTask();
+        result = result * PRIME + ($task == null ? 43 : $task.hashCode());
+        final Object $permission = this.getPermission();
+        result = result * PRIME + ($permission == null ? 43 : $permission.hashCode());
+        result = result * PRIME + this.getPriority();
+        return result;
+    }
+
+    public String toString() {
+        return "ProxyFallback(task=" + this.getTask() + ", permission=" + this.getPermission() + ", priority=" + this.getPriority() + ")";
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallbackConfiguration.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallbackConfiguration.java
@@ -1,16 +1,79 @@
 package de.dytanic.cloudnet.ext.bridge;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
 import java.util.List;
 
-@Data
-@AllArgsConstructor
 public class ProxyFallbackConfiguration {
 
     protected String targetGroup, defaultFallbackTask;
 
     protected List<ProxyFallback> fallbacks;
 
+    public ProxyFallbackConfiguration(String targetGroup, String defaultFallbackTask, List<ProxyFallback> fallbacks) {
+        this.targetGroup = targetGroup;
+        this.defaultFallbackTask = defaultFallbackTask;
+        this.fallbacks = fallbacks;
+    }
+
+    public String getTargetGroup() {
+        return this.targetGroup;
+    }
+
+    public String getDefaultFallbackTask() {
+        return this.defaultFallbackTask;
+    }
+
+    public List<ProxyFallback> getFallbacks() {
+        return this.fallbacks;
+    }
+
+    public void setTargetGroup(String targetGroup) {
+        this.targetGroup = targetGroup;
+    }
+
+    public void setDefaultFallbackTask(String defaultFallbackTask) {
+        this.defaultFallbackTask = defaultFallbackTask;
+    }
+
+    public void setFallbacks(List<ProxyFallback> fallbacks) {
+        this.fallbacks = fallbacks;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ProxyFallbackConfiguration)) return false;
+        final ProxyFallbackConfiguration other = (ProxyFallbackConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$targetGroup = this.getTargetGroup();
+        final Object other$targetGroup = other.getTargetGroup();
+        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
+            return false;
+        final Object this$defaultFallbackTask = this.getDefaultFallbackTask();
+        final Object other$defaultFallbackTask = other.getDefaultFallbackTask();
+        if (this$defaultFallbackTask == null ? other$defaultFallbackTask != null : !this$defaultFallbackTask.equals(other$defaultFallbackTask))
+            return false;
+        final Object this$fallbacks = this.getFallbacks();
+        final Object other$fallbacks = other.getFallbacks();
+        if (this$fallbacks == null ? other$fallbacks != null : !this$fallbacks.equals(other$fallbacks)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ProxyFallbackConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $targetGroup = this.getTargetGroup();
+        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
+        final Object $defaultFallbackTask = this.getDefaultFallbackTask();
+        result = result * PRIME + ($defaultFallbackTask == null ? 43 : $defaultFallbackTask.hashCode());
+        final Object $fallbacks = this.getFallbacks();
+        result = result * PRIME + ($fallbacks == null ? 43 : $fallbacks.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "ProxyFallbackConfiguration(targetGroup=" + this.getTargetGroup() + ", defaultFallbackTask=" + this.getDefaultFallbackTask() + ", fallbacks=" + this.getFallbacks() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallbackConfiguration.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallbackConfiguration.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.ext.bridge;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
+@ToString
+@EqualsAndHashCode
 public class ProxyFallbackConfiguration {
 
     protected String targetGroup, defaultFallbackTask;
@@ -38,42 +43,4 @@ public class ProxyFallbackConfiguration {
         this.fallbacks = fallbacks;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ProxyFallbackConfiguration)) return false;
-        final ProxyFallbackConfiguration other = (ProxyFallbackConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$targetGroup = this.getTargetGroup();
-        final Object other$targetGroup = other.getTargetGroup();
-        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
-            return false;
-        final Object this$defaultFallbackTask = this.getDefaultFallbackTask();
-        final Object other$defaultFallbackTask = other.getDefaultFallbackTask();
-        if (this$defaultFallbackTask == null ? other$defaultFallbackTask != null : !this$defaultFallbackTask.equals(other$defaultFallbackTask))
-            return false;
-        final Object this$fallbacks = this.getFallbacks();
-        final Object other$fallbacks = other.getFallbacks();
-        if (this$fallbacks == null ? other$fallbacks != null : !this$fallbacks.equals(other$fallbacks)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ProxyFallbackConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $targetGroup = this.getTargetGroup();
-        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
-        final Object $defaultFallbackTask = this.getDefaultFallbackTask();
-        result = result * PRIME + ($defaultFallbackTask == null ? 43 : $defaultFallbackTask.hashCode());
-        final Object $fallbacks = this.getFallbacks();
-        result = result * PRIME + ($fallbacks == null ? 43 : $fallbacks.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "ProxyFallbackConfiguration(targetGroup=" + this.getTargetGroup() + ", defaultFallbackTask=" + this.getDefaultFallbackTask() + ", fallbacks=" + this.getFallbacks() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/WorldInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/WorldInfo.java
@@ -1,8 +1,13 @@
 package de.dytanic.cloudnet.ext.bridge;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.Map;
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 public class WorldInfo {
 
     protected UUID uniqueId;
@@ -52,46 +57,4 @@ public class WorldInfo {
         this.gameRules = gameRules;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof WorldInfo)) return false;
-        final WorldInfo other = (WorldInfo) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$difficulty = this.getDifficulty();
-        final Object other$difficulty = other.getDifficulty();
-        if (this$difficulty == null ? other$difficulty != null : !this$difficulty.equals(other$difficulty))
-            return false;
-        final Object this$gameRules = this.getGameRules();
-        final Object other$gameRules = other.getGameRules();
-        if (this$gameRules == null ? other$gameRules != null : !this$gameRules.equals(other$gameRules)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof WorldInfo;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $difficulty = this.getDifficulty();
-        result = result * PRIME + ($difficulty == null ? 43 : $difficulty.hashCode());
-        final Object $gameRules = this.getGameRules();
-        result = result * PRIME + ($gameRules == null ? 43 : $gameRules.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "WorldInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", difficulty=" + this.getDifficulty() + ", gameRules=" + this.getGameRules() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/WorldInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/WorldInfo.java
@@ -1,13 +1,8 @@
 package de.dytanic.cloudnet.ext.bridge;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
 import java.util.Map;
 import java.util.UUID;
 
-@Data
-@AllArgsConstructor
 public class WorldInfo {
 
     protected UUID uniqueId;
@@ -18,4 +13,85 @@ public class WorldInfo {
 
     protected Map<String, String> gameRules;
 
+    public WorldInfo(UUID uniqueId, String name, String difficulty, Map<String, String> gameRules) {
+        this.uniqueId = uniqueId;
+        this.name = name;
+        this.difficulty = difficulty;
+        this.gameRules = gameRules;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getDifficulty() {
+        return this.difficulty;
+    }
+
+    public Map<String, String> getGameRules() {
+        return this.gameRules;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDifficulty(String difficulty) {
+        this.difficulty = difficulty;
+    }
+
+    public void setGameRules(Map<String, String> gameRules) {
+        this.gameRules = gameRules;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof WorldInfo)) return false;
+        final WorldInfo other = (WorldInfo) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$difficulty = this.getDifficulty();
+        final Object other$difficulty = other.getDifficulty();
+        if (this$difficulty == null ? other$difficulty != null : !this$difficulty.equals(other$difficulty))
+            return false;
+        final Object this$gameRules = this.getGameRules();
+        final Object other$gameRules = other.getGameRules();
+        if (this$gameRules == null ? other$gameRules != null : !this$gameRules.equals(other$gameRules)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof WorldInfo;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $difficulty = this.getDifficulty();
+        result = result * PRIME + ($difficulty == null ? 43 : $difficulty.hashCode());
+        final Object $gameRules = this.getGameRules();
+        result = result * PRIME + ($gameRules == null ? 43 : $gameRules.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "WorldInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", difficulty=" + this.getDifficulty() + ", gameRules=" + this.getGameRules() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/WorldPosition.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/WorldPosition.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.ext.bridge;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class WorldPosition {
 
     protected double x, y, z, yaw, pitch;
@@ -66,45 +71,4 @@ public class WorldPosition {
         this.world = world;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof WorldPosition)) return false;
-        final WorldPosition other = (WorldPosition) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (Double.compare(this.getX(), other.getX()) != 0) return false;
-        if (Double.compare(this.getY(), other.getY()) != 0) return false;
-        if (Double.compare(this.getZ(), other.getZ()) != 0) return false;
-        if (Double.compare(this.getYaw(), other.getYaw()) != 0) return false;
-        if (Double.compare(this.getPitch(), other.getPitch()) != 0) return false;
-        final Object this$world = this.getWorld();
-        final Object other$world = other.getWorld();
-        if (this$world == null ? other$world != null : !this$world.equals(other$world)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof WorldPosition;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final long $x = Double.doubleToLongBits(this.getX());
-        result = result * PRIME + (int) ($x >>> 32 ^ $x);
-        final long $y = Double.doubleToLongBits(this.getY());
-        result = result * PRIME + (int) ($y >>> 32 ^ $y);
-        final long $z = Double.doubleToLongBits(this.getZ());
-        result = result * PRIME + (int) ($z >>> 32 ^ $z);
-        final long $yaw = Double.doubleToLongBits(this.getYaw());
-        result = result * PRIME + (int) ($yaw >>> 32 ^ $yaw);
-        final long $pitch = Double.doubleToLongBits(this.getPitch());
-        result = result * PRIME + (int) ($pitch >>> 32 ^ $pitch);
-        final Object $world = this.getWorld();
-        result = result * PRIME + ($world == null ? 43 : $world.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "WorldPosition(x=" + this.getX() + ", y=" + this.getY() + ", z=" + this.getZ() + ", yaw=" + this.getYaw() + ", pitch=" + this.getPitch() + ", world=" + this.getWorld() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/WorldPosition.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/WorldPosition.java
@@ -1,16 +1,110 @@
 package de.dytanic.cloudnet.ext.bridge;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class WorldPosition {
 
     protected double x, y, z, yaw, pitch;
 
     protected String world;
 
+    public WorldPosition(double x, double y, double z, double yaw, double pitch, String world) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.yaw = yaw;
+        this.pitch = pitch;
+        this.world = world;
+    }
+
+    public WorldPosition() {
+    }
+
+    public double getX() {
+        return this.x;
+    }
+
+    public double getY() {
+        return this.y;
+    }
+
+    public double getZ() {
+        return this.z;
+    }
+
+    public double getYaw() {
+        return this.yaw;
+    }
+
+    public double getPitch() {
+        return this.pitch;
+    }
+
+    public String getWorld() {
+        return this.world;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public void setZ(double z) {
+        this.z = z;
+    }
+
+    public void setYaw(double yaw) {
+        this.yaw = yaw;
+    }
+
+    public void setPitch(double pitch) {
+        this.pitch = pitch;
+    }
+
+    public void setWorld(String world) {
+        this.world = world;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof WorldPosition)) return false;
+        final WorldPosition other = (WorldPosition) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (Double.compare(this.getX(), other.getX()) != 0) return false;
+        if (Double.compare(this.getY(), other.getY()) != 0) return false;
+        if (Double.compare(this.getZ(), other.getZ()) != 0) return false;
+        if (Double.compare(this.getYaw(), other.getYaw()) != 0) return false;
+        if (Double.compare(this.getPitch(), other.getPitch()) != 0) return false;
+        final Object this$world = this.getWorld();
+        final Object other$world = other.getWorld();
+        if (this$world == null ? other$world != null : !this$world.equals(other$world)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof WorldPosition;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final long $x = Double.doubleToLongBits(this.getX());
+        result = result * PRIME + (int) ($x >>> 32 ^ $x);
+        final long $y = Double.doubleToLongBits(this.getY());
+        result = result * PRIME + (int) ($y >>> 32 ^ $y);
+        final long $z = Double.doubleToLongBits(this.getZ());
+        result = result * PRIME + (int) ($z >>> 32 ^ $z);
+        final long $yaw = Double.doubleToLongBits(this.getYaw());
+        result = result * PRIME + (int) ($yaw >>> 32 ^ $yaw);
+        final long $pitch = Double.doubleToLongBits(this.getPitch());
+        result = result * PRIME + (int) ($pitch >>> 32 ^ $pitch);
+        final Object $world = this.getWorld();
+        result = result * PRIME + ($world == null ? 43 : $world.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "WorldPosition(x=" + this.getX() + ", y=" + this.getY() + ", z=" + this.getZ() + ", yaw=" + this.getYaw() + ", pitch=" + this.getPitch() + ", world=" + this.getWorld() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetHelper.java
@@ -18,8 +18,6 @@ import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
-import lombok.Setter;
 import org.bukkit.*;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -35,20 +33,14 @@ import java.util.function.Function;
 
 public final class BukkitCloudNetHelper {
 
-    @Getter
-    @Setter
     private static volatile String
             apiMotd = Bukkit.getMotd(),
             extra = "",
             state = "LOBBY";
 
-    @Getter
-    @Setter
     private static volatile int
             maxPlayers = Bukkit.getMaxPlayers();
 
-    @Setter
-    @Getter
     private static JavaPlugin plugin;
 
     //*= ----------------------------------------------------------------
@@ -289,5 +281,45 @@ public final class BukkitCloudNetHelper {
         }
 
         return 20D;
+    }
+
+    public static String getApiMotd() {
+        return BukkitCloudNetHelper.apiMotd;
+    }
+
+    public static String getExtra() {
+        return BukkitCloudNetHelper.extra;
+    }
+
+    public static String getState() {
+        return BukkitCloudNetHelper.state;
+    }
+
+    public static int getMaxPlayers() {
+        return BukkitCloudNetHelper.maxPlayers;
+    }
+
+    public static JavaPlugin getPlugin() {
+        return BukkitCloudNetHelper.plugin;
+    }
+
+    public static void setApiMotd(String apiMotd) {
+        BukkitCloudNetHelper.apiMotd = apiMotd;
+    }
+
+    public static void setExtra(String extra) {
+        BukkitCloudNetHelper.extra = extra;
+    }
+
+    public static void setState(String state) {
+        BukkitCloudNetHelper.state = state;
+    }
+
+    public static void setMaxPlayers(int maxPlayers) {
+        BukkitCloudNetHelper.maxPlayers = maxPlayers;
+    }
+
+    public static void setPlugin(JavaPlugin plugin) {
+        BukkitCloudNetHelper.plugin = plugin;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetPlayerInfo.java
@@ -2,9 +2,13 @@ package de.dytanic.cloudnet.ext.bridge.bukkit;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 final class BukkitCloudNetPlayerInfo {
 
     protected UUID uniqueId;
@@ -94,51 +98,4 @@ final class BukkitCloudNetPlayerInfo {
         this.address = address;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof BukkitCloudNetPlayerInfo)) return false;
-        final BukkitCloudNetPlayerInfo other = (BukkitCloudNetPlayerInfo) o;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
-        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
-        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
-        if (this.getLevel() != other.getLevel()) return false;
-        final Object this$location = this.getLocation();
-        final Object other$location = other.getLocation();
-        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final long $health = Double.doubleToLongBits(this.getHealth());
-        result = result * PRIME + (int) ($health >>> 32 ^ $health);
-        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
-        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
-        final long $saturation = Double.doubleToLongBits(this.getSaturation());
-        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
-        result = result * PRIME + this.getLevel();
-        final Object $location = this.getLocation();
-        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "BukkitCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetPlayerInfo.java
@@ -2,13 +2,9 @@ package de.dytanic.cloudnet.ext.bridge.bukkit;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.UUID;
 
-@Data
-@AllArgsConstructor
 final class BukkitCloudNetPlayerInfo {
 
     protected UUID uniqueId;
@@ -23,4 +19,126 @@ final class BukkitCloudNetPlayerInfo {
 
     protected HostAndPort address;
 
+    public BukkitCloudNetPlayerInfo(UUID uniqueId, String name, double health, double maxHealth, double saturation, int level, WorldPosition location, HostAndPort address) {
+        this.uniqueId = uniqueId;
+        this.name = name;
+        this.health = health;
+        this.maxHealth = maxHealth;
+        this.saturation = saturation;
+        this.level = level;
+        this.location = location;
+        this.address = address;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public double getHealth() {
+        return this.health;
+    }
+
+    public double getMaxHealth() {
+        return this.maxHealth;
+    }
+
+    public double getSaturation() {
+        return this.saturation;
+    }
+
+    public int getLevel() {
+        return this.level;
+    }
+
+    public WorldPosition getLocation() {
+        return this.location;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setHealth(double health) {
+        this.health = health;
+    }
+
+    public void setMaxHealth(double maxHealth) {
+        this.maxHealth = maxHealth;
+    }
+
+    public void setSaturation(double saturation) {
+        this.saturation = saturation;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public void setLocation(WorldPosition location) {
+        this.location = location;
+    }
+
+    public void setAddress(HostAndPort address) {
+        this.address = address;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof BukkitCloudNetPlayerInfo)) return false;
+        final BukkitCloudNetPlayerInfo other = (BukkitCloudNetPlayerInfo) o;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
+        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
+        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
+        if (this.getLevel() != other.getLevel()) return false;
+        final Object this$location = this.getLocation();
+        final Object other$location = other.getLocation();
+        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final long $health = Double.doubleToLongBits(this.getHealth());
+        result = result * PRIME + (int) ($health >>> 32 ^ $health);
+        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
+        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
+        final long $saturation = Double.doubleToLongBits(this.getSaturation());
+        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
+        result = result * PRIME + this.getLevel();
+        final Object $location = this.getLocation();
+        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "BukkitCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeConfigurationUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeConfigurationUpdateEvent.java
@@ -1,20 +1,27 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@Getter
-@RequiredArgsConstructor
 public final class BukkitBridgeConfigurationUpdateEvent extends BukkitBridgeEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
     private final BridgeConfiguration bridgeConfiguration;
+
+    public BukkitBridgeConfigurationUpdateEvent(BridgeConfiguration bridgeConfiguration) {
+        this.bridgeConfiguration = bridgeConfiguration;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitBridgeConfigurationUpdateEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public BridgeConfiguration getBridgeConfiguration() {
+        return this.bridgeConfiguration;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerDisconnectEvent.java
@@ -1,21 +1,27 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@Getter
-@RequiredArgsConstructor
 public final class BukkitBridgeProxyPlayerDisconnectEvent extends BukkitBridgeEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
     private final NetworkConnectionInfo networkConnectionInfo;
+
+    public BukkitBridgeProxyPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitBridgeProxyPlayerDisconnectEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
     }
 
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerLoginRequestEvent.java
@@ -1,21 +1,27 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@Getter
-@RequiredArgsConstructor
 public final class BukkitBridgeProxyPlayerLoginRequestEvent extends BukkitBridgeEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
     private final NetworkConnectionInfo networkConnectionInfo;
+
+    public BukkitBridgeProxyPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitBridgeProxyPlayerLoginRequestEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
     }
 
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerLoginSuccessEvent.java
@@ -1,21 +1,27 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@Getter
-@RequiredArgsConstructor
 public final class BukkitBridgeProxyPlayerLoginSuccessEvent extends BukkitBridgeEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
     private final NetworkConnectionInfo networkConnectionInfo;
+
+    public BukkitBridgeProxyPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitBridgeProxyPlayerLoginSuccessEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
     }
 
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerServerConnectRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerServerConnectRequestEvent.java
@@ -2,22 +2,33 @@ package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@Getter
-@RequiredArgsConstructor
 public class BukkitBridgeProxyPlayerServerConnectRequestEvent extends BukkitBridgeEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
     private final NetworkConnectionInfo networkConnectionInfo;
     private final NetworkServiceInfo networkServiceInfo;
+
+    public BukkitBridgeProxyPlayerServerConnectRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitBridgeProxyPlayerServerConnectRequestEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
     }
 
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerServerSwitchEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeProxyPlayerServerSwitchEvent.java
@@ -2,22 +2,33 @@ package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@Getter
-@RequiredArgsConstructor
 public final class BukkitBridgeProxyPlayerServerSwitchEvent extends BukkitBridgeEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
     private final NetworkConnectionInfo networkConnectionInfo;
     private final NetworkServiceInfo networkServiceInfo;
+
+    public BukkitBridgeProxyPlayerServerSwitchEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitBridgeProxyPlayerServerSwitchEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
     }
 
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeServerPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeServerPlayerDisconnectEvent.java
@@ -2,22 +2,33 @@ package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@Getter
-@RequiredArgsConstructor
 public final class BukkitBridgeServerPlayerDisconnectEvent extends BukkitBridgeEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
     private final NetworkConnectionInfo networkConnectionInfo;
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
+
+    public BukkitBridgeServerPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitBridgeServerPlayerDisconnectEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
     }
 
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeServerPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeServerPlayerLoginRequestEvent.java
@@ -2,22 +2,33 @@ package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@Getter
-@RequiredArgsConstructor
 public final class BukkitBridgeServerPlayerLoginRequestEvent extends BukkitBridgeEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
     private final NetworkConnectionInfo networkConnectionInfo;
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
+
+    public BukkitBridgeServerPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitBridgeServerPlayerLoginRequestEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
     }
 
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeServerPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitBridgeServerPlayerLoginSuccessEvent.java
@@ -2,22 +2,33 @@ package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@Getter
-@RequiredArgsConstructor
 public final class BukkitBridgeServerPlayerLoginSuccessEvent extends BukkitBridgeEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
     private final NetworkConnectionInfo networkConnectionInfo;
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
+
+    public BukkitBridgeServerPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitBridgeServerPlayerLoginSuccessEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
     }
 
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitChannelMessageReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitChannelMessageReceiveEvent.java
@@ -1,24 +1,40 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitChannelMessageReceiveEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final String channel, message;
 
-    @Getter
     private final JsonDocument data;
+
+    public BukkitChannelMessageReceiveEvent(String channel, String message, JsonDocument data) {
+        this.channel = channel;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitChannelMessageReceiveEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public JsonDocument getData() {
+        return this.data;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudNetTickEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudNetTickEvent.java
@@ -1,14 +1,17 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@NoArgsConstructor
 public final class BukkitCloudNetTickEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
+
+    public BukkitCloudNetTickEvent() {
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitCloudNetTickEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceConnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceConnectNetworkEvent.java
@@ -1,21 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitCloudServiceConnectNetworkEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BukkitCloudServiceConnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitCloudServiceConnectNetworkEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceDisconnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceDisconnectNetworkEvent.java
@@ -1,21 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitCloudServiceDisconnectNetworkEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BukkitCloudServiceDisconnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitCloudServiceDisconnectNetworkEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceInfoUpdateEvent.java
@@ -1,21 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitCloudServiceInfoUpdateEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BukkitCloudServiceInfoUpdateEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitCloudServiceInfoUpdateEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceRegisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceRegisterEvent.java
@@ -1,21 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitCloudServiceRegisterEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BukkitCloudServiceRegisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitCloudServiceRegisterEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceStartEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceStartEvent.java
@@ -1,21 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitCloudServiceStartEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BukkitCloudServiceStartEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitCloudServiceStartEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceStopEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceStopEvent.java
@@ -1,21 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitCloudServiceStopEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BukkitCloudServiceStopEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitCloudServiceStopEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceUnregisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitCloudServiceUnregisterEvent.java
@@ -1,21 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitCloudServiceUnregisterEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BukkitCloudServiceUnregisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitCloudServiceUnregisterEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitNetworkChannelPacketReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitNetworkChannelPacketReceiveEvent.java
@@ -2,24 +2,35 @@ package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitNetworkChannelPacketReceiveEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final INetworkChannel channel;
 
-    @Getter
     private final IPacket packet;
+
+    public BukkitNetworkChannelPacketReceiveEvent(INetworkChannel channel, IPacket packet) {
+        this.channel = channel;
+        this.packet = packet;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitNetworkChannelPacketReceiveEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
+
+    public IPacket getPacket() {
+        return this.packet;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitNetworkClusterNodeInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitNetworkClusterNodeInfoUpdateEvent.java
@@ -1,21 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNodeInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitNetworkClusterNodeInfoUpdateEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot;
+
+    public BukkitNetworkClusterNodeInfoUpdateEvent(NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot) {
+        this.networkClusterNodeInfoSnapshot = networkClusterNodeInfoSnapshot;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitNetworkClusterNodeInfoUpdateEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNetworkClusterNodeInfoSnapshot() {
+        return this.networkClusterNodeInfoSnapshot;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitServiceInfoSnapshotConfigureEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/event/BukkitServiceInfoSnapshotConfigureEvent.java
@@ -1,21 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bukkit.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.HandlerList;
 
-@RequiredArgsConstructor
 public final class BukkitServiceInfoSnapshotConfigureEvent extends BukkitCloudNetEvent {
 
-    @Getter
     private static HandlerList handlerList = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BukkitServiceInfoSnapshotConfigureEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlerList() {
+        return BukkitServiceInfoSnapshotConfigureEvent.handlerList;
+    }
 
     @Override
     public HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/listener/BukkitPlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/listener/BukkitPlayerListener.java
@@ -8,7 +8,6 @@ import de.dytanic.cloudnet.ext.bridge.bukkit.BukkitCloudNetBridgePlugin;
 import de.dytanic.cloudnet.ext.bridge.bukkit.BukkitCloudNetHelper;
 import de.dytanic.cloudnet.ext.bridge.bukkit.event.BukkitBridgeProxyPlayerServerConnectRequestEvent;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
@@ -21,7 +20,6 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import java.util.Collection;
 import java.util.UUID;
 
-@RequiredArgsConstructor
 public final class BukkitPlayerListener implements Listener {
 
     private final Collection<UUID> accessUniqueIds = Iterables.newCopyOnWriteArrayList();
@@ -29,6 +27,10 @@ public final class BukkitPlayerListener implements Listener {
     private final Collection<String> accessNames = Iterables.newCopyOnWriteArrayList();
 
     private final BukkitCloudNetBridgePlugin plugin;
+
+    public BukkitPlayerListener(BukkitCloudNetBridgePlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler
     public void handle(BukkitBridgeProxyPlayerServerConnectRequestEvent event) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetBridgePlugin.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetBridgePlugin.java
@@ -10,13 +10,11 @@ import de.dytanic.cloudnet.ext.bridge.bungee.listener.BungeeCloudNetListener;
 import de.dytanic.cloudnet.ext.bridge.bungee.listener.BungeePlayerListener;
 import de.dytanic.cloudnet.ext.bridge.listener.BridgeCustomChannelMessageListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
 
 import java.net.InetSocketAddress;
 
-@Getter
 public final class BungeeCloudNetBridgePlugin extends Plugin {
 
     @Override

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetPlayerInfo.java
@@ -1,9 +1,13 @@
 package de.dytanic.cloudnet.ext.bridge.bungee;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 final class BungeeCloudNetPlayerInfo {
 
     private UUID uniqueId;
@@ -62,42 +66,4 @@ final class BungeeCloudNetPlayerInfo {
         this.address = address;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof BungeeCloudNetPlayerInfo)) return false;
-        final BungeeCloudNetPlayerInfo other = (BungeeCloudNetPlayerInfo) o;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$server = this.getServer();
-        final Object other$server = other.getServer();
-        if (this$server == null ? other$server != null : !this$server.equals(other$server)) return false;
-        if (this.getPing() != other.getPing()) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $server = this.getServer();
-        result = result * PRIME + ($server == null ? 43 : $server.hashCode());
-        result = result * PRIME + this.getPing();
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "BungeeCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", server=" + this.getServer() + ", ping=" + this.getPing() + ", address=" + this.getAddress() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetPlayerInfo.java
@@ -1,13 +1,9 @@
 package de.dytanic.cloudnet.ext.bridge.bungee;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.UUID;
 
-@Data
-@AllArgsConstructor
 final class BungeeCloudNetPlayerInfo {
 
     private UUID uniqueId;
@@ -18,4 +14,90 @@ final class BungeeCloudNetPlayerInfo {
 
     private HostAndPort address;
 
+    public BungeeCloudNetPlayerInfo(UUID uniqueId, String name, String server, int ping, HostAndPort address) {
+        this.uniqueId = uniqueId;
+        this.name = name;
+        this.server = server;
+        this.ping = ping;
+        this.address = address;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getServer() {
+        return this.server;
+    }
+
+    public int getPing() {
+        return this.ping;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setServer(String server) {
+        this.server = server;
+    }
+
+    public void setPing(int ping) {
+        this.ping = ping;
+    }
+
+    public void setAddress(HostAndPort address) {
+        this.address = address;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof BungeeCloudNetPlayerInfo)) return false;
+        final BungeeCloudNetPlayerInfo other = (BungeeCloudNetPlayerInfo) o;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$server = this.getServer();
+        final Object other$server = other.getServer();
+        if (this$server == null ? other$server != null : !this$server.equals(other$server)) return false;
+        if (this.getPing() != other.getPing()) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $server = this.getServer();
+        result = result * PRIME + ($server == null ? 43 : $server.hashCode());
+        result = result * PRIME + this.getPing();
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "BungeeCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", server=" + this.getServer() + ", ping=" + this.getPing() + ", address=" + this.getAddress() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeConfigurationUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeConfigurationUpdateEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BungeeBridgeConfigurationUpdateEvent extends BungeeBridgeEvent {
 
     private final BridgeConfiguration bridgeConfiguration;
 
+    public BungeeBridgeConfigurationUpdateEvent(BridgeConfiguration bridgeConfiguration) {
+        this.bridgeConfiguration = bridgeConfiguration;
+    }
+
+    public BridgeConfiguration getBridgeConfiguration() {
+        return this.bridgeConfiguration;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerDisconnectEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BungeeBridgeProxyPlayerDisconnectEvent extends BungeeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public BungeeBridgeProxyPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerLoginRequestEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BungeeBridgeProxyPlayerLoginRequestEvent extends BungeeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public BungeeBridgeProxyPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerLoginSuccessEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BungeeBridgeProxyPlayerLoginSuccessEvent extends BungeeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public BungeeBridgeProxyPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerServerConnectRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerServerConnectRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public class BungeeBridgeProxyPlayerServerConnectRequestEvent extends BungeeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public BungeeBridgeProxyPlayerServerConnectRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerServerSwitchEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeProxyPlayerServerSwitchEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BungeeBridgeProxyPlayerServerSwitchEvent extends BungeeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public BungeeBridgeProxyPlayerServerSwitchEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeServerPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeServerPlayerDisconnectEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BungeeBridgeServerPlayerDisconnectEvent extends BungeeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public BungeeBridgeServerPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeServerPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeServerPlayerLoginRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BungeeBridgeServerPlayerLoginRequestEvent extends BungeeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public BungeeBridgeServerPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeServerPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeBridgeServerPlayerLoginSuccessEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BungeeBridgeServerPlayerLoginSuccessEvent extends BungeeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public BungeeBridgeServerPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeChannelMessageReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeChannelMessageReceiveEvent.java
@@ -1,15 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeChannelMessageReceiveEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final String channel, message;
 
-    @Getter
     private final JsonDocument data;
+
+    public BungeeChannelMessageReceiveEvent(String channel, String message, JsonDocument data) {
+        this.channel = channel;
+        this.message = message;
+        this.data = data;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public JsonDocument getData() {
+        return this.data;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudNetTickEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudNetTickEvent.java
@@ -1,8 +1,7 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
 public final class BungeeCloudNetTickEvent extends BungeeCloudNetEvent {
 
+    public BungeeCloudNetTickEvent() {
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceConnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceConnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeCloudServiceConnectNetworkEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BungeeCloudServiceConnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceDisconnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceDisconnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeCloudServiceDisconnectNetworkEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BungeeCloudServiceDisconnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeCloudServiceInfoUpdateEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BungeeCloudServiceInfoUpdateEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceRegisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceRegisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeCloudServiceRegisterEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BungeeCloudServiceRegisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceStartEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceStartEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeCloudServiceStartEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BungeeCloudServiceStartEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceStopEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceStopEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeCloudServiceStopEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BungeeCloudServiceStopEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceUnregisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeCloudServiceUnregisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeCloudServiceUnregisterEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BungeeCloudServiceUnregisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeNetworkChannelPacketReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeNetworkChannelPacketReceiveEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeNetworkChannelPacketReceiveEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final INetworkChannel channel;
 
-    @Getter
     private final IPacket packet;
+
+    public BungeeNetworkChannelPacketReceiveEvent(INetworkChannel channel, IPacket packet) {
+        this.channel = channel;
+        this.packet = packet;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
+
+    public IPacket getPacket() {
+        return this.packet;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeNetworkClusterNodeInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeNetworkClusterNodeInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNodeInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeNetworkClusterNodeInfoUpdateEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot;
+
+    public BungeeNetworkClusterNodeInfoUpdateEvent(NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot) {
+        this.networkClusterNodeInfoSnapshot = networkClusterNodeInfoSnapshot;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNetworkClusterNodeInfoSnapshot() {
+        return this.networkClusterNodeInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeServiceInfoSnapshotConfigureEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/event/BungeeServiceInfoSnapshotConfigureEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.bungee.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class BungeeServiceInfoSnapshotConfigureEvent extends BungeeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public BungeeServiceInfoSnapshotConfigureEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeConfigurationUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeConfigurationUpdateEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.ext.bridge.event;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeConfigurationUpdateEvent extends DriverEvent {
 
     private final BridgeConfiguration bridgeConfiguration;
 
+    public BridgeConfigurationUpdateEvent(BridgeConfiguration bridgeConfiguration) {
+        this.bridgeConfiguration = bridgeConfiguration;
+    }
+
+    public BridgeConfiguration getBridgeConfiguration() {
+        return this.bridgeConfiguration;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerDisconnectEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.ext.bridge.event;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeProxyPlayerDisconnectEvent extends DriverEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public BridgeProxyPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerLoginRequestEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.ext.bridge.event;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeProxyPlayerLoginRequestEvent extends DriverEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public BridgeProxyPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerLoginSuccessEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.ext.bridge.event;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeProxyPlayerLoginSuccessEvent extends DriverEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public BridgeProxyPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerServerConnectRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerServerConnectRequestEvent.java
@@ -3,15 +3,23 @@ package de.dytanic.cloudnet.ext.bridge.event;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeProxyPlayerServerConnectRequestEvent extends DriverEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public BridgeProxyPlayerServerConnectRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerServerSwitchEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeProxyPlayerServerSwitchEvent.java
@@ -3,15 +3,23 @@ package de.dytanic.cloudnet.ext.bridge.event;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeProxyPlayerServerSwitchEvent extends DriverEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public BridgeProxyPlayerServerSwitchEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeServerPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeServerPlayerDisconnectEvent.java
@@ -3,15 +3,23 @@ package de.dytanic.cloudnet.ext.bridge.event;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeServerPlayerDisconnectEvent extends DriverEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public BridgeServerPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeServerPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeServerPlayerLoginRequestEvent.java
@@ -3,15 +3,23 @@ package de.dytanic.cloudnet.ext.bridge.event;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeServerPlayerLoginRequestEvent extends DriverEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public BridgeServerPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeServerPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeServerPlayerLoginSuccessEvent.java
@@ -3,15 +3,23 @@ package de.dytanic.cloudnet.ext.bridge.event;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeServerPlayerLoginSuccessEvent extends DriverEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public BridgeServerPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeUpdateCloudOfflinePlayerEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeUpdateCloudOfflinePlayerEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.ext.bridge.event;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.ICloudOfflinePlayer;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeUpdateCloudOfflinePlayerEvent extends DriverEvent {
 
     private final ICloudOfflinePlayer cloudOfflinePlayer;
 
+    public BridgeUpdateCloudOfflinePlayerEvent(ICloudOfflinePlayer cloudOfflinePlayer) {
+        this.cloudOfflinePlayer = cloudOfflinePlayer;
+    }
+
+    public ICloudOfflinePlayer getCloudOfflinePlayer() {
+        return this.cloudOfflinePlayer;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeUpdateCloudPlayerEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/event/BridgeUpdateCloudPlayerEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.ext.bridge.event;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.ext.bridge.player.ICloudPlayer;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class BridgeUpdateCloudPlayerEvent extends DriverEvent {
 
     private final ICloudPlayer cloudPlayer;
 
+    public BridgeUpdateCloudPlayerEvent(ICloudPlayer cloudPlayer) {
+        this.cloudPlayer = cloudPlayer;
+    }
+
+    public ICloudPlayer getCloudPlayer() {
+        return this.cloudPlayer;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/GoMintCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/GoMintCloudNetHelper.java
@@ -23,8 +23,6 @@ import io.gomint.server.GoMintServer;
 import io.gomint.server.network.Protocol;
 import io.gomint.world.Gamerule;
 import io.gomint.world.World;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -34,19 +32,13 @@ import java.util.function.Function;
 
 public final class GoMintCloudNetHelper {
 
-    @Getter
-    @Setter
     private static volatile String
             apiMotd,
             extra = "",
             state = "LOBBY";
 
-    @Getter
-    @Setter
     private static volatile int maxPlayers = GoMint.instance().getMaxPlayers();
 
-    @Getter
-    @Setter
     private static volatile GoMintCloudNetBridgePlugin plugin;
 
     static {
@@ -224,5 +216,45 @@ public final class GoMintCloudNetHelper {
                         Wrapper.getInstance().getServiceId().getName()
                 )
         );
+    }
+
+    public static String getApiMotd() {
+        return GoMintCloudNetHelper.apiMotd;
+    }
+
+    public static String getExtra() {
+        return GoMintCloudNetHelper.extra;
+    }
+
+    public static String getState() {
+        return GoMintCloudNetHelper.state;
+    }
+
+    public static int getMaxPlayers() {
+        return GoMintCloudNetHelper.maxPlayers;
+    }
+
+    public static GoMintCloudNetBridgePlugin getPlugin() {
+        return GoMintCloudNetHelper.plugin;
+    }
+
+    public static void setApiMotd(String apiMotd) {
+        GoMintCloudNetHelper.apiMotd = apiMotd;
+    }
+
+    public static void setExtra(String extra) {
+        GoMintCloudNetHelper.extra = extra;
+    }
+
+    public static void setState(String state) {
+        GoMintCloudNetHelper.state = state;
+    }
+
+    public static void setMaxPlayers(int maxPlayers) {
+        GoMintCloudNetHelper.maxPlayers = maxPlayers;
+    }
+
+    public static void setPlugin(GoMintCloudNetBridgePlugin plugin) {
+        GoMintCloudNetHelper.plugin = plugin;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/GoMintCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/GoMintCloudNetPlayerInfo.java
@@ -2,10 +2,14 @@ package de.dytanic.cloudnet.ext.bridge.gomint;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Locale;
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 final class GoMintCloudNetPlayerInfo {
 
     protected double health, maxHealth, saturation;
@@ -146,76 +150,4 @@ final class GoMintCloudNetPlayerInfo {
         this.gamemode = gamemode;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof GoMintCloudNetPlayerInfo)) return false;
-        final GoMintCloudNetPlayerInfo other = (GoMintCloudNetPlayerInfo) o;
-        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
-        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
-        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
-        if (this.getLevel() != other.getLevel()) return false;
-        if (this.getPing() != other.getPing()) return false;
-        final Object this$locale = this.getLocale();
-        final Object other$locale = other.getLocale();
-        if (this$locale == null ? other$locale != null : !this$locale.equals(other$locale)) return false;
-        final Object this$location = this.getLocation();
-        final Object other$location = other.getLocation();
-        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        if (this.isOnline() != other.isOnline()) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$deviceName = this.getDeviceName();
-        final Object other$deviceName = other.getDeviceName();
-        if (this$deviceName == null ? other$deviceName != null : !this$deviceName.equals(other$deviceName))
-            return false;
-        final Object this$xBoxId = this.getXBoxId();
-        final Object other$xBoxId = other.getXBoxId();
-        if (this$xBoxId == null ? other$xBoxId != null : !this$xBoxId.equals(other$xBoxId)) return false;
-        final Object this$gamemode = this.getGamemode();
-        final Object other$gamemode = other.getGamemode();
-        if (this$gamemode == null ? other$gamemode != null : !this$gamemode.equals(other$gamemode)) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final long $health = Double.doubleToLongBits(this.getHealth());
-        result = result * PRIME + (int) ($health >>> 32 ^ $health);
-        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
-        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
-        final long $saturation = Double.doubleToLongBits(this.getSaturation());
-        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
-        result = result * PRIME + this.getLevel();
-        result = result * PRIME + this.getPing();
-        final Object $locale = this.getLocale();
-        result = result * PRIME + ($locale == null ? 43 : $locale.hashCode());
-        final Object $location = this.getLocation();
-        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        result = result * PRIME + (this.isOnline() ? 79 : 97);
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $deviceName = this.getDeviceName();
-        result = result * PRIME + ($deviceName == null ? 43 : $deviceName.hashCode());
-        final Object $xBoxId = this.getXBoxId();
-        result = result * PRIME + ($xBoxId == null ? 43 : $xBoxId.hashCode());
-        final Object $gamemode = this.getGamemode();
-        result = result * PRIME + ($gamemode == null ? 43 : $gamemode.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "GoMintCloudNetPlayerInfo(health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", ping=" + this.getPing() + ", locale=" + this.getLocale() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ", uniqueId=" + this.getUniqueId() + ", online=" + this.isOnline() + ", name=" + this.getName() + ", deviceName=" + this.getDeviceName() + ", xBoxId=" + this.getXBoxId() + ", gamemode=" + this.getGamemode() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/GoMintCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/GoMintCloudNetPlayerInfo.java
@@ -2,14 +2,10 @@ package de.dytanic.cloudnet.ext.bridge.gomint;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.Locale;
 import java.util.UUID;
 
-@Data
-@AllArgsConstructor
 final class GoMintCloudNetPlayerInfo {
 
     protected double health, maxHealth, saturation;
@@ -21,4 +17,205 @@ final class GoMintCloudNetPlayerInfo {
     private boolean online;
     private String name, deviceName, xBoxId, gamemode;
 
+    public GoMintCloudNetPlayerInfo(double health, double maxHealth, double saturation, int level, int ping, Locale locale, WorldPosition location, HostAndPort address, UUID uniqueId, boolean online, String name, String deviceName, String xBoxId, String gamemode) {
+        this.health = health;
+        this.maxHealth = maxHealth;
+        this.saturation = saturation;
+        this.level = level;
+        this.ping = ping;
+        this.locale = locale;
+        this.location = location;
+        this.address = address;
+        this.uniqueId = uniqueId;
+        this.online = online;
+        this.name = name;
+        this.deviceName = deviceName;
+        this.xBoxId = xBoxId;
+        this.gamemode = gamemode;
+    }
+
+    public double getHealth() {
+        return this.health;
+    }
+
+    public double getMaxHealth() {
+        return this.maxHealth;
+    }
+
+    public double getSaturation() {
+        return this.saturation;
+    }
+
+    public int getLevel() {
+        return this.level;
+    }
+
+    public int getPing() {
+        return this.ping;
+    }
+
+    public Locale getLocale() {
+        return this.locale;
+    }
+
+    public WorldPosition getLocation() {
+        return this.location;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public boolean isOnline() {
+        return this.online;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getDeviceName() {
+        return this.deviceName;
+    }
+
+    public String getXBoxId() {
+        return this.xBoxId;
+    }
+
+    public String getGamemode() {
+        return this.gamemode;
+    }
+
+    public void setHealth(double health) {
+        this.health = health;
+    }
+
+    public void setMaxHealth(double maxHealth) {
+        this.maxHealth = maxHealth;
+    }
+
+    public void setSaturation(double saturation) {
+        this.saturation = saturation;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public void setPing(int ping) {
+        this.ping = ping;
+    }
+
+    public void setLocale(Locale locale) {
+        this.locale = locale;
+    }
+
+    public void setLocation(WorldPosition location) {
+        this.location = location;
+    }
+
+    public void setAddress(HostAndPort address) {
+        this.address = address;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setOnline(boolean online) {
+        this.online = online;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDeviceName(String deviceName) {
+        this.deviceName = deviceName;
+    }
+
+    public void setXBoxId(String xBoxId) {
+        this.xBoxId = xBoxId;
+    }
+
+    public void setGamemode(String gamemode) {
+        this.gamemode = gamemode;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof GoMintCloudNetPlayerInfo)) return false;
+        final GoMintCloudNetPlayerInfo other = (GoMintCloudNetPlayerInfo) o;
+        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
+        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
+        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
+        if (this.getLevel() != other.getLevel()) return false;
+        if (this.getPing() != other.getPing()) return false;
+        final Object this$locale = this.getLocale();
+        final Object other$locale = other.getLocale();
+        if (this$locale == null ? other$locale != null : !this$locale.equals(other$locale)) return false;
+        final Object this$location = this.getLocation();
+        final Object other$location = other.getLocation();
+        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        if (this.isOnline() != other.isOnline()) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$deviceName = this.getDeviceName();
+        final Object other$deviceName = other.getDeviceName();
+        if (this$deviceName == null ? other$deviceName != null : !this$deviceName.equals(other$deviceName))
+            return false;
+        final Object this$xBoxId = this.getXBoxId();
+        final Object other$xBoxId = other.getXBoxId();
+        if (this$xBoxId == null ? other$xBoxId != null : !this$xBoxId.equals(other$xBoxId)) return false;
+        final Object this$gamemode = this.getGamemode();
+        final Object other$gamemode = other.getGamemode();
+        if (this$gamemode == null ? other$gamemode != null : !this$gamemode.equals(other$gamemode)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final long $health = Double.doubleToLongBits(this.getHealth());
+        result = result * PRIME + (int) ($health >>> 32 ^ $health);
+        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
+        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
+        final long $saturation = Double.doubleToLongBits(this.getSaturation());
+        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
+        result = result * PRIME + this.getLevel();
+        result = result * PRIME + this.getPing();
+        final Object $locale = this.getLocale();
+        result = result * PRIME + ($locale == null ? 43 : $locale.hashCode());
+        final Object $location = this.getLocation();
+        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        result = result * PRIME + (this.isOnline() ? 79 : 97);
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $deviceName = this.getDeviceName();
+        result = result * PRIME + ($deviceName == null ? 43 : $deviceName.hashCode());
+        final Object $xBoxId = this.getXBoxId();
+        result = result * PRIME + ($xBoxId == null ? 43 : $xBoxId.hashCode());
+        final Object $gamemode = this.getGamemode();
+        result = result * PRIME + ($gamemode == null ? 43 : $gamemode.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "GoMintCloudNetPlayerInfo(health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", ping=" + this.getPing() + ", locale=" + this.getLocale() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ", uniqueId=" + this.getUniqueId() + ", online=" + this.isOnline() + ", name=" + this.getName() + ", deviceName=" + this.getDeviceName() + ", xBoxId=" + this.getXBoxId() + ", gamemode=" + this.getGamemode() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeConfigurationUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeConfigurationUpdateEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class GoMintBridgeConfigurationUpdateEvent extends GoMintBridgeEvent {
 
     private final BridgeConfiguration bridgeConfiguration;
 
+    public GoMintBridgeConfigurationUpdateEvent(BridgeConfiguration bridgeConfiguration) {
+        this.bridgeConfiguration = bridgeConfiguration;
+    }
+
+    public BridgeConfiguration getBridgeConfiguration() {
+        return this.bridgeConfiguration;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerDisconnectEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class GoMintBridgeProxyPlayerDisconnectEvent extends GoMintBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public GoMintBridgeProxyPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerLoginRequestEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class GoMintBridgeProxyPlayerLoginRequestEvent extends GoMintBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public GoMintBridgeProxyPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerLoginSuccessEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class GoMintBridgeProxyPlayerLoginSuccessEvent extends GoMintBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public GoMintBridgeProxyPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerServerConnectRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerServerConnectRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public class GoMintBridgeProxyPlayerServerConnectRequestEvent extends GoMintBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public GoMintBridgeProxyPlayerServerConnectRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerServerSwitchEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeProxyPlayerServerSwitchEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class GoMintBridgeProxyPlayerServerSwitchEvent extends GoMintBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public GoMintBridgeProxyPlayerServerSwitchEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeServerPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeServerPlayerDisconnectEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class GoMintBridgeServerPlayerDisconnectEvent extends GoMintBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public GoMintBridgeServerPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeServerPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeServerPlayerLoginRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class GoMintBridgeServerPlayerLoginRequestEvent extends GoMintBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public GoMintBridgeServerPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeServerPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintBridgeServerPlayerLoginSuccessEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class GoMintBridgeServerPlayerLoginSuccessEvent extends GoMintBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public GoMintBridgeServerPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintChannelMessageReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintChannelMessageReceiveEvent.java
@@ -1,15 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintChannelMessageReceiveEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final String channel, message;
 
-    @Getter
     private final JsonDocument data;
+
+    public GoMintChannelMessageReceiveEvent(String channel, String message, JsonDocument data) {
+        this.channel = channel;
+        this.message = message;
+        this.data = data;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public JsonDocument getData() {
+        return this.data;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudNetTickEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudNetTickEvent.java
@@ -1,8 +1,7 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
 public final class GoMintCloudNetTickEvent extends GoMintCloudNetEvent {
 
+    public GoMintCloudNetTickEvent() {
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceConnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceConnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintCloudServiceConnectNetworkEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public GoMintCloudServiceConnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceDisconnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceDisconnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintCloudServiceDisconnectNetworkEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public GoMintCloudServiceDisconnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintCloudServiceInfoUpdateEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public GoMintCloudServiceInfoUpdateEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceRegisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceRegisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintCloudServiceRegisterEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public GoMintCloudServiceRegisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceStartEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceStartEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintCloudServiceStartEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public GoMintCloudServiceStartEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceStopEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceStopEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintCloudServiceStopEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public GoMintCloudServiceStopEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceUnregisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintCloudServiceUnregisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintCloudServiceUnregisterEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public GoMintCloudServiceUnregisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintNetworkChannelPacketReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintNetworkChannelPacketReceiveEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintNetworkChannelPacketReceiveEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final INetworkChannel channel;
 
-    @Getter
     private final IPacket packet;
+
+    public GoMintNetworkChannelPacketReceiveEvent(INetworkChannel channel, IPacket packet) {
+        this.channel = channel;
+        this.packet = packet;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
+
+    public IPacket getPacket() {
+        return this.packet;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintNetworkClusterNodeInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintNetworkClusterNodeInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNodeInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintNetworkClusterNodeInfoUpdateEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot;
+
+    public GoMintNetworkClusterNodeInfoUpdateEvent(NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot) {
+        this.networkClusterNodeInfoSnapshot = networkClusterNodeInfoSnapshot;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNetworkClusterNodeInfoSnapshot() {
+        return this.networkClusterNodeInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintServiceInfoSnapshotConfigureEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/gomint/event/GoMintServiceInfoSnapshotConfigureEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.gomint.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class GoMintServiceInfoSnapshotConfigureEvent extends GoMintCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public GoMintServiceInfoSnapshotConfigureEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/node/CloudNetBridgeModule.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/node/CloudNetBridgeModule.java
@@ -17,22 +17,21 @@ import de.dytanic.cloudnet.ext.bridge.node.listener.NodeCustomChannelMessageList
 import de.dytanic.cloudnet.ext.bridge.node.listener.PlayerManagerListener;
 import de.dytanic.cloudnet.ext.bridge.node.player.NodePlayerManager;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.Collections;
 
 public final class CloudNetBridgeModule extends NodeCloudNetModule {
 
-    @Getter
     private static CloudNetBridgeModule instance;
 
-    @Getter
-    @Setter
     private BridgeConfiguration bridgeConfiguration;
 
     public CloudNetBridgeModule() {
         instance = this;
+    }
+
+    public static CloudNetBridgeModule getInstance() {
+        return CloudNetBridgeModule.instance;
     }
 
     @ModuleTask(order = 64, event = ModuleLifeCycle.STARTED)
@@ -92,5 +91,13 @@ public final class CloudNetBridgeModule extends NodeCloudNetModule {
     @ModuleTask(order = 8, event = ModuleLifeCycle.STARTED)
     public void initListeners() {
         registerListeners(new NetworkListenerRegisterListener(), new IncludePluginListener(), new NodeCustomChannelMessageListener());
+    }
+
+    public BridgeConfiguration getBridgeConfiguration() {
+        return this.bridgeConfiguration;
+    }
+
+    public void setBridgeConfiguration(BridgeConfiguration bridgeConfiguration) {
+        this.bridgeConfiguration = bridgeConfiguration;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/node/player/NodePlayerManager.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/node/player/NodePlayerManager.java
@@ -11,7 +11,6 @@ import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.service.ServiceEnvironmentType;
 import de.dytanic.cloudnet.ext.bridge.BridgeConstants;
 import de.dytanic.cloudnet.ext.bridge.player.*;
-import lombok.Getter;
 
 import java.util.List;
 import java.util.Map;
@@ -21,10 +20,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-@Getter
 public final class NodePlayerManager implements IPlayerManager {
 
-    @Getter
     private static NodePlayerManager instance;
 
     private final Map<UUID, CloudPlayer> onlineCloudPlayers = Maps.newConcurrentHashMap();
@@ -37,6 +34,10 @@ public final class NodePlayerManager implements IPlayerManager {
         /*= --------------------------------- =*/
 
         instance = this;
+    }
+
+    public static NodePlayerManager getInstance() {
+        return NodePlayerManager.instance;
     }
 
     /*= ---------------------------------------------------------------- =*/
@@ -275,5 +276,13 @@ public final class NodePlayerManager implements IPlayerManager {
 
     private <T> ITask<T> schedule(Callable<T> callable) {
         return CloudNet.getInstance().getTaskScheduler().schedule(callable);
+    }
+
+    public Map<UUID, CloudPlayer> getOnlineCloudPlayers() {
+        return this.onlineCloudPlayers;
+    }
+
+    public String getDatabaseName() {
+        return this.databaseName;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/NukkitCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/NukkitCloudNetHelper.java
@@ -23,23 +23,17 @@ import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.Map;
 import java.util.function.Function;
 
 public final class NukkitCloudNetHelper {
 
-    @Getter
-    @Setter
     private static volatile String
             apiMotd = Server.getInstance().getMotd(),
             extra = "",
             state = "LOBBY";
 
-    @Getter
-    @Setter
     private static volatile int maxPlayers = Server.getInstance().getMaxPlayers();
 
     //*= ----------------------------------------------------------------
@@ -222,5 +216,37 @@ public final class NukkitCloudNetHelper {
                         Wrapper.getInstance().getServiceId().getName()
                 )
         );
+    }
+
+    public static String getApiMotd() {
+        return NukkitCloudNetHelper.apiMotd;
+    }
+
+    public static String getExtra() {
+        return NukkitCloudNetHelper.extra;
+    }
+
+    public static String getState() {
+        return NukkitCloudNetHelper.state;
+    }
+
+    public static int getMaxPlayers() {
+        return NukkitCloudNetHelper.maxPlayers;
+    }
+
+    public static void setApiMotd(String apiMotd) {
+        NukkitCloudNetHelper.apiMotd = apiMotd;
+    }
+
+    public static void setExtra(String extra) {
+        NukkitCloudNetHelper.extra = extra;
+    }
+
+    public static void setState(String state) {
+        NukkitCloudNetHelper.state = state;
+    }
+
+    public static void setMaxPlayers(int maxPlayers) {
+        NukkitCloudNetHelper.maxPlayers = maxPlayers;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/NukkitCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/NukkitCloudNetPlayerInfo.java
@@ -2,9 +2,13 @@ package de.dytanic.cloudnet.ext.bridge.nukkit;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 final class NukkitCloudNetPlayerInfo {
 
     protected double health, maxHealth, saturation;
@@ -98,53 +102,4 @@ final class NukkitCloudNetPlayerInfo {
         this.name = name;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NukkitCloudNetPlayerInfo)) return false;
-        final NukkitCloudNetPlayerInfo other = (NukkitCloudNetPlayerInfo) o;
-        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
-        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
-        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
-        if (this.getLevel() != other.getLevel()) return false;
-        if (this.getPing() != other.getPing()) return false;
-        final Object this$location = this.getLocation();
-        final Object other$location = other.getLocation();
-        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final long $health = Double.doubleToLongBits(this.getHealth());
-        result = result * PRIME + (int) ($health >>> 32 ^ $health);
-        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
-        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
-        final long $saturation = Double.doubleToLongBits(this.getSaturation());
-        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
-        result = result * PRIME + this.getLevel();
-        result = result * PRIME + this.getPing();
-        final Object $location = this.getLocation();
-        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "NukkitCloudNetPlayerInfo(health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", ping=" + this.getPing() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ", uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/NukkitCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/NukkitCloudNetPlayerInfo.java
@@ -2,13 +2,9 @@ package de.dytanic.cloudnet.ext.bridge.nukkit;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.UUID;
 
-@Data
-@AllArgsConstructor
 final class NukkitCloudNetPlayerInfo {
 
     protected double health, maxHealth, saturation;
@@ -18,4 +14,137 @@ final class NukkitCloudNetPlayerInfo {
     private UUID uniqueId;
     private String name;
 
+    public NukkitCloudNetPlayerInfo(double health, double maxHealth, double saturation, int level, int ping, WorldPosition location, HostAndPort address, UUID uniqueId, String name) {
+        this.health = health;
+        this.maxHealth = maxHealth;
+        this.saturation = saturation;
+        this.level = level;
+        this.ping = ping;
+        this.location = location;
+        this.address = address;
+        this.uniqueId = uniqueId;
+        this.name = name;
+    }
+
+    public double getHealth() {
+        return this.health;
+    }
+
+    public double getMaxHealth() {
+        return this.maxHealth;
+    }
+
+    public double getSaturation() {
+        return this.saturation;
+    }
+
+    public int getLevel() {
+        return this.level;
+    }
+
+    public int getPing() {
+        return this.ping;
+    }
+
+    public WorldPosition getLocation() {
+        return this.location;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setHealth(double health) {
+        this.health = health;
+    }
+
+    public void setMaxHealth(double maxHealth) {
+        this.maxHealth = maxHealth;
+    }
+
+    public void setSaturation(double saturation) {
+        this.saturation = saturation;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public void setPing(int ping) {
+        this.ping = ping;
+    }
+
+    public void setLocation(WorldPosition location) {
+        this.location = location;
+    }
+
+    public void setAddress(HostAndPort address) {
+        this.address = address;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NukkitCloudNetPlayerInfo)) return false;
+        final NukkitCloudNetPlayerInfo other = (NukkitCloudNetPlayerInfo) o;
+        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
+        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
+        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
+        if (this.getLevel() != other.getLevel()) return false;
+        if (this.getPing() != other.getPing()) return false;
+        final Object this$location = this.getLocation();
+        final Object other$location = other.getLocation();
+        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final long $health = Double.doubleToLongBits(this.getHealth());
+        result = result * PRIME + (int) ($health >>> 32 ^ $health);
+        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
+        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
+        final long $saturation = Double.doubleToLongBits(this.getSaturation());
+        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
+        result = result * PRIME + this.getLevel();
+        result = result * PRIME + this.getPing();
+        final Object $location = this.getLocation();
+        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "NukkitCloudNetPlayerInfo(health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", ping=" + this.getPing() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ", uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeConfigurationUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeConfigurationUpdateEvent.java
@@ -2,16 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NukkitBridgeConfigurationUpdateEvent extends NukkitBridgeEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
     private final BridgeConfiguration bridgeConfiguration;
 
+    public NukkitBridgeConfigurationUpdateEvent(BridgeConfiguration bridgeConfiguration) {
+        this.bridgeConfiguration = bridgeConfiguration;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitBridgeConfigurationUpdateEvent.handlers;
+    }
+
+    public BridgeConfiguration getBridgeConfiguration() {
+        return this.bridgeConfiguration;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerDisconnectEvent.java
@@ -2,16 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NukkitBridgeProxyPlayerDisconnectEvent extends NukkitBridgeEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public NukkitBridgeProxyPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitBridgeProxyPlayerDisconnectEvent.handlers;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerLoginRequestEvent.java
@@ -2,16 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NukkitBridgeProxyPlayerLoginRequestEvent extends NukkitBridgeEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public NukkitBridgeProxyPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitBridgeProxyPlayerLoginRequestEvent.handlers;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerLoginSuccessEvent.java
@@ -2,16 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NukkitBridgeProxyPlayerLoginSuccessEvent extends NukkitBridgeEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public NukkitBridgeProxyPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitBridgeProxyPlayerLoginSuccessEvent.handlers;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerServerConnectRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerServerConnectRequestEvent.java
@@ -3,18 +3,29 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public class NukkitBridgeProxyPlayerServerConnectRequestEvent extends NukkitBridgeEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public NukkitBridgeProxyPlayerServerConnectRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitBridgeProxyPlayerServerConnectRequestEvent.handlers;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerServerSwitchEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeProxyPlayerServerSwitchEvent.java
@@ -3,18 +3,29 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NukkitBridgeProxyPlayerServerSwitchEvent extends NukkitBridgeEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public NukkitBridgeProxyPlayerServerSwitchEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitBridgeProxyPlayerServerSwitchEvent.handlers;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeServerPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeServerPlayerDisconnectEvent.java
@@ -3,18 +3,29 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NukkitBridgeServerPlayerDisconnectEvent extends NukkitBridgeEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public NukkitBridgeServerPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitBridgeServerPlayerDisconnectEvent.handlers;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeServerPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeServerPlayerLoginRequestEvent.java
@@ -3,18 +3,29 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NukkitBridgeServerPlayerLoginRequestEvent extends NukkitBridgeEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public NukkitBridgeServerPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitBridgeServerPlayerLoginRequestEvent.handlers;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeServerPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitBridgeServerPlayerLoginSuccessEvent.java
@@ -3,18 +3,29 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NukkitBridgeServerPlayerLoginSuccessEvent extends NukkitBridgeEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public NukkitBridgeServerPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitBridgeServerPlayerLoginSuccessEvent.handlers;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitChannelMessageReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitChannelMessageReceiveEvent.java
@@ -2,18 +2,34 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitChannelMessageReceiveEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final String channel, message;
 
-    @Getter
     private final JsonDocument data;
+
+    public NukkitChannelMessageReceiveEvent(String channel, String message, JsonDocument data) {
+        this.channel = channel;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitChannelMessageReceiveEvent.handlers;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public JsonDocument getData() {
+        return this.data;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudNetTickEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudNetTickEvent.java
@@ -1,13 +1,15 @@
 package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
 public final class NukkitCloudNetTickEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
+    public NukkitCloudNetTickEvent() {
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitCloudNetTickEvent.handlers;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceConnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceConnectNetworkEvent.java
@@ -2,15 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitCloudServiceConnectNetworkEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public NukkitCloudServiceConnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitCloudServiceConnectNetworkEvent.handlers;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceDisconnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceDisconnectNetworkEvent.java
@@ -2,15 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitCloudServiceDisconnectNetworkEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public NukkitCloudServiceDisconnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitCloudServiceDisconnectNetworkEvent.handlers;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceInfoUpdateEvent.java
@@ -2,15 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitCloudServiceInfoUpdateEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public NukkitCloudServiceInfoUpdateEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitCloudServiceInfoUpdateEvent.handlers;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceRegisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceRegisterEvent.java
@@ -2,15 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitCloudServiceRegisterEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public NukkitCloudServiceRegisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitCloudServiceRegisterEvent.handlers;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceStartEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceStartEvent.java
@@ -2,15 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitCloudServiceStartEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public NukkitCloudServiceStartEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitCloudServiceStartEvent.handlers;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceStopEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceStopEvent.java
@@ -2,15 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitCloudServiceStopEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public NukkitCloudServiceStopEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitCloudServiceStopEvent.handlers;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceUnregisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitCloudServiceUnregisterEvent.java
@@ -2,15 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitCloudServiceUnregisterEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public NukkitCloudServiceUnregisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitCloudServiceUnregisterEvent.handlers;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitNetworkChannelPacketReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitNetworkChannelPacketReceiveEvent.java
@@ -3,18 +3,29 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitNetworkChannelPacketReceiveEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final INetworkChannel channel;
 
-    @Getter
     private final IPacket packet;
+
+    public NukkitNetworkChannelPacketReceiveEvent(INetworkChannel channel, IPacket packet) {
+        this.channel = channel;
+        this.packet = packet;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitNetworkChannelPacketReceiveEvent.handlers;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
+
+    public IPacket getPacket() {
+        return this.packet;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitNetworkClusterNodeInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitNetworkClusterNodeInfoUpdateEvent.java
@@ -2,15 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNodeInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitNetworkClusterNodeInfoUpdateEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot;
+
+    public NukkitNetworkClusterNodeInfoUpdateEvent(NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot) {
+        this.networkClusterNodeInfoSnapshot = networkClusterNodeInfoSnapshot;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitNetworkClusterNodeInfoUpdateEvent.handlers;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNetworkClusterNodeInfoSnapshot() {
+        return this.networkClusterNodeInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitServiceInfoSnapshotConfigureEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/event/NukkitServiceInfoSnapshotConfigureEvent.java
@@ -2,15 +2,22 @@ package de.dytanic.cloudnet.ext.bridge.nukkit.event;
 
 import cn.nukkit.event.HandlerList;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class NukkitServiceInfoSnapshotConfigureEvent extends NukkitCloudNetEvent {
 
-    @Getter
     private static final HandlerList handlers = new HandlerList();
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public NukkitServiceInfoSnapshotConfigureEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public static HandlerList getHandlers() {
+        return NukkitServiceInfoSnapshotConfigureEvent.handlers;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/CloudOfflinePlayer.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/CloudOfflinePlayer.java
@@ -4,18 +4,10 @@ import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Type;
 import java.util.UUID;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public class CloudOfflinePlayer extends BasicJsonDocPropertyable implements ICloudOfflinePlayer {
 
     public static final Type TYPE = new TypeToken<CloudOfflinePlayer>() {
@@ -28,6 +20,18 @@ public class CloudOfflinePlayer extends BasicJsonDocPropertyable implements IClo
     protected long firstLoginTimeMillis, lastLoginTimeMillis;
 
     protected NetworkConnectionInfo lastNetworkConnectionInfo;
+
+    public CloudOfflinePlayer(UUID uniqueId, String name, String xBoxId, long firstLoginTimeMillis, long lastLoginTimeMillis, NetworkConnectionInfo lastNetworkConnectionInfo) {
+        this.uniqueId = uniqueId;
+        this.name = name;
+        this.xBoxId = xBoxId;
+        this.firstLoginTimeMillis = firstLoginTimeMillis;
+        this.lastLoginTimeMillis = lastLoginTimeMillis;
+        this.lastNetworkConnectionInfo = lastNetworkConnectionInfo;
+    }
+
+    public CloudOfflinePlayer() {
+    }
 
     /*= --------------------------------------------------------------- =*/
 
@@ -51,5 +55,102 @@ public class CloudOfflinePlayer extends BasicJsonDocPropertyable implements IClo
     @Override
     public void setProperties(JsonDocument properties) {
         this.properties = properties;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getXBoxId() {
+        return this.xBoxId;
+    }
+
+    public long getFirstLoginTimeMillis() {
+        return this.firstLoginTimeMillis;
+    }
+
+    public long getLastLoginTimeMillis() {
+        return this.lastLoginTimeMillis;
+    }
+
+    public NetworkConnectionInfo getLastNetworkConnectionInfo() {
+        return this.lastNetworkConnectionInfo;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setXBoxId(String xBoxId) {
+        this.xBoxId = xBoxId;
+    }
+
+    public void setFirstLoginTimeMillis(long firstLoginTimeMillis) {
+        this.firstLoginTimeMillis = firstLoginTimeMillis;
+    }
+
+    public void setLastLoginTimeMillis(long lastLoginTimeMillis) {
+        this.lastLoginTimeMillis = lastLoginTimeMillis;
+    }
+
+    public void setLastNetworkConnectionInfo(NetworkConnectionInfo lastNetworkConnectionInfo) {
+        this.lastNetworkConnectionInfo = lastNetworkConnectionInfo;
+    }
+
+    public String toString() {
+        return "CloudOfflinePlayer(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", xBoxId=" + this.getXBoxId() + ", firstLoginTimeMillis=" + this.getFirstLoginTimeMillis() + ", lastLoginTimeMillis=" + this.getLastLoginTimeMillis() + ", lastNetworkConnectionInfo=" + this.getLastNetworkConnectionInfo() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CloudOfflinePlayer)) return false;
+        final CloudOfflinePlayer other = (CloudOfflinePlayer) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$xBoxId = this.getXBoxId();
+        final Object other$xBoxId = other.getXBoxId();
+        if (this$xBoxId == null ? other$xBoxId != null : !this$xBoxId.equals(other$xBoxId)) return false;
+        if (this.getFirstLoginTimeMillis() != other.getFirstLoginTimeMillis()) return false;
+        if (this.getLastLoginTimeMillis() != other.getLastLoginTimeMillis()) return false;
+        final Object this$lastNetworkConnectionInfo = this.getLastNetworkConnectionInfo();
+        final Object other$lastNetworkConnectionInfo = other.getLastNetworkConnectionInfo();
+        if (this$lastNetworkConnectionInfo == null ? other$lastNetworkConnectionInfo != null : !this$lastNetworkConnectionInfo.equals(other$lastNetworkConnectionInfo))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof CloudOfflinePlayer;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $xBoxId = this.getXBoxId();
+        result = result * PRIME + ($xBoxId == null ? 43 : $xBoxId.hashCode());
+        final long $firstLoginTimeMillis = this.getFirstLoginTimeMillis();
+        result = result * PRIME + (int) ($firstLoginTimeMillis >>> 32 ^ $firstLoginTimeMillis);
+        final long $lastLoginTimeMillis = this.getLastLoginTimeMillis();
+        result = result * PRIME + (int) ($lastLoginTimeMillis >>> 32 ^ $lastLoginTimeMillis);
+        final Object $lastNetworkConnectionInfo = this.getLastNetworkConnectionInfo();
+        result = result * PRIME + ($lastNetworkConnectionInfo == null ? 43 : $lastNetworkConnectionInfo.hashCode());
+        return result;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/CloudOfflinePlayer.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/CloudOfflinePlayer.java
@@ -4,10 +4,14 @@ import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public class CloudOfflinePlayer extends BasicJsonDocPropertyable implements ICloudOfflinePlayer {
 
     public static final Type TYPE = new TypeToken<CloudOfflinePlayer>() {
@@ -105,52 +109,4 @@ public class CloudOfflinePlayer extends BasicJsonDocPropertyable implements IClo
         this.lastNetworkConnectionInfo = lastNetworkConnectionInfo;
     }
 
-    public String toString() {
-        return "CloudOfflinePlayer(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", xBoxId=" + this.getXBoxId() + ", firstLoginTimeMillis=" + this.getFirstLoginTimeMillis() + ", lastLoginTimeMillis=" + this.getLastLoginTimeMillis() + ", lastNetworkConnectionInfo=" + this.getLastNetworkConnectionInfo() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof CloudOfflinePlayer)) return false;
-        final CloudOfflinePlayer other = (CloudOfflinePlayer) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$xBoxId = this.getXBoxId();
-        final Object other$xBoxId = other.getXBoxId();
-        if (this$xBoxId == null ? other$xBoxId != null : !this$xBoxId.equals(other$xBoxId)) return false;
-        if (this.getFirstLoginTimeMillis() != other.getFirstLoginTimeMillis()) return false;
-        if (this.getLastLoginTimeMillis() != other.getLastLoginTimeMillis()) return false;
-        final Object this$lastNetworkConnectionInfo = this.getLastNetworkConnectionInfo();
-        final Object other$lastNetworkConnectionInfo = other.getLastNetworkConnectionInfo();
-        if (this$lastNetworkConnectionInfo == null ? other$lastNetworkConnectionInfo != null : !this$lastNetworkConnectionInfo.equals(other$lastNetworkConnectionInfo))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof CloudOfflinePlayer;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $xBoxId = this.getXBoxId();
-        result = result * PRIME + ($xBoxId == null ? 43 : $xBoxId.hashCode());
-        final long $firstLoginTimeMillis = this.getFirstLoginTimeMillis();
-        result = result * PRIME + (int) ($firstLoginTimeMillis >>> 32 ^ $firstLoginTimeMillis);
-        final long $lastLoginTimeMillis = this.getLastLoginTimeMillis();
-        result = result * PRIME + (int) ($lastLoginTimeMillis >>> 32 ^ $lastLoginTimeMillis);
-        final Object $lastNetworkConnectionInfo = this.getLastNetworkConnectionInfo();
-        result = result * PRIME + ($lastNetworkConnectionInfo == null ? 43 : $lastNetworkConnectionInfo.hashCode());
-        return result;
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/CloudPlayer.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/CloudPlayer.java
@@ -2,18 +2,10 @@ package de.dytanic.cloudnet.ext.bridge.player;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Type;
 import java.util.UUID;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public class CloudPlayer extends CloudOfflinePlayer implements ICloudPlayer {
 
     public static final Type TYPE = new TypeToken<CloudPlayer>() {
@@ -68,5 +60,93 @@ public class CloudPlayer extends CloudOfflinePlayer implements ICloudPlayer {
         this.networkConnectionInfo = networkConnectionInfo;
         this.networkPlayerServerInfo = networkPlayerServerInfo;
         this.properties = properties;
+    }
+
+    public CloudPlayer(NetworkServiceInfo loginService, NetworkServiceInfo connectedService, NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.loginService = loginService;
+        this.connectedService = connectedService;
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public CloudPlayer() {
+    }
+
+    public NetworkServiceInfo getLoginService() {
+        return this.loginService;
+    }
+
+    public NetworkServiceInfo getConnectedService() {
+        return this.connectedService;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
+
+    public void setLoginService(NetworkServiceInfo loginService) {
+        this.loginService = loginService;
+    }
+
+    public void setConnectedService(NetworkServiceInfo connectedService) {
+        this.connectedService = connectedService;
+    }
+
+    public void setNetworkConnectionInfo(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public void setNetworkPlayerServerInfo(NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public String toString() {
+        return "CloudPlayer(loginService=" + this.getLoginService() + ", connectedService=" + this.getConnectedService() + ", networkConnectionInfo=" + this.getNetworkConnectionInfo() + ", networkPlayerServerInfo=" + this.getNetworkPlayerServerInfo() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CloudPlayer)) return false;
+        final CloudPlayer other = (CloudPlayer) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$loginService = this.getLoginService();
+        final Object other$loginService = other.getLoginService();
+        if (this$loginService == null ? other$loginService != null : !this$loginService.equals(other$loginService))
+            return false;
+        final Object this$connectedService = this.getConnectedService();
+        final Object other$connectedService = other.getConnectedService();
+        if (this$connectedService == null ? other$connectedService != null : !this$connectedService.equals(other$connectedService))
+            return false;
+        final Object this$networkConnectionInfo = this.getNetworkConnectionInfo();
+        final Object other$networkConnectionInfo = other.getNetworkConnectionInfo();
+        if (this$networkConnectionInfo == null ? other$networkConnectionInfo != null : !this$networkConnectionInfo.equals(other$networkConnectionInfo))
+            return false;
+        final Object this$networkPlayerServerInfo = this.getNetworkPlayerServerInfo();
+        final Object other$networkPlayerServerInfo = other.getNetworkPlayerServerInfo();
+        if (this$networkPlayerServerInfo == null ? other$networkPlayerServerInfo != null : !this$networkPlayerServerInfo.equals(other$networkPlayerServerInfo))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof CloudPlayer;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $loginService = this.getLoginService();
+        result = result * PRIME + ($loginService == null ? 43 : $loginService.hashCode());
+        final Object $connectedService = this.getConnectedService();
+        result = result * PRIME + ($connectedService == null ? 43 : $connectedService.hashCode());
+        final Object $networkConnectionInfo = this.getNetworkConnectionInfo();
+        result = result * PRIME + ($networkConnectionInfo == null ? 43 : $networkConnectionInfo.hashCode());
+        final Object $networkPlayerServerInfo = this.getNetworkPlayerServerInfo();
+        result = result * PRIME + ($networkPlayerServerInfo == null ? 43 : $networkPlayerServerInfo.hashCode());
+        return result;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/CloudPlayer.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/CloudPlayer.java
@@ -2,10 +2,14 @@ package de.dytanic.cloudnet.ext.bridge.player;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public class CloudPlayer extends CloudOfflinePlayer implements ICloudPlayer {
 
     public static final Type TYPE = new TypeToken<CloudPlayer>() {
@@ -104,49 +108,4 @@ public class CloudPlayer extends CloudOfflinePlayer implements ICloudPlayer {
         this.networkPlayerServerInfo = networkPlayerServerInfo;
     }
 
-    public String toString() {
-        return "CloudPlayer(loginService=" + this.getLoginService() + ", connectedService=" + this.getConnectedService() + ", networkConnectionInfo=" + this.getNetworkConnectionInfo() + ", networkPlayerServerInfo=" + this.getNetworkPlayerServerInfo() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof CloudPlayer)) return false;
-        final CloudPlayer other = (CloudPlayer) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$loginService = this.getLoginService();
-        final Object other$loginService = other.getLoginService();
-        if (this$loginService == null ? other$loginService != null : !this$loginService.equals(other$loginService))
-            return false;
-        final Object this$connectedService = this.getConnectedService();
-        final Object other$connectedService = other.getConnectedService();
-        if (this$connectedService == null ? other$connectedService != null : !this$connectedService.equals(other$connectedService))
-            return false;
-        final Object this$networkConnectionInfo = this.getNetworkConnectionInfo();
-        final Object other$networkConnectionInfo = other.getNetworkConnectionInfo();
-        if (this$networkConnectionInfo == null ? other$networkConnectionInfo != null : !this$networkConnectionInfo.equals(other$networkConnectionInfo))
-            return false;
-        final Object this$networkPlayerServerInfo = this.getNetworkPlayerServerInfo();
-        final Object other$networkPlayerServerInfo = other.getNetworkPlayerServerInfo();
-        if (this$networkPlayerServerInfo == null ? other$networkPlayerServerInfo != null : !this$networkPlayerServerInfo.equals(other$networkPlayerServerInfo))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof CloudPlayer;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $loginService = this.getLoginService();
-        result = result * PRIME + ($loginService == null ? 43 : $loginService.hashCode());
-        final Object $connectedService = this.getConnectedService();
-        result = result * PRIME + ($connectedService == null ? 43 : $connectedService.hashCode());
-        final Object $networkConnectionInfo = this.getNetworkConnectionInfo();
-        result = result * PRIME + ($networkConnectionInfo == null ? 43 : $networkConnectionInfo.hashCode());
-        final Object $networkPlayerServerInfo = this.getNetworkPlayerServerInfo();
-        result = result * PRIME + ($networkPlayerServerInfo == null ? 43 : $networkPlayerServerInfo.hashCode());
-        return result;
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkConnectionInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkConnectionInfo.java
@@ -2,16 +2,10 @@ package de.dytanic.cloudnet.ext.bridge.player;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Type;
 import java.util.UUID;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class NetworkConnectionInfo {
 
     public static final Type TYPE = new TypeToken<NetworkConnectionInfo>() {
@@ -29,4 +23,135 @@ public class NetworkConnectionInfo {
 
     protected NetworkServiceInfo networkService;
 
+    public NetworkConnectionInfo(UUID uniqueId, String name, int version, HostAndPort address, HostAndPort listener, boolean onlineMode, boolean legacy, NetworkServiceInfo networkService) {
+        this.uniqueId = uniqueId;
+        this.name = name;
+        this.version = version;
+        this.address = address;
+        this.listener = listener;
+        this.onlineMode = onlineMode;
+        this.legacy = legacy;
+        this.networkService = networkService;
+    }
+
+    public NetworkConnectionInfo() {
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getVersion() {
+        return this.version;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public HostAndPort getListener() {
+        return this.listener;
+    }
+
+    public boolean isOnlineMode() {
+        return this.onlineMode;
+    }
+
+    public boolean isLegacy() {
+        return this.legacy;
+    }
+
+    public NetworkServiceInfo getNetworkService() {
+        return this.networkService;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public void setAddress(HostAndPort address) {
+        this.address = address;
+    }
+
+    public void setListener(HostAndPort listener) {
+        this.listener = listener;
+    }
+
+    public void setOnlineMode(boolean onlineMode) {
+        this.onlineMode = onlineMode;
+    }
+
+    public void setLegacy(boolean legacy) {
+        this.legacy = legacy;
+    }
+
+    public void setNetworkService(NetworkServiceInfo networkService) {
+        this.networkService = networkService;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NetworkConnectionInfo)) return false;
+        final NetworkConnectionInfo other = (NetworkConnectionInfo) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        if (this.getVersion() != other.getVersion()) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        final Object this$listener = this.getListener();
+        final Object other$listener = other.getListener();
+        if (this$listener == null ? other$listener != null : !this$listener.equals(other$listener)) return false;
+        if (this.isOnlineMode() != other.isOnlineMode()) return false;
+        if (this.isLegacy() != other.isLegacy()) return false;
+        final Object this$networkService = this.getNetworkService();
+        final Object other$networkService = other.getNetworkService();
+        if (this$networkService == null ? other$networkService != null : !this$networkService.equals(other$networkService))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof NetworkConnectionInfo;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        result = result * PRIME + this.getVersion();
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        final Object $listener = this.getListener();
+        result = result * PRIME + ($listener == null ? 43 : $listener.hashCode());
+        result = result * PRIME + (this.isOnlineMode() ? 79 : 97);
+        result = result * PRIME + (this.isLegacy() ? 79 : 97);
+        final Object $networkService = this.getNetworkService();
+        result = result * PRIME + ($networkService == null ? 43 : $networkService.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "NetworkConnectionInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", version=" + this.getVersion() + ", address=" + this.getAddress() + ", listener=" + this.getListener() + ", onlineMode=" + this.isOnlineMode() + ", legacy=" + this.isLegacy() + ", networkService=" + this.getNetworkService() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkConnectionInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkConnectionInfo.java
@@ -2,10 +2,14 @@ package de.dytanic.cloudnet.ext.bridge.player;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 public class NetworkConnectionInfo {
 
     public static final Type TYPE = new TypeToken<NetworkConnectionInfo>() {
@@ -101,57 +105,4 @@ public class NetworkConnectionInfo {
         this.networkService = networkService;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NetworkConnectionInfo)) return false;
-        final NetworkConnectionInfo other = (NetworkConnectionInfo) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        if (this.getVersion() != other.getVersion()) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        final Object this$listener = this.getListener();
-        final Object other$listener = other.getListener();
-        if (this$listener == null ? other$listener != null : !this$listener.equals(other$listener)) return false;
-        if (this.isOnlineMode() != other.isOnlineMode()) return false;
-        if (this.isLegacy() != other.isLegacy()) return false;
-        final Object this$networkService = this.getNetworkService();
-        final Object other$networkService = other.getNetworkService();
-        if (this$networkService == null ? other$networkService != null : !this$networkService.equals(other$networkService))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof NetworkConnectionInfo;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        result = result * PRIME + this.getVersion();
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        final Object $listener = this.getListener();
-        result = result * PRIME + ($listener == null ? 43 : $listener.hashCode());
-        result = result * PRIME + (this.isOnlineMode() ? 79 : 97);
-        result = result * PRIME + (this.isLegacy() ? 79 : 97);
-        final Object $networkService = this.getNetworkService();
-        result = result * PRIME + ($networkService == null ? 43 : $networkService.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "NetworkConnectionInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", version=" + this.getVersion() + ", address=" + this.getAddress() + ", listener=" + this.getListener() + ", onlineMode=" + this.isOnlineMode() + ", legacy=" + this.isLegacy() + ", networkService=" + this.getNetworkService() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkPlayerServerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkPlayerServerInfo.java
@@ -3,16 +3,10 @@ package de.dytanic.cloudnet.ext.bridge.player;
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Type;
 import java.util.UUID;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public final class NetworkPlayerServerInfo {
 
     public static final Type TYPE = new TypeToken<NetworkPlayerServerInfo>() {
@@ -32,4 +26,158 @@ public final class NetworkPlayerServerInfo {
 
     protected NetworkServiceInfo networkService;
 
+    public NetworkPlayerServerInfo(UUID uniqueId, String name, String xBoxId, double health, double maxHealth, double saturation, int level, WorldPosition location, HostAndPort address, NetworkServiceInfo networkService) {
+        this.uniqueId = uniqueId;
+        this.name = name;
+        this.xBoxId = xBoxId;
+        this.health = health;
+        this.maxHealth = maxHealth;
+        this.saturation = saturation;
+        this.level = level;
+        this.location = location;
+        this.address = address;
+        this.networkService = networkService;
+    }
+
+    public NetworkPlayerServerInfo() {
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getXBoxId() {
+        return this.xBoxId;
+    }
+
+    public double getHealth() {
+        return this.health;
+    }
+
+    public double getMaxHealth() {
+        return this.maxHealth;
+    }
+
+    public double getSaturation() {
+        return this.saturation;
+    }
+
+    public int getLevel() {
+        return this.level;
+    }
+
+    public WorldPosition getLocation() {
+        return this.location;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public NetworkServiceInfo getNetworkService() {
+        return this.networkService;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setXBoxId(String xBoxId) {
+        this.xBoxId = xBoxId;
+    }
+
+    public void setHealth(double health) {
+        this.health = health;
+    }
+
+    public void setMaxHealth(double maxHealth) {
+        this.maxHealth = maxHealth;
+    }
+
+    public void setSaturation(double saturation) {
+        this.saturation = saturation;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public void setLocation(WorldPosition location) {
+        this.location = location;
+    }
+
+    public void setAddress(HostAndPort address) {
+        this.address = address;
+    }
+
+    public void setNetworkService(NetworkServiceInfo networkService) {
+        this.networkService = networkService;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NetworkPlayerServerInfo)) return false;
+        final NetworkPlayerServerInfo other = (NetworkPlayerServerInfo) o;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$xBoxId = this.getXBoxId();
+        final Object other$xBoxId = other.getXBoxId();
+        if (this$xBoxId == null ? other$xBoxId != null : !this$xBoxId.equals(other$xBoxId)) return false;
+        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
+        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
+        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
+        if (this.getLevel() != other.getLevel()) return false;
+        final Object this$location = this.getLocation();
+        final Object other$location = other.getLocation();
+        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        final Object this$networkService = this.getNetworkService();
+        final Object other$networkService = other.getNetworkService();
+        if (this$networkService == null ? other$networkService != null : !this$networkService.equals(other$networkService))
+            return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $xBoxId = this.getXBoxId();
+        result = result * PRIME + ($xBoxId == null ? 43 : $xBoxId.hashCode());
+        final long $health = Double.doubleToLongBits(this.getHealth());
+        result = result * PRIME + (int) ($health >>> 32 ^ $health);
+        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
+        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
+        final long $saturation = Double.doubleToLongBits(this.getSaturation());
+        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
+        result = result * PRIME + this.getLevel();
+        final Object $location = this.getLocation();
+        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        final Object $networkService = this.getNetworkService();
+        result = result * PRIME + ($networkService == null ? 43 : $networkService.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "NetworkPlayerServerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", xBoxId=" + this.getXBoxId() + ", health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ", networkService=" + this.getNetworkService() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkPlayerServerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkPlayerServerInfo.java
@@ -3,10 +3,14 @@ package de.dytanic.cloudnet.ext.bridge.player;
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 public final class NetworkPlayerServerInfo {
 
     public static final Type TYPE = new TypeToken<NetworkPlayerServerInfo>() {
@@ -122,62 +126,4 @@ public final class NetworkPlayerServerInfo {
         this.networkService = networkService;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NetworkPlayerServerInfo)) return false;
-        final NetworkPlayerServerInfo other = (NetworkPlayerServerInfo) o;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$xBoxId = this.getXBoxId();
-        final Object other$xBoxId = other.getXBoxId();
-        if (this$xBoxId == null ? other$xBoxId != null : !this$xBoxId.equals(other$xBoxId)) return false;
-        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
-        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
-        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
-        if (this.getLevel() != other.getLevel()) return false;
-        final Object this$location = this.getLocation();
-        final Object other$location = other.getLocation();
-        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        final Object this$networkService = this.getNetworkService();
-        final Object other$networkService = other.getNetworkService();
-        if (this$networkService == null ? other$networkService != null : !this$networkService.equals(other$networkService))
-            return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $xBoxId = this.getXBoxId();
-        result = result * PRIME + ($xBoxId == null ? 43 : $xBoxId.hashCode());
-        final long $health = Double.doubleToLongBits(this.getHealth());
-        result = result * PRIME + (int) ($health >>> 32 ^ $health);
-        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
-        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
-        final long $saturation = Double.doubleToLongBits(this.getSaturation());
-        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
-        result = result * PRIME + this.getLevel();
-        final Object $location = this.getLocation();
-        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        final Object $networkService = this.getNetworkService();
-        result = result * PRIME + ($networkService == null ? 43 : $networkService.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "NetworkPlayerServerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", xBoxId=" + this.getXBoxId() + ", health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ", networkService=" + this.getNetworkService() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkServiceInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkServiceInfo.java
@@ -1,15 +1,9 @@
 package de.dytanic.cloudnet.ext.bridge.player;
 
 import de.dytanic.cloudnet.driver.service.ServiceEnvironmentType;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class NetworkServiceInfo {
 
     protected ServiceEnvironmentType environment;
@@ -18,4 +12,75 @@ public class NetworkServiceInfo {
 
     protected String serverName;
 
+    public NetworkServiceInfo(ServiceEnvironmentType environment, UUID uniqueId, String serverName) {
+        this.environment = environment;
+        this.uniqueId = uniqueId;
+        this.serverName = serverName;
+    }
+
+    public NetworkServiceInfo() {
+    }
+
+    public ServiceEnvironmentType getEnvironment() {
+        return this.environment;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getServerName() {
+        return this.serverName;
+    }
+
+    public void setEnvironment(ServiceEnvironmentType environment) {
+        this.environment = environment;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setServerName(String serverName) {
+        this.serverName = serverName;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NetworkServiceInfo)) return false;
+        final NetworkServiceInfo other = (NetworkServiceInfo) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$environment = this.getEnvironment();
+        final Object other$environment = other.getEnvironment();
+        if (this$environment == null ? other$environment != null : !this$environment.equals(other$environment))
+            return false;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$serverName = this.getServerName();
+        final Object other$serverName = other.getServerName();
+        if (this$serverName == null ? other$serverName != null : !this$serverName.equals(other$serverName))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof NetworkServiceInfo;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $environment = this.getEnvironment();
+        result = result * PRIME + ($environment == null ? 43 : $environment.hashCode());
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $serverName = this.getServerName();
+        result = result * PRIME + ($serverName == null ? 43 : $serverName.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "NetworkServiceInfo(environment=" + this.getEnvironment() + ", uniqueId=" + this.getUniqueId() + ", serverName=" + this.getServerName() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkServiceInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/player/NetworkServiceInfo.java
@@ -1,9 +1,13 @@
 package de.dytanic.cloudnet.ext.bridge.player;
 
 import de.dytanic.cloudnet.driver.service.ServiceEnvironmentType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 public class NetworkServiceInfo {
 
     protected ServiceEnvironmentType environment;
@@ -45,42 +49,4 @@ public class NetworkServiceInfo {
         this.serverName = serverName;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NetworkServiceInfo)) return false;
-        final NetworkServiceInfo other = (NetworkServiceInfo) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$environment = this.getEnvironment();
-        final Object other$environment = other.getEnvironment();
-        if (this$environment == null ? other$environment != null : !this$environment.equals(other$environment))
-            return false;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$serverName = this.getServerName();
-        final Object other$serverName = other.getServerName();
-        if (this$serverName == null ? other$serverName != null : !this$serverName.equals(other$serverName))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof NetworkServiceInfo;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $environment = this.getEnvironment();
-        result = result * PRIME + ($environment == null ? 43 : $environment.hashCode());
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $serverName = this.getServerName();
-        result = result * PRIME + ($serverName == null ? 43 : $serverName.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "NetworkServiceInfo(environment=" + this.getEnvironment() + ", uniqueId=" + this.getUniqueId() + ", serverName=" + this.getServerName() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/ProxProxCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/ProxProxCloudNetPlayerInfo.java
@@ -1,10 +1,14 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Locale;
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 final class ProxProxCloudNetPlayerInfo {
 
     private UUID uniqueId;
@@ -83,54 +87,4 @@ final class ProxProxCloudNetPlayerInfo {
         this.ping = ping;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ProxProxCloudNetPlayerInfo)) return false;
-        final ProxProxCloudNetPlayerInfo other = (ProxProxCloudNetPlayerInfo) o;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$locale = this.getLocale();
-        final Object other$locale = other.getLocale();
-        if (this$locale == null ? other$locale != null : !this$locale.equals(other$locale)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$xBoxId = this.getXBoxId();
-        final Object other$xBoxId = other.getXBoxId();
-        if (this$xBoxId == null ? other$xBoxId != null : !this$xBoxId.equals(other$xBoxId)) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        final Object this$connectedServer = this.getConnectedServer();
-        final Object other$connectedServer = other.getConnectedServer();
-        if (this$connectedServer == null ? other$connectedServer != null : !this$connectedServer.equals(other$connectedServer))
-            return false;
-        if (this.getPing() != other.getPing()) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $locale = this.getLocale();
-        result = result * PRIME + ($locale == null ? 43 : $locale.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $xBoxId = this.getXBoxId();
-        result = result * PRIME + ($xBoxId == null ? 43 : $xBoxId.hashCode());
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        final Object $connectedServer = this.getConnectedServer();
-        result = result * PRIME + ($connectedServer == null ? 43 : $connectedServer.hashCode());
-        final long $ping = this.getPing();
-        result = result * PRIME + (int) ($ping >>> 32 ^ $ping);
-        return result;
-    }
-
-    public String toString() {
-        return "ProxProxCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", locale=" + this.getLocale() + ", name=" + this.getName() + ", xBoxId=" + this.getXBoxId() + ", address=" + this.getAddress() + ", connectedServer=" + this.getConnectedServer() + ", ping=" + this.getPing() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/ProxProxCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/ProxProxCloudNetPlayerInfo.java
@@ -1,14 +1,10 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.Locale;
 import java.util.UUID;
 
-@Data
-@AllArgsConstructor
 final class ProxProxCloudNetPlayerInfo {
 
     private UUID uniqueId;
@@ -21,4 +17,120 @@ final class ProxProxCloudNetPlayerInfo {
 
     private long ping;
 
+    public ProxProxCloudNetPlayerInfo(UUID uniqueId, Locale locale, String name, String xBoxId, HostAndPort address, HostAndPort connectedServer, long ping) {
+        this.uniqueId = uniqueId;
+        this.locale = locale;
+        this.name = name;
+        this.xBoxId = xBoxId;
+        this.address = address;
+        this.connectedServer = connectedServer;
+        this.ping = ping;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public Locale getLocale() {
+        return this.locale;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getXBoxId() {
+        return this.xBoxId;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public HostAndPort getConnectedServer() {
+        return this.connectedServer;
+    }
+
+    public long getPing() {
+        return this.ping;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setLocale(Locale locale) {
+        this.locale = locale;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setXBoxId(String xBoxId) {
+        this.xBoxId = xBoxId;
+    }
+
+    public void setAddress(HostAndPort address) {
+        this.address = address;
+    }
+
+    public void setConnectedServer(HostAndPort connectedServer) {
+        this.connectedServer = connectedServer;
+    }
+
+    public void setPing(long ping) {
+        this.ping = ping;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ProxProxCloudNetPlayerInfo)) return false;
+        final ProxProxCloudNetPlayerInfo other = (ProxProxCloudNetPlayerInfo) o;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$locale = this.getLocale();
+        final Object other$locale = other.getLocale();
+        if (this$locale == null ? other$locale != null : !this$locale.equals(other$locale)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$xBoxId = this.getXBoxId();
+        final Object other$xBoxId = other.getXBoxId();
+        if (this$xBoxId == null ? other$xBoxId != null : !this$xBoxId.equals(other$xBoxId)) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        final Object this$connectedServer = this.getConnectedServer();
+        final Object other$connectedServer = other.getConnectedServer();
+        if (this$connectedServer == null ? other$connectedServer != null : !this$connectedServer.equals(other$connectedServer))
+            return false;
+        if (this.getPing() != other.getPing()) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $locale = this.getLocale();
+        result = result * PRIME + ($locale == null ? 43 : $locale.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $xBoxId = this.getXBoxId();
+        result = result * PRIME + ($xBoxId == null ? 43 : $xBoxId.hashCode());
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        final Object $connectedServer = this.getConnectedServer();
+        result = result * PRIME + ($connectedServer == null ? 43 : $connectedServer.hashCode());
+        final long $ping = this.getPing();
+        result = result * PRIME + (int) ($ping >>> 32 ^ $ping);
+        return result;
+    }
+
+    public String toString() {
+        return "ProxProxCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", locale=" + this.getLocale() + ", name=" + this.getName() + ", xBoxId=" + this.getXBoxId() + ", address=" + this.getAddress() + ", connectedServer=" + this.getConnectedServer() + ", ping=" + this.getPing() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeConfigurationUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeConfigurationUpdateEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ProxProxBridgeConfigurationUpdateEvent extends ProxProxBridgeEvent {
 
     private final BridgeConfiguration bridgeConfiguration;
 
+    public ProxProxBridgeConfigurationUpdateEvent(BridgeConfiguration bridgeConfiguration) {
+        this.bridgeConfiguration = bridgeConfiguration;
+    }
+
+    public BridgeConfiguration getBridgeConfiguration() {
+        return this.bridgeConfiguration;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerDisconnectEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ProxProxBridgeProxyPlayerDisconnectEvent extends ProxProxBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public ProxProxBridgeProxyPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerLoginRequestEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ProxProxBridgeProxyPlayerLoginRequestEvent extends ProxProxBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public ProxProxBridgeProxyPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerLoginSuccessEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ProxProxBridgeProxyPlayerLoginSuccessEvent extends ProxProxBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public ProxProxBridgeProxyPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerServerConnectRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerServerConnectRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public class ProxProxBridgeProxyPlayerServerConnectRequestEvent extends ProxProxBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public ProxProxBridgeProxyPlayerServerConnectRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerServerSwitchEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeProxyPlayerServerSwitchEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ProxProxBridgeProxyPlayerServerSwitchEvent extends ProxProxBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public ProxProxBridgeProxyPlayerServerSwitchEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeServerPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeServerPlayerDisconnectEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ProxProxBridgeServerPlayerDisconnectEvent extends ProxProxBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public ProxProxBridgeServerPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeServerPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeServerPlayerLoginRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ProxProxBridgeServerPlayerLoginRequestEvent extends ProxProxBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public ProxProxBridgeServerPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeServerPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxBridgeServerPlayerLoginSuccessEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class ProxProxBridgeServerPlayerLoginSuccessEvent extends ProxProxBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public ProxProxBridgeServerPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxChannelMessageReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxChannelMessageReceiveEvent.java
@@ -1,15 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxChannelMessageReceiveEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final String channel, message;
 
-    @Getter
     private final JsonDocument data;
+
+    public ProxProxChannelMessageReceiveEvent(String channel, String message, JsonDocument data) {
+        this.channel = channel;
+        this.message = message;
+        this.data = data;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public JsonDocument getData() {
+        return this.data;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudNetTickEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudNetTickEvent.java
@@ -1,8 +1,7 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
 public final class ProxProxCloudNetTickEvent extends ProxProxCloudNetEvent {
 
+    public ProxProxCloudNetTickEvent() {
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceConnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceConnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxCloudServiceConnectNetworkEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public ProxProxCloudServiceConnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceDisconnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceDisconnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxCloudServiceDisconnectNetworkEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public ProxProxCloudServiceDisconnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxCloudServiceInfoUpdateEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public ProxProxCloudServiceInfoUpdateEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceRegisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceRegisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxCloudServiceRegisterEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public ProxProxCloudServiceRegisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceStartEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceStartEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxCloudServiceStartEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public ProxProxCloudServiceStartEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceStopEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceStopEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxCloudServiceStopEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public ProxProxCloudServiceStopEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceUnregisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxCloudServiceUnregisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxCloudServiceUnregisterEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public ProxProxCloudServiceUnregisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxNetworkChannelPacketReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxNetworkChannelPacketReceiveEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxNetworkChannelPacketReceiveEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final INetworkChannel channel;
 
-    @Getter
     private final IPacket packet;
+
+    public ProxProxNetworkChannelPacketReceiveEvent(INetworkChannel channel, IPacket packet) {
+        this.channel = channel;
+        this.packet = packet;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
+
+    public IPacket getPacket() {
+        return this.packet;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxNetworkClusterNodeInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxNetworkClusterNodeInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNodeInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxNetworkClusterNodeInfoUpdateEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot;
+
+    public ProxProxNetworkClusterNodeInfoUpdateEvent(NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot) {
+        this.networkClusterNodeInfoSnapshot = networkClusterNodeInfoSnapshot;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNetworkClusterNodeInfoSnapshot() {
+        return this.networkClusterNodeInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxServiceInfoSnapshotConfigureEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxprox/event/ProxProxServiceInfoSnapshotConfigureEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.proxprox.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class ProxProxServiceInfoSnapshotConfigureEvent extends ProxProxCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public ProxProxServiceInfoSnapshotConfigureEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/SpongeCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/SpongeCloudNetHelper.java
@@ -17,8 +17,6 @@ import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
-import lombok.Setter;
 import org.spongepowered.api.Platform;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExperienceHolderData;
@@ -32,14 +30,10 @@ import java.util.function.Function;
 
 public final class SpongeCloudNetHelper {
 
-    @Getter
-    @Setter
     private static volatile String
             apiMotd = Sponge.getServer().getMotd().toPlain(),
             extra = "",
             state = "LOBBY";
-    @Getter
-    @Setter
     private static volatile int maxPlayers = Sponge.getServer().getMaxPlayers();
 
     private SpongeCloudNetHelper() {
@@ -193,5 +187,37 @@ public final class SpongeCloudNetHelper {
                         Wrapper.getInstance().getServiceId().getName()
                 )
         );
+    }
+
+    public static String getApiMotd() {
+        return SpongeCloudNetHelper.apiMotd;
+    }
+
+    public static String getExtra() {
+        return SpongeCloudNetHelper.extra;
+    }
+
+    public static String getState() {
+        return SpongeCloudNetHelper.state;
+    }
+
+    public static int getMaxPlayers() {
+        return SpongeCloudNetHelper.maxPlayers;
+    }
+
+    public static void setApiMotd(String apiMotd) {
+        SpongeCloudNetHelper.apiMotd = apiMotd;
+    }
+
+    public static void setExtra(String extra) {
+        SpongeCloudNetHelper.extra = extra;
+    }
+
+    public static void setState(String state) {
+        SpongeCloudNetHelper.state = state;
+    }
+
+    public static void setMaxPlayers(int maxPlayers) {
+        SpongeCloudNetHelper.maxPlayers = maxPlayers;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/SpongeCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/SpongeCloudNetPlayerInfo.java
@@ -2,9 +2,13 @@ package de.dytanic.cloudnet.ext.bridge.sponge;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 final class SpongeCloudNetPlayerInfo {
 
     private UUID uniqueId;
@@ -105,53 +109,4 @@ final class SpongeCloudNetPlayerInfo {
         this.address = address;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SpongeCloudNetPlayerInfo)) return false;
-        final SpongeCloudNetPlayerInfo other = (SpongeCloudNetPlayerInfo) o;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        if (this.getPing() != other.getPing()) return false;
-        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
-        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
-        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
-        if (this.getLevel() != other.getLevel()) return false;
-        final Object this$location = this.getLocation();
-        final Object other$location = other.getLocation();
-        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        result = result * PRIME + this.getPing();
-        final long $health = Double.doubleToLongBits(this.getHealth());
-        result = result * PRIME + (int) ($health >>> 32 ^ $health);
-        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
-        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
-        final long $saturation = Double.doubleToLongBits(this.getSaturation());
-        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
-        result = result * PRIME + this.getLevel();
-        final Object $location = this.getLocation();
-        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SpongeCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", ping=" + this.getPing() + ", health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/SpongeCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/SpongeCloudNetPlayerInfo.java
@@ -2,13 +2,9 @@ package de.dytanic.cloudnet.ext.bridge.sponge;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.bridge.WorldPosition;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.UUID;
 
-@Data
-@AllArgsConstructor
 final class SpongeCloudNetPlayerInfo {
 
     private UUID uniqueId;
@@ -25,4 +21,137 @@ final class SpongeCloudNetPlayerInfo {
 
     private HostAndPort address;
 
+    public SpongeCloudNetPlayerInfo(UUID uniqueId, String name, int ping, double health, double maxHealth, double saturation, int level, WorldPosition location, HostAndPort address) {
+        this.uniqueId = uniqueId;
+        this.name = name;
+        this.ping = ping;
+        this.health = health;
+        this.maxHealth = maxHealth;
+        this.saturation = saturation;
+        this.level = level;
+        this.location = location;
+        this.address = address;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getPing() {
+        return this.ping;
+    }
+
+    public double getHealth() {
+        return this.health;
+    }
+
+    public double getMaxHealth() {
+        return this.maxHealth;
+    }
+
+    public double getSaturation() {
+        return this.saturation;
+    }
+
+    public int getLevel() {
+        return this.level;
+    }
+
+    public WorldPosition getLocation() {
+        return this.location;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setPing(int ping) {
+        this.ping = ping;
+    }
+
+    public void setHealth(double health) {
+        this.health = health;
+    }
+
+    public void setMaxHealth(double maxHealth) {
+        this.maxHealth = maxHealth;
+    }
+
+    public void setSaturation(double saturation) {
+        this.saturation = saturation;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public void setLocation(WorldPosition location) {
+        this.location = location;
+    }
+
+    public void setAddress(HostAndPort address) {
+        this.address = address;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SpongeCloudNetPlayerInfo)) return false;
+        final SpongeCloudNetPlayerInfo other = (SpongeCloudNetPlayerInfo) o;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        if (this.getPing() != other.getPing()) return false;
+        if (Double.compare(this.getHealth(), other.getHealth()) != 0) return false;
+        if (Double.compare(this.getMaxHealth(), other.getMaxHealth()) != 0) return false;
+        if (Double.compare(this.getSaturation(), other.getSaturation()) != 0) return false;
+        if (this.getLevel() != other.getLevel()) return false;
+        final Object this$location = this.getLocation();
+        final Object other$location = other.getLocation();
+        if (this$location == null ? other$location != null : !this$location.equals(other$location)) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        result = result * PRIME + this.getPing();
+        final long $health = Double.doubleToLongBits(this.getHealth());
+        result = result * PRIME + (int) ($health >>> 32 ^ $health);
+        final long $maxHealth = Double.doubleToLongBits(this.getMaxHealth());
+        result = result * PRIME + (int) ($maxHealth >>> 32 ^ $maxHealth);
+        final long $saturation = Double.doubleToLongBits(this.getSaturation());
+        result = result * PRIME + (int) ($saturation >>> 32 ^ $saturation);
+        result = result * PRIME + this.getLevel();
+        final Object $location = this.getLocation();
+        result = result * PRIME + ($location == null ? 43 : $location.hashCode());
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SpongeCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", ping=" + this.getPing() + ", health=" + this.getHealth() + ", maxHealth=" + this.getMaxHealth() + ", saturation=" + this.getSaturation() + ", level=" + this.getLevel() + ", location=" + this.getLocation() + ", address=" + this.getAddress() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeConfigurationUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeConfigurationUpdateEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class SpongeBridgeConfigurationUpdateEvent extends SpongeBridgeEvent {
 
     private final BridgeConfiguration bridgeConfiguration;
 
+    public SpongeBridgeConfigurationUpdateEvent(BridgeConfiguration bridgeConfiguration) {
+        this.bridgeConfiguration = bridgeConfiguration;
+    }
+
+    public BridgeConfiguration getBridgeConfiguration() {
+        return this.bridgeConfiguration;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerDisconnectEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class SpongeBridgeProxyPlayerDisconnectEvent extends SpongeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public SpongeBridgeProxyPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerLoginRequestEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class SpongeBridgeProxyPlayerLoginRequestEvent extends SpongeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public SpongeBridgeProxyPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerLoginSuccessEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class SpongeBridgeProxyPlayerLoginSuccessEvent extends SpongeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public SpongeBridgeProxyPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerServerConnectRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerServerConnectRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public class SpongeBridgeProxyPlayerServerConnectRequestEvent extends SpongeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public SpongeBridgeProxyPlayerServerConnectRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerServerSwitchEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeProxyPlayerServerSwitchEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class SpongeBridgeProxyPlayerServerSwitchEvent extends SpongeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public SpongeBridgeProxyPlayerServerSwitchEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeServerPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeServerPlayerDisconnectEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class SpongeBridgeServerPlayerDisconnectEvent extends SpongeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public SpongeBridgeServerPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeServerPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeServerPlayerLoginRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class SpongeBridgeServerPlayerLoginRequestEvent extends SpongeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public SpongeBridgeServerPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeServerPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeBridgeServerPlayerLoginSuccessEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class SpongeBridgeServerPlayerLoginSuccessEvent extends SpongeBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public SpongeBridgeServerPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeChannelMessageReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeChannelMessageReceiveEvent.java
@@ -1,15 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeChannelMessageReceiveEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final String channel, message;
 
-    @Getter
     private final JsonDocument data;
+
+    public SpongeChannelMessageReceiveEvent(String channel, String message, JsonDocument data) {
+        this.channel = channel;
+        this.message = message;
+        this.data = data;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public JsonDocument getData() {
+        return this.data;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudNetTickEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudNetTickEvent.java
@@ -1,8 +1,7 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
 public final class SpongeCloudNetTickEvent extends SpongeCloudNetEvent {
 
+    public SpongeCloudNetTickEvent() {
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceConnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceConnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeCloudServiceConnectNetworkEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public SpongeCloudServiceConnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceDisconnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceDisconnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeCloudServiceDisconnectNetworkEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public SpongeCloudServiceDisconnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeCloudServiceInfoUpdateEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public SpongeCloudServiceInfoUpdateEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceRegisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceRegisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeCloudServiceRegisterEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public SpongeCloudServiceRegisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceStartEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceStartEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeCloudServiceStartEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public SpongeCloudServiceStartEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceStopEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceStopEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeCloudServiceStopEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public SpongeCloudServiceStopEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceUnregisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeCloudServiceUnregisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeCloudServiceUnregisterEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public SpongeCloudServiceUnregisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeNetworkChannelPacketReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeNetworkChannelPacketReceiveEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeNetworkChannelPacketReceiveEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final INetworkChannel channel;
 
-    @Getter
     private final IPacket packet;
+
+    public SpongeNetworkChannelPacketReceiveEvent(INetworkChannel channel, IPacket packet) {
+        this.channel = channel;
+        this.packet = packet;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
+
+    public IPacket getPacket() {
+        return this.packet;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeNetworkClusterNodeInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeNetworkClusterNodeInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNodeInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeNetworkClusterNodeInfoUpdateEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot;
+
+    public SpongeNetworkClusterNodeInfoUpdateEvent(NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot) {
+        this.networkClusterNodeInfoSnapshot = networkClusterNodeInfoSnapshot;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNetworkClusterNodeInfoSnapshot() {
+        return this.networkClusterNodeInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeServiceInfoSnapshotConfigureEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/event/SpongeServiceInfoSnapshotConfigureEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class SpongeServiceInfoSnapshotConfigureEvent extends SpongeCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public SpongeServiceInfoSnapshotConfigureEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/util/SpongeCloudNetAdapterClassLoader.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/util/SpongeCloudNetAdapterClassLoader.java
@@ -1,14 +1,11 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.util;
 
-import lombok.Getter;
-
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 
 public final class SpongeCloudNetAdapterClassLoader extends URLClassLoader {
 
-    @Getter
     private final ClassLoader cloudNetClassLoader, spongeAppClassLoader;
 
     public SpongeCloudNetAdapterClassLoader(ClassLoader cloudNetClassLoader, ClassLoader spongeAppClassLoader, ClassLoader parent) {
@@ -61,4 +58,11 @@ public final class SpongeCloudNetAdapterClassLoader extends URLClassLoader {
         return url;
     }
 
+    public ClassLoader getCloudNetClassLoader() {
+        return this.cloudNetClassLoader;
+    }
+
+    public ClassLoader getSpongeAppClassLoader() {
+        return this.spongeAppClassLoader;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetBridgePlugin.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetBridgePlugin.java
@@ -16,11 +16,9 @@ import de.dytanic.cloudnet.ext.bridge.velocity.command.CommandHub;
 import de.dytanic.cloudnet.ext.bridge.velocity.listener.VelocityCloudNetListener;
 import de.dytanic.cloudnet.ext.bridge.velocity.listener.VelocityPlayerListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 
 import java.net.InetSocketAddress;
 
-@Getter
 @Plugin(
         id = "cloudnet_bridge_velocity",
         name = "CloudNet-Bridge",
@@ -33,7 +31,6 @@ import java.net.InetSocketAddress;
 )
 public final class VelocityCloudNetBridgePlugin {
 
-    @Getter
     private static VelocityCloudNetBridgePlugin instance;
 
     private final ProxyServer proxyServer;
@@ -44,6 +41,10 @@ public final class VelocityCloudNetBridgePlugin {
 
         this.proxyServer = proxyServer;
         VelocityCloudNetHelper.setProxyServer(proxyServer);
+    }
+
+    public static VelocityCloudNetBridgePlugin getInstance() {
+        return VelocityCloudNetBridgePlugin.instance;
     }
 
     @Subscribe
@@ -89,5 +90,9 @@ public final class VelocityCloudNetBridgePlugin {
                 VelocityCloudNetHelper.SERVER_TO_SERVICE_INFO_SNAPSHOT_ASSOCIATION.put(name, serviceInfoSnapshot);
                 VelocityCloudNetHelper.addServerToVelocityPrioritySystemConfiguration(serviceInfoSnapshot, name);
             }
+    }
+
+    public ProxyServer getProxyServer() {
+        return this.proxyServer;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
@@ -16,8 +16,6 @@ import de.dytanic.cloudnet.ext.bridge.ProxyFallbackConfiguration;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -28,8 +26,6 @@ public final class VelocityCloudNetHelper {
 
     public static final Map<String, ServiceInfoSnapshot> SERVER_TO_SERVICE_INFO_SNAPSHOT_ASSOCIATION = Maps.newConcurrentHashMap();
 
-    @Getter
-    @Setter
     private static ProxyServer proxyServer;
 
     private VelocityCloudNetHelper() {
@@ -199,5 +195,13 @@ public final class VelocityCloudNetHelper {
                     }
                 }))
         ;
+    }
+
+    public static ProxyServer getProxyServer() {
+        return VelocityCloudNetHelper.proxyServer;
+    }
+
+    public static void setProxyServer(ProxyServer proxyServer) {
+        VelocityCloudNetHelper.proxyServer = proxyServer;
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetPlayerInfo.java
@@ -1,9 +1,13 @@
 package de.dytanic.cloudnet.ext.bridge.velocity;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.UUID;
 
+@ToString
+@EqualsAndHashCode
 final class VelocityCloudNetPlayerInfo {
 
     private UUID uniqueId;
@@ -62,42 +66,4 @@ final class VelocityCloudNetPlayerInfo {
         this.address = address;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof VelocityCloudNetPlayerInfo)) return false;
-        final VelocityCloudNetPlayerInfo other = (VelocityCloudNetPlayerInfo) o;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$server = this.getServer();
-        final Object other$server = other.getServer();
-        if (this$server == null ? other$server != null : !this$server.equals(other$server)) return false;
-        if (this.getPing() != other.getPing()) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $server = this.getServer();
-        result = result * PRIME + ($server == null ? 43 : $server.hashCode());
-        result = result * PRIME + this.getPing();
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "VelocityCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", server=" + this.getServer() + ", ping=" + this.getPing() + ", address=" + this.getAddress() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetPlayerInfo.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetPlayerInfo.java
@@ -1,13 +1,9 @@
 package de.dytanic.cloudnet.ext.bridge.velocity;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.UUID;
 
-@Data
-@AllArgsConstructor
 final class VelocityCloudNetPlayerInfo {
 
     private UUID uniqueId;
@@ -18,4 +14,90 @@ final class VelocityCloudNetPlayerInfo {
 
     private HostAndPort address;
 
+    public VelocityCloudNetPlayerInfo(UUID uniqueId, String name, String server, int ping, HostAndPort address) {
+        this.uniqueId = uniqueId;
+        this.name = name;
+        this.server = server;
+        this.ping = ping;
+        this.address = address;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getServer() {
+        return this.server;
+    }
+
+    public int getPing() {
+        return this.ping;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public void setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setServer(String server) {
+        this.server = server;
+    }
+
+    public void setPing(int ping) {
+        this.ping = ping;
+    }
+
+    public void setAddress(HostAndPort address) {
+        this.address = address;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof VelocityCloudNetPlayerInfo)) return false;
+        final VelocityCloudNetPlayerInfo other = (VelocityCloudNetPlayerInfo) o;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$server = this.getServer();
+        final Object other$server = other.getServer();
+        if (this$server == null ? other$server != null : !this$server.equals(other$server)) return false;
+        if (this.getPing() != other.getPing()) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $server = this.getServer();
+        result = result * PRIME + ($server == null ? 43 : $server.hashCode());
+        result = result * PRIME + this.getPing();
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "VelocityCloudNetPlayerInfo(uniqueId=" + this.getUniqueId() + ", name=" + this.getName() + ", server=" + this.getServer() + ", ping=" + this.getPing() + ", address=" + this.getAddress() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeConfigurationUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeConfigurationUpdateEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class VelocityBridgeConfigurationUpdateEvent extends VelocityBridgeEvent {
 
     private final BridgeConfiguration bridgeConfiguration;
 
+    public VelocityBridgeConfigurationUpdateEvent(BridgeConfiguration bridgeConfiguration) {
+        this.bridgeConfiguration = bridgeConfiguration;
+    }
+
+    public BridgeConfiguration getBridgeConfiguration() {
+        return this.bridgeConfiguration;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerDisconnectEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class VelocityBridgeProxyPlayerDisconnectEvent extends VelocityBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public VelocityBridgeProxyPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerLoginRequestEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class VelocityBridgeProxyPlayerLoginRequestEvent extends VelocityBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public VelocityBridgeProxyPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerLoginSuccessEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class VelocityBridgeProxyPlayerLoginSuccessEvent extends VelocityBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
+    public VelocityBridgeProxyPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerServerConnectRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerServerConnectRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public class VelocityBridgeProxyPlayerServerConnectRequestEvent extends VelocityBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public VelocityBridgeProxyPlayerServerConnectRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerServerSwitchEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeProxyPlayerServerSwitchEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class VelocityBridgeProxyPlayerServerSwitchEvent extends VelocityBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkServiceInfo networkServiceInfo;
 
+    public VelocityBridgeProxyPlayerServerSwitchEvent(NetworkConnectionInfo networkConnectionInfo, NetworkServiceInfo networkServiceInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkServiceInfo = networkServiceInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkServiceInfo getNetworkServiceInfo() {
+        return this.networkServiceInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeServerPlayerDisconnectEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeServerPlayerDisconnectEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class VelocityBridgeServerPlayerDisconnectEvent extends VelocityBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public VelocityBridgeServerPlayerDisconnectEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeServerPlayerLoginRequestEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeServerPlayerLoginRequestEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class VelocityBridgeServerPlayerLoginRequestEvent extends VelocityBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public VelocityBridgeServerPlayerLoginRequestEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeServerPlayerLoginSuccessEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityBridgeServerPlayerLoginSuccessEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.ext.bridge.player.NetworkConnectionInfo;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkPlayerServerInfo;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class VelocityBridgeServerPlayerLoginSuccessEvent extends VelocityBridgeEvent {
 
     private final NetworkConnectionInfo networkConnectionInfo;
 
     private final NetworkPlayerServerInfo networkPlayerServerInfo;
 
+    public VelocityBridgeServerPlayerLoginSuccessEvent(NetworkConnectionInfo networkConnectionInfo, NetworkPlayerServerInfo networkPlayerServerInfo) {
+        this.networkConnectionInfo = networkConnectionInfo;
+        this.networkPlayerServerInfo = networkPlayerServerInfo;
+    }
+
+    public NetworkConnectionInfo getNetworkConnectionInfo() {
+        return this.networkConnectionInfo;
+    }
+
+    public NetworkPlayerServerInfo getNetworkPlayerServerInfo() {
+        return this.networkPlayerServerInfo;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityChannelMessageReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityChannelMessageReceiveEvent.java
@@ -1,15 +1,28 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityChannelMessageReceiveEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final String channel, message;
 
-    @Getter
     private final JsonDocument data;
+
+    public VelocityChannelMessageReceiveEvent(String channel, String message, JsonDocument data) {
+        this.channel = channel;
+        this.message = message;
+        this.data = data;
+    }
+
+    public String getChannel() {
+        return this.channel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public JsonDocument getData() {
+        return this.data;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudNetTickEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudNetTickEvent.java
@@ -1,8 +1,7 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
 public final class VelocityCloudNetTickEvent extends VelocityCloudNetEvent {
 
+    public VelocityCloudNetTickEvent() {
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceConnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceConnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityCloudServiceConnectNetworkEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public VelocityCloudServiceConnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceDisconnectNetworkEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceDisconnectNetworkEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityCloudServiceDisconnectNetworkEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public VelocityCloudServiceDisconnectNetworkEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityCloudServiceInfoUpdateEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public VelocityCloudServiceInfoUpdateEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceRegisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceRegisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityCloudServiceRegisterEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public VelocityCloudServiceRegisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceStartEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceStartEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityCloudServiceStartEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public VelocityCloudServiceStartEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceStopEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceStopEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityCloudServiceStopEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public VelocityCloudServiceStopEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceUnregisterEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityCloudServiceUnregisterEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityCloudServiceUnregisterEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public VelocityCloudServiceUnregisterEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityNetworkChannelPacketReceiveEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityNetworkChannelPacketReceiveEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityNetworkChannelPacketReceiveEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final INetworkChannel channel;
 
-    @Getter
     private final IPacket packet;
+
+    public VelocityNetworkChannelPacketReceiveEvent(INetworkChannel channel, IPacket packet) {
+        this.channel = channel;
+        this.packet = packet;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
+
+    public IPacket getPacket() {
+        return this.packet;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityNetworkClusterNodeInfoUpdateEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityNetworkClusterNodeInfoUpdateEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNodeInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityNetworkClusterNodeInfoUpdateEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot;
+
+    public VelocityNetworkClusterNodeInfoUpdateEvent(NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot) {
+        this.networkClusterNodeInfoSnapshot = networkClusterNodeInfoSnapshot;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNetworkClusterNodeInfoSnapshot() {
+        return this.networkClusterNodeInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityServiceInfoSnapshotConfigureEvent.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/event/VelocityServiceInfoSnapshotConfigureEvent.java
@@ -1,12 +1,16 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.event;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class VelocityServiceInfoSnapshotConfigureEvent extends VelocityCloudNetEvent {
 
-    @Getter
     private final ServiceInfoSnapshot serviceInfoSnapshot;
+
+    public VelocityServiceInfoSnapshotConfigureEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudNetCloudflareModule.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudNetCloudflareModule.java
@@ -13,23 +13,22 @@ import de.dytanic.cloudnet.ext.cloudflare.dns.DefaultDNSRecord;
 import de.dytanic.cloudnet.ext.cloudflare.http.V1CloudflareConfigurationHttpHandler;
 import de.dytanic.cloudnet.ext.cloudflare.listener.CloudflareStartAndStopListener;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.net.InetAddress;
 import java.util.Map;
 
-@Getter
 public final class CloudNetCloudflareModule extends NodeCloudNetModule {
 
-    @Getter
     private static CloudNetCloudflareModule instance;
 
-    @Setter
     private CloudflareConfiguration cloudflareConfiguration;
 
     public CloudNetCloudflareModule() {
         instance = this;
+    }
+
+    public static CloudNetCloudflareModule getInstance() {
+        return CloudNetCloudflareModule.instance;
     }
 
     @ModuleTask(order = 127, event = ModuleLifeCycle.STARTED)
@@ -142,4 +141,11 @@ public final class CloudNetCloudflareModule extends NodeCloudNetModule {
         }
     }
 
+    public CloudflareConfiguration getCloudflareConfiguration() {
+        return this.cloudflareConfiguration;
+    }
+
+    public void setCloudflareConfiguration(CloudflareConfiguration cloudflareConfiguration) {
+        this.cloudflareConfiguration = cloudflareConfiguration;
+    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareAPI.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareAPI.java
@@ -10,7 +10,6 @@ import de.dytanic.cloudnet.common.io.FileUtils;
 import de.dytanic.cloudnet.database.IDatabase;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.ext.cloudflare.dns.DNSRecord;
-import lombok.Getter;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -28,17 +27,14 @@ public final class CloudflareAPI implements AutoCloseable {
     private static final Type MAP_STRING_DOCUMENT = new TypeToken<Map<String, Pair<String, JsonDocument>>>() {
     }.getType();
 
-    @Getter
     private static CloudflareAPI instance;
 
     /*
     @Getter
     private final File file;
     */
-    @Getter
     private final IDatabase database;
 
-    @Getter
     private final Map<String, Pair<String, JsonDocument>> createdRecords = Maps.newConcurrentHashMap();
 
     protected CloudflareAPI(IDatabase database) {
@@ -48,6 +44,10 @@ public final class CloudflareAPI implements AutoCloseable {
         //this.file = file;
 
         this.read();
+    }
+
+    public static CloudflareAPI getInstance() {
+        return CloudflareAPI.instance;
     }
 
     public Pair<Integer, JsonDocument> createRecord(String serviceName, String email, String apiKey, String zoneId, DNSRecord dnsRecord) {
@@ -223,5 +223,13 @@ public final class CloudflareAPI implements AutoCloseable {
         }
 
         return null;
+    }
+
+    public IDatabase getDatabase() {
+        return this.database;
+    }
+
+    public Map<String, Pair<String, JsonDocument>> getCreatedRecords() {
+        return this.createdRecords;
     }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareConfiguration.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareConfiguration.java
@@ -1,10 +1,14 @@
 package de.dytanic.cloudnet.ext.cloudflare;
 
 import com.google.gson.reflect.TypeToken;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 
+@ToString
+@EqualsAndHashCode
 public class CloudflareConfiguration {
 
     public static final Type TYPE = new TypeToken<CloudflareConfiguration>() {
@@ -27,30 +31,4 @@ public class CloudflareConfiguration {
         this.entries = entries;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof CloudflareConfiguration)) return false;
-        final CloudflareConfiguration other = (CloudflareConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$entries = this.getEntries();
-        final Object other$entries = other.getEntries();
-        if (this$entries == null ? other$entries != null : !this$entries.equals(other$entries)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof CloudflareConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $entries = this.getEntries();
-        result = result * PRIME + ($entries == null ? 43 : $entries.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "CloudflareConfiguration(entries=" + this.getEntries() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareConfiguration.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareConfiguration.java
@@ -1,16 +1,10 @@
 package de.dytanic.cloudnet.ext.cloudflare;
 
 import com.google.gson.reflect.TypeToken;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class CloudflareConfiguration {
 
     public static final Type TYPE = new TypeToken<CloudflareConfiguration>() {
@@ -18,4 +12,45 @@ public class CloudflareConfiguration {
 
     protected Collection<CloudflareConfigurationEntry> entries;
 
+    public CloudflareConfiguration(Collection<CloudflareConfigurationEntry> entries) {
+        this.entries = entries;
+    }
+
+    public CloudflareConfiguration() {
+    }
+
+    public Collection<CloudflareConfigurationEntry> getEntries() {
+        return this.entries;
+    }
+
+    public void setEntries(Collection<CloudflareConfigurationEntry> entries) {
+        this.entries = entries;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CloudflareConfiguration)) return false;
+        final CloudflareConfiguration other = (CloudflareConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$entries = this.getEntries();
+        final Object other$entries = other.getEntries();
+        if (this$entries == null ? other$entries != null : !this$entries.equals(other$entries)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof CloudflareConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $entries = this.getEntries();
+        result = result * PRIME + ($entries == null ? 43 : $entries.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "CloudflareConfiguration(entries=" + this.getEntries() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareConfigurationEntry.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareConfigurationEntry.java
@@ -1,14 +1,7 @@
 package de.dytanic.cloudnet.ext.cloudflare;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.Collection;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class CloudflareConfigurationEntry {
 
     protected boolean enabled;
@@ -17,4 +10,128 @@ public class CloudflareConfigurationEntry {
 
     protected Collection<CloudflareGroupConfiguration> groups;
 
+    public CloudflareConfigurationEntry(boolean enabled, String hostAddress, String email, String apiToken, String zoneId, String domainName, Collection<CloudflareGroupConfiguration> groups) {
+        this.enabled = enabled;
+        this.hostAddress = hostAddress;
+        this.email = email;
+        this.apiToken = apiToken;
+        this.zoneId = zoneId;
+        this.domainName = domainName;
+        this.groups = groups;
+    }
+
+    public CloudflareConfigurationEntry() {
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public String getHostAddress() {
+        return this.hostAddress;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    public String getApiToken() {
+        return this.apiToken;
+    }
+
+    public String getZoneId() {
+        return this.zoneId;
+    }
+
+    public String getDomainName() {
+        return this.domainName;
+    }
+
+    public Collection<CloudflareGroupConfiguration> getGroups() {
+        return this.groups;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setHostAddress(String hostAddress) {
+        this.hostAddress = hostAddress;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setApiToken(String apiToken) {
+        this.apiToken = apiToken;
+    }
+
+    public void setZoneId(String zoneId) {
+        this.zoneId = zoneId;
+    }
+
+    public void setDomainName(String domainName) {
+        this.domainName = domainName;
+    }
+
+    public void setGroups(Collection<CloudflareGroupConfiguration> groups) {
+        this.groups = groups;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CloudflareConfigurationEntry)) return false;
+        final CloudflareConfigurationEntry other = (CloudflareConfigurationEntry) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (this.isEnabled() != other.isEnabled()) return false;
+        final Object this$hostAddress = this.getHostAddress();
+        final Object other$hostAddress = other.getHostAddress();
+        if (this$hostAddress == null ? other$hostAddress != null : !this$hostAddress.equals(other$hostAddress))
+            return false;
+        final Object this$email = this.getEmail();
+        final Object other$email = other.getEmail();
+        if (this$email == null ? other$email != null : !this$email.equals(other$email)) return false;
+        final Object this$apiToken = this.getApiToken();
+        final Object other$apiToken = other.getApiToken();
+        if (this$apiToken == null ? other$apiToken != null : !this$apiToken.equals(other$apiToken)) return false;
+        final Object this$zoneId = this.getZoneId();
+        final Object other$zoneId = other.getZoneId();
+        if (this$zoneId == null ? other$zoneId != null : !this$zoneId.equals(other$zoneId)) return false;
+        final Object this$domainName = this.getDomainName();
+        final Object other$domainName = other.getDomainName();
+        if (this$domainName == null ? other$domainName != null : !this$domainName.equals(other$domainName))
+            return false;
+        final Object this$groups = this.getGroups();
+        final Object other$groups = other.getGroups();
+        if (this$groups == null ? other$groups != null : !this$groups.equals(other$groups)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof CloudflareConfigurationEntry;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + (this.isEnabled() ? 79 : 97);
+        final Object $hostAddress = this.getHostAddress();
+        result = result * PRIME + ($hostAddress == null ? 43 : $hostAddress.hashCode());
+        final Object $email = this.getEmail();
+        result = result * PRIME + ($email == null ? 43 : $email.hashCode());
+        final Object $apiToken = this.getApiToken();
+        result = result * PRIME + ($apiToken == null ? 43 : $apiToken.hashCode());
+        final Object $zoneId = this.getZoneId();
+        result = result * PRIME + ($zoneId == null ? 43 : $zoneId.hashCode());
+        final Object $domainName = this.getDomainName();
+        result = result * PRIME + ($domainName == null ? 43 : $domainName.hashCode());
+        final Object $groups = this.getGroups();
+        result = result * PRIME + ($groups == null ? 43 : $groups.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "CloudflareConfigurationEntry(enabled=" + this.isEnabled() + ", hostAddress=" + this.getHostAddress() + ", email=" + this.getEmail() + ", apiToken=" + this.getApiToken() + ", zoneId=" + this.getZoneId() + ", domainName=" + this.getDomainName() + ", groups=" + this.getGroups() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareConfigurationEntry.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareConfigurationEntry.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.ext.cloudflare;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.Collection;
 
+@ToString
+@EqualsAndHashCode
 public class CloudflareConfigurationEntry {
 
     protected boolean enabled;
@@ -79,59 +84,4 @@ public class CloudflareConfigurationEntry {
         this.groups = groups;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof CloudflareConfigurationEntry)) return false;
-        final CloudflareConfigurationEntry other = (CloudflareConfigurationEntry) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (this.isEnabled() != other.isEnabled()) return false;
-        final Object this$hostAddress = this.getHostAddress();
-        final Object other$hostAddress = other.getHostAddress();
-        if (this$hostAddress == null ? other$hostAddress != null : !this$hostAddress.equals(other$hostAddress))
-            return false;
-        final Object this$email = this.getEmail();
-        final Object other$email = other.getEmail();
-        if (this$email == null ? other$email != null : !this$email.equals(other$email)) return false;
-        final Object this$apiToken = this.getApiToken();
-        final Object other$apiToken = other.getApiToken();
-        if (this$apiToken == null ? other$apiToken != null : !this$apiToken.equals(other$apiToken)) return false;
-        final Object this$zoneId = this.getZoneId();
-        final Object other$zoneId = other.getZoneId();
-        if (this$zoneId == null ? other$zoneId != null : !this$zoneId.equals(other$zoneId)) return false;
-        final Object this$domainName = this.getDomainName();
-        final Object other$domainName = other.getDomainName();
-        if (this$domainName == null ? other$domainName != null : !this$domainName.equals(other$domainName))
-            return false;
-        final Object this$groups = this.getGroups();
-        final Object other$groups = other.getGroups();
-        if (this$groups == null ? other$groups != null : !this$groups.equals(other$groups)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof CloudflareConfigurationEntry;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        result = result * PRIME + (this.isEnabled() ? 79 : 97);
-        final Object $hostAddress = this.getHostAddress();
-        result = result * PRIME + ($hostAddress == null ? 43 : $hostAddress.hashCode());
-        final Object $email = this.getEmail();
-        result = result * PRIME + ($email == null ? 43 : $email.hashCode());
-        final Object $apiToken = this.getApiToken();
-        result = result * PRIME + ($apiToken == null ? 43 : $apiToken.hashCode());
-        final Object $zoneId = this.getZoneId();
-        result = result * PRIME + ($zoneId == null ? 43 : $zoneId.hashCode());
-        final Object $domainName = this.getDomainName();
-        result = result * PRIME + ($domainName == null ? 43 : $domainName.hashCode());
-        final Object $groups = this.getGroups();
-        result = result * PRIME + ($groups == null ? 43 : $groups.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "CloudflareConfigurationEntry(enabled=" + this.isEnabled() + ", hostAddress=" + this.getHostAddress() + ", email=" + this.getEmail() + ", apiToken=" + this.getApiToken() + ", zoneId=" + this.getZoneId() + ", domainName=" + this.getDomainName() + ", groups=" + this.getGroups() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareGroupConfiguration.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareGroupConfiguration.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.ext.cloudflare;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class CloudflareGroupConfiguration {
 
     protected String name, sub;
@@ -48,39 +53,4 @@ public class CloudflareGroupConfiguration {
         this.weight = weight;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof CloudflareGroupConfiguration)) return false;
-        final CloudflareGroupConfiguration other = (CloudflareGroupConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$sub = this.getSub();
-        final Object other$sub = other.getSub();
-        if (this$sub == null ? other$sub != null : !this$sub.equals(other$sub)) return false;
-        if (this.getPriority() != other.getPriority()) return false;
-        if (this.getWeight() != other.getWeight()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof CloudflareGroupConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $sub = this.getSub();
-        result = result * PRIME + ($sub == null ? 43 : $sub.hashCode());
-        result = result * PRIME + this.getPriority();
-        result = result * PRIME + this.getWeight();
-        return result;
-    }
-
-    public String toString() {
-        return "CloudflareGroupConfiguration(name=" + this.getName() + ", sub=" + this.getSub() + ", priority=" + this.getPriority() + ", weight=" + this.getWeight() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareGroupConfiguration.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/CloudflareGroupConfiguration.java
@@ -1,16 +1,86 @@
 package de.dytanic.cloudnet.ext.cloudflare;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class CloudflareGroupConfiguration {
 
     protected String name, sub;
 
     protected int priority, weight;
 
+    public CloudflareGroupConfiguration(String name, String sub, int priority, int weight) {
+        this.name = name;
+        this.sub = sub;
+        this.priority = priority;
+        this.weight = weight;
+    }
+
+    public CloudflareGroupConfiguration() {
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getSub() {
+        return this.sub;
+    }
+
+    public int getPriority() {
+        return this.priority;
+    }
+
+    public int getWeight() {
+        return this.weight;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setSub(String sub) {
+        this.sub = sub;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public void setWeight(int weight) {
+        this.weight = weight;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CloudflareGroupConfiguration)) return false;
+        final CloudflareGroupConfiguration other = (CloudflareGroupConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$sub = this.getSub();
+        final Object other$sub = other.getSub();
+        if (this$sub == null ? other$sub != null : !this$sub.equals(other$sub)) return false;
+        if (this.getPriority() != other.getPriority()) return false;
+        if (this.getWeight() != other.getWeight()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof CloudflareGroupConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $sub = this.getSub();
+        result = result * PRIME + ($sub == null ? 43 : $sub.hashCode());
+        result = result * PRIME + this.getPriority();
+        result = result * PRIME + this.getWeight();
+        return result;
+    }
+
+    public String toString() {
+        return "CloudflareGroupConfiguration(name=" + this.getName() + ", sub=" + this.getSub() + ", priority=" + this.getPriority() + ", weight=" + this.getWeight() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/dns/DNSRecord.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/dns/DNSRecord.java
@@ -5,7 +5,11 @@
 package de.dytanic.cloudnet.ext.cloudflare.dns;
 
 import com.google.gson.JsonObject;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
+@ToString
+@EqualsAndHashCode
 public class DNSRecord {
 
     protected String type, name, content;
@@ -76,49 +80,4 @@ public class DNSRecord {
         this.data = data;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof DNSRecord)) return false;
-        final DNSRecord other = (DNSRecord) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$type = this.getType();
-        final Object other$type = other.getType();
-        if (this$type == null ? other$type != null : !this$type.equals(other$type)) return false;
-        final Object this$name = this.getName();
-        final Object other$name = other.getName();
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$content = this.getContent();
-        final Object other$content = other.getContent();
-        if (this$content == null ? other$content != null : !this$content.equals(other$content)) return false;
-        if (this.getTtl() != other.getTtl()) return false;
-        if (this.isProxied() != other.isProxied()) return false;
-        final Object this$data = this.getData();
-        final Object other$data = other.getData();
-        if (this$data == null ? other$data != null : !this$data.equals(other$data)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof DNSRecord;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $type = this.getType();
-        result = result * PRIME + ($type == null ? 43 : $type.hashCode());
-        final Object $name = this.getName();
-        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
-        final Object $content = this.getContent();
-        result = result * PRIME + ($content == null ? 43 : $content.hashCode());
-        result = result * PRIME + this.getTtl();
-        result = result * PRIME + (this.isProxied() ? 79 : 97);
-        final Object $data = this.getData();
-        result = result * PRIME + ($data == null ? 43 : $data.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "DNSRecord(type=" + this.getType() + ", name=" + this.getName() + ", content=" + this.getContent() + ", ttl=" + this.getTtl() + ", proxied=" + this.isProxied() + ", data=" + this.getData() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/dns/DNSRecord.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/dns/DNSRecord.java
@@ -5,13 +5,7 @@
 package de.dytanic.cloudnet.ext.cloudflare.dns;
 
 import com.google.gson.JsonObject;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class DNSRecord {
 
     protected String type, name, content;
@@ -22,4 +16,109 @@ public class DNSRecord {
 
     protected JsonObject data;
 
+    public DNSRecord(String type, String name, String content, int ttl, boolean proxied, JsonObject data) {
+        this.type = type;
+        this.name = name;
+        this.content = content;
+        this.ttl = ttl;
+        this.proxied = proxied;
+        this.data = data;
+    }
+
+    public DNSRecord() {
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getContent() {
+        return this.content;
+    }
+
+    public int getTtl() {
+        return this.ttl;
+    }
+
+    public boolean isProxied() {
+        return this.proxied;
+    }
+
+    public JsonObject getData() {
+        return this.data;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setTtl(int ttl) {
+        this.ttl = ttl;
+    }
+
+    public void setProxied(boolean proxied) {
+        this.proxied = proxied;
+    }
+
+    public void setData(JsonObject data) {
+        this.data = data;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof DNSRecord)) return false;
+        final DNSRecord other = (DNSRecord) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$type = this.getType();
+        final Object other$type = other.getType();
+        if (this$type == null ? other$type != null : !this$type.equals(other$type)) return false;
+        final Object this$name = this.getName();
+        final Object other$name = other.getName();
+        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+        final Object this$content = this.getContent();
+        final Object other$content = other.getContent();
+        if (this$content == null ? other$content != null : !this$content.equals(other$content)) return false;
+        if (this.getTtl() != other.getTtl()) return false;
+        if (this.isProxied() != other.isProxied()) return false;
+        final Object this$data = this.getData();
+        final Object other$data = other.getData();
+        if (this$data == null ? other$data != null : !this$data.equals(other$data)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof DNSRecord;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $type = this.getType();
+        result = result * PRIME + ($type == null ? 43 : $type.hashCode());
+        final Object $name = this.getName();
+        result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+        final Object $content = this.getContent();
+        result = result * PRIME + ($content == null ? 43 : $content.hashCode());
+        result = result * PRIME + this.getTtl();
+        result = result * PRIME + (this.isProxied() ? 79 : 97);
+        final Object $data = this.getData();
+        result = result * PRIME + ($data == null ? 43 : $data.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "DNSRecord(type=" + this.getType() + ", name=" + this.getName() + ", content=" + this.getContent() + ", ttl=" + this.getTtl() + ", proxied=" + this.isProxied() + ", data=" + this.getData() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/dns/SRVRecord.java
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/java/de/dytanic/cloudnet/ext/cloudflare/dns/SRVRecord.java
@@ -5,12 +5,10 @@
 package de.dytanic.cloudnet.ext.cloudflare.dns;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.Getter;
 
 /**
  * A representation of an SRV DNS record
  */
-@Getter
 public class SRVRecord extends DNSRecord {
 
     public SRVRecord(String name, String content, String service, String proto, String name_, int priority, int weight, int port, String target) {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsPermissionManagement.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsPermissionManagement.java
@@ -6,7 +6,6 @@ import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.permission.*;
 import de.dytanic.cloudnet.ext.cloudperms.listener.PermissionsUpdateListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 
 import java.util.Collection;
 import java.util.List;
@@ -16,10 +15,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-@Getter
 public final class CloudPermissionsPermissionManagement implements IPermissionManagement {
 
-    @Getter
     private static CloudPermissionsPermissionManagement instance;
 
     private final Map<String, IPermissionGroup> cachedPermissionGroups = Maps.newConcurrentHashMap();
@@ -30,6 +27,10 @@ public final class CloudPermissionsPermissionManagement implements IPermissionMa
         instance = this;
 
         init();
+    }
+
+    public static CloudPermissionsPermissionManagement getInstance() {
+        return CloudPermissionsPermissionManagement.instance;
     }
 
     private void init() {
@@ -214,5 +215,13 @@ public final class CloudPermissionsPermissionManagement implements IPermissionMa
 
     private CloudNetDriver getDriver() {
         return CloudNetDriver.getInstance();
+    }
+
+    public Map<String, IPermissionGroup> getCachedPermissionGroups() {
+        return this.cachedPermissionGroups;
+    }
+
+    public Map<UUID, IPermissionUser> getCachedPermissionUsers() {
+        return this.cachedPermissionUsers;
     }
 }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPermissible.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPermissible.java
@@ -4,7 +4,6 @@ import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissibleBase;
 import org.bukkit.permissions.Permission;
@@ -16,7 +15,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Getter
 public final class BukkitCloudNetCloudPermissionsPermissible extends PermissibleBase {
 
     private static final Collection<String> DEFAULT_ALLOWED_PERMISSION_COLLECTION = Iterables.newArrayList(Arrays.asList(
@@ -78,5 +76,9 @@ public final class BukkitCloudNetCloudPermissionsPermissible extends Permissible
             ex.printStackTrace();
             return false;
         }
+    }
+
+    public Player getPlayer() {
+        return this.player;
     }
 }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
@@ -8,7 +8,6 @@ import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.bukkit.listener.BukkitCloudNetCloudPermissionsPlayerListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Server;
@@ -24,8 +23,11 @@ import java.util.function.Function;
 
 public final class BukkitCloudNetCloudPermissionsPlugin extends JavaPlugin {
 
-    @Getter
     private static BukkitCloudNetCloudPermissionsPlugin instance;
+
+    public static BukkitCloudNetCloudPermissionsPlugin getInstance() {
+        return BukkitCloudNetCloudPermissionsPlugin.instance;
+    }
 
     @Override
     public void onLoad() {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bungee/BungeeCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bungee/BungeeCloudNetCloudPermissionsPlugin.java
@@ -4,14 +4,15 @@ import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.bungee.listener.BungeeCloudNetCloudPermissionsPlayerListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 import net.md_5.bungee.api.plugin.Plugin;
 
-@Getter
 public final class BungeeCloudNetCloudPermissionsPlugin extends Plugin {
 
-    @Getter
     private static BungeeCloudNetCloudPermissionsPlugin instance;
+
+    public static BungeeCloudNetCloudPermissionsPlugin getInstance() {
+        return BungeeCloudNetCloudPermissionsPlugin.instance;
+    }
 
     @Override
     public void onLoad() {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/gomint/GoMintCloudNetCloudPermissionsPermissionManager.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/gomint/GoMintCloudNetCloudPermissionsPermissionManager.java
@@ -7,9 +7,7 @@ import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
 import io.gomint.entity.EntityPlayer;
 import io.gomint.permission.Group;
 import io.gomint.server.permission.PermissionManager;
-import lombok.Getter;
 
-@Getter
 public final class GoMintCloudNetCloudPermissionsPermissionManager extends PermissionManager {
 
     private final EntityPlayer player;
@@ -63,5 +61,13 @@ public final class GoMintCloudNetCloudPermissionsPermissionManager extends Permi
 
     private IPermissionUser getUser() {
         return CloudPermissionsPermissionManagement.getInstance().getUser(player.getUUID());
+    }
+
+    public EntityPlayer getPlayer() {
+        return this.player;
+    }
+
+    public io.gomint.permission.PermissionManager getDefaultPermissionManager() {
+        return this.defaultPermissionManager;
     }
 }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/gomint/GoMintCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/gomint/GoMintCloudNetCloudPermissionsPlugin.java
@@ -10,20 +10,21 @@ import io.gomint.entity.EntityPlayer;
 import io.gomint.plugin.Plugin;
 import io.gomint.plugin.PluginName;
 import io.gomint.plugin.Version;
-import lombok.Getter;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@Getter
 @PluginName("CloudNet-CloudPerms")
 @Version(major = 1, minor = 0)
 public final class GoMintCloudNetCloudPermissionsPlugin extends Plugin {
 
-    @Getter
     private static GoMintCloudNetCloudPermissionsPlugin instance;
+
+    public static GoMintCloudNetCloudPermissionsPlugin getInstance() {
+        return GoMintCloudNetCloudPermissionsPlugin.instance;
+    }
 
     @Override
     public void onInstall() {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/node/CloudNetCloudPermissionsModule.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/node/CloudNetCloudPermissionsModule.java
@@ -6,7 +6,6 @@ import de.dytanic.cloudnet.driver.module.ModuleTask;
 import de.dytanic.cloudnet.ext.cloudperms.node.listener.ConfigurationUpdateListener;
 import de.dytanic.cloudnet.ext.cloudperms.node.listener.IncludePluginListener;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
-import lombok.Getter;
 
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -17,8 +16,11 @@ public final class CloudNetCloudPermissionsModule extends NodeCloudNetModule {
     private static final Type LIST_STRING = new TypeToken<List<String>>() {
     }.getType();
 
-    @Getter
     private static CloudNetCloudPermissionsModule instance;
+
+    public static CloudNetCloudPermissionsModule getInstance() {
+        return CloudNetCloudPermissionsModule.instance;
+    }
 
     @ModuleTask(order = 127, event = ModuleLifeCycle.LOADED)
     public void init() {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPermissible.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPermissible.java
@@ -7,14 +7,11 @@ import cn.nukkit.permission.PermissionAttachmentInfo;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@Getter
 public final class NukkitCloudNetCloudPermissionsPermissible extends PermissibleBase {
 
     private final Player player;
@@ -65,5 +62,9 @@ public final class NukkitCloudNetCloudPermissionsPermissible extends Permissible
 
         IPermissionUser permissionUser = CloudPermissionsPermissionManagement.getInstance().getUser(player.getUniqueId());
         return permissionUser != null && CloudPermissionsPermissionManagement.getInstance().hasPlayerPermission(permissionUser, inName);
+    }
+
+    public Player getPlayer() {
+        return this.player;
     }
 }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPlugin.java
@@ -8,15 +8,16 @@ import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.nukkit.listener.NukkitCloudNetCloudPermissionsPlayerListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 
 import java.lang.reflect.Field;
 
-@Getter
 public final class NukkitCloudNetCloudPermissionsPlugin extends PluginBase {
 
-    @Getter
     private static NukkitCloudNetCloudPermissionsPlugin instance;
+
+    public static NukkitCloudNetCloudPermissionsPlugin getInstance() {
+        return NukkitCloudNetCloudPermissionsPlugin.instance;
+    }
 
     @Override
     public void onLoad() {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionFunction.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionFunction.java
@@ -4,16 +4,16 @@ import com.velocitypowered.api.permission.PermissionFunction;
 import com.velocitypowered.api.permission.Tristate;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
-@Getter
-@RequiredArgsConstructor
 public final class VelocityCloudNetCloudPermissionsPermissionFunction implements PermissionFunction {
 
     private final UUID uniqueId;
+
+    public VelocityCloudNetCloudPermissionsPermissionFunction(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
 
     @Override
     public Tristate getPermissionValue(String permission) {
@@ -22,5 +22,9 @@ public final class VelocityCloudNetCloudPermissionsPermissionFunction implements
         IPermissionUser permissionUser = CloudPermissionsPermissionManagement.getInstance().getUser(uniqueId);
         return (permissionUser != null && CloudPermissionsPermissionManagement.getInstance().hasPlayerPermission(permissionUser, permission)) ?
                 Tristate.TRUE : Tristate.FALSE;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
     }
 }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
@@ -13,11 +13,9 @@ import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.velocity.listener.VelocityCloudNetCloudPermissionsPlayerListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 
 import java.lang.reflect.Field;
 
-@Getter
 @Plugin(
         id = "cloudnet_cloudperms_velocity",
         name = "CloudNet-CloudPerms",
@@ -30,7 +28,6 @@ import java.lang.reflect.Field;
 )
 public final class VelocityCloudNetCloudPermissionsPlugin {
 
-    @Getter
     private static VelocityCloudNetCloudPermissionsPlugin instance;
 
     private final ProxyServer proxyServer;
@@ -42,6 +39,10 @@ public final class VelocityCloudNetCloudPermissionsPlugin {
         instance = this;
 
         this.proxyServer = proxyServer;
+    }
+
+    public static VelocityCloudNetCloudPermissionsPlugin getInstance() {
+        return VelocityCloudNetCloudPermissionsPlugin.instance;
     }
 
     @Subscribe
@@ -76,5 +77,13 @@ public final class VelocityCloudNetCloudPermissionsPlugin {
         } catch (Exception ignored) {
 
         }
+    }
+
+    public ProxyServer getProxyServer() {
+        return this.proxyServer;
+    }
+
+    public PermissionProvider getPermissionProvider() {
+        return this.permissionProvider;
     }
 }

--- a/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/CloudNetMySQLDatabaseModule.java
+++ b/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/CloudNetMySQLDatabaseModule.java
@@ -7,7 +7,6 @@ import de.dytanic.cloudnet.driver.module.ModuleTask;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.ext.database.mysql.util.MySQLConnectionEndpoint;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
-import lombok.Getter;
 
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -18,8 +17,11 @@ public final class CloudNetMySQLDatabaseModule extends NodeCloudNetModule {
     public static final Type TYPE = new TypeToken<List<MySQLConnectionEndpoint>>() {
     }.getType();
 
-    @Getter
     private static CloudNetMySQLDatabaseModule instance;
+
+    public static CloudNetMySQLDatabaseModule getInstance() {
+        return CloudNetMySQLDatabaseModule.instance;
+    }
 
     @ModuleTask(order = 127, event = ModuleLifeCycle.LOADED)
     public void init() {

--- a/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/MySQLDatabase.java
+++ b/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/MySQLDatabase.java
@@ -9,7 +9,6 @@ import de.dytanic.cloudnet.common.concurrent.IThrowableCallback;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.database.IDatabase;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
-import lombok.Getter;
 
 import java.sql.ResultSet;
 import java.util.Collection;
@@ -20,7 +19,6 @@ import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 
-@Getter
 public final class MySQLDatabase implements IDatabase {
 
     private static final String TABLE_COLUMN_KEY = "Name", TABLE_COLUMN_VALUE = "Document";
@@ -419,5 +417,13 @@ public final class MySQLDatabase implements IDatabase {
 
     private ITaskScheduler getTaskScheduler() {
         return CloudNetDriver.getInstance().getTaskScheduler();
+    }
+
+    public MySQLDatabaseProvider getDatabaseProvider() {
+        return this.databaseProvider;
+    }
+
+    public String getName() {
+        return this.name;
     }
 }

--- a/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/MySQLDatabaseProvider.java
+++ b/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/MySQLDatabaseProvider.java
@@ -10,8 +10,6 @@ import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.database.AbstractDatabaseProvider;
 import de.dytanic.cloudnet.database.IDatabase;
 import de.dytanic.cloudnet.ext.database.mysql.util.MySQLConnectionEndpoint;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -22,8 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-@Getter
-@RequiredArgsConstructor
 public final class MySQLDatabaseProvider extends AbstractDatabaseProvider {
 
     private static final long NEW_CREATION_DELAY = 600000;
@@ -37,6 +33,10 @@ public final class MySQLDatabaseProvider extends AbstractDatabaseProvider {
     private final JsonDocument config;
 
     private List<MySQLConnectionEndpoint> addresses;
+
+    public MySQLDatabaseProvider(JsonDocument config) {
+        this.config = config;
+    }
 
     @Override
     public boolean init() throws Exception {
@@ -181,5 +181,21 @@ public final class MySQLDatabaseProvider extends AbstractDatabaseProvider {
 
     private Connection getConnection() throws SQLException {
         return hikariDataSource.getConnection();
+    }
+
+    public NetorHashMap<String, Long, MySQLDatabase> getCachedDatabaseInstances() {
+        return this.cachedDatabaseInstances;
+    }
+
+    public HikariDataSource getHikariDataSource() {
+        return this.hikariDataSource;
+    }
+
+    public JsonDocument getConfig() {
+        return this.config;
+    }
+
+    public List<MySQLConnectionEndpoint> getAddresses() {
+        return this.addresses;
     }
 }

--- a/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/util/MySQLConnectionEndpoint.java
+++ b/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/util/MySQLConnectionEndpoint.java
@@ -1,12 +1,8 @@
 package de.dytanic.cloudnet.ext.database.mysql.util;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
-import lombok.AllArgsConstructor;
-import lombok.Value;
 
-@Value
-@AllArgsConstructor
-public class MySQLConnectionEndpoint {
+public final class MySQLConnectionEndpoint {
 
     protected final boolean useSsl;
 
@@ -14,4 +10,50 @@ public class MySQLConnectionEndpoint {
 
     protected final HostAndPort address;
 
+    public MySQLConnectionEndpoint(boolean useSsl, String database, HostAndPort address) {
+        this.useSsl = useSsl;
+        this.database = database;
+        this.address = address;
+    }
+
+    public boolean isUseSsl() {
+        return this.useSsl;
+    }
+
+    public String getDatabase() {
+        return this.database;
+    }
+
+    public HostAndPort getAddress() {
+        return this.address;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof MySQLConnectionEndpoint)) return false;
+        final MySQLConnectionEndpoint other = (MySQLConnectionEndpoint) o;
+        if (this.isUseSsl() != other.isUseSsl()) return false;
+        final Object this$database = this.getDatabase();
+        final Object other$database = other.getDatabase();
+        if (this$database == null ? other$database != null : !this$database.equals(other$database)) return false;
+        final Object this$address = this.getAddress();
+        final Object other$address = other.getAddress();
+        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + (this.isUseSsl() ? 79 : 97);
+        final Object $database = this.getDatabase();
+        result = result * PRIME + ($database == null ? 43 : $database.hashCode());
+        final Object $address = this.getAddress();
+        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "MySQLConnectionEndpoint(useSsl=" + this.isUseSsl() + ", database=" + this.getDatabase() + ", address=" + this.getAddress() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/util/MySQLConnectionEndpoint.java
+++ b/cloudnet-modules/cloudnet-database-mysql/src/main/java/de/dytanic/cloudnet/ext/database/mysql/util/MySQLConnectionEndpoint.java
@@ -1,7 +1,11 @@
 package de.dytanic.cloudnet.ext.database.mysql.util;
 
 import de.dytanic.cloudnet.driver.network.HostAndPort;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
+@ToString
+@EqualsAndHashCode
 public final class MySQLConnectionEndpoint {
 
     protected final boolean useSsl;
@@ -28,32 +32,4 @@ public final class MySQLConnectionEndpoint {
         return this.address;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof MySQLConnectionEndpoint)) return false;
-        final MySQLConnectionEndpoint other = (MySQLConnectionEndpoint) o;
-        if (this.isUseSsl() != other.isUseSsl()) return false;
-        final Object this$database = this.getDatabase();
-        final Object other$database = other.getDatabase();
-        if (this$database == null ? other$database != null : !this$database.equals(other$database)) return false;
-        final Object this$address = this.getAddress();
-        final Object other$address = other.getAddress();
-        if (this$address == null ? other$address != null : !this$address.equals(other$address)) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        result = result * PRIME + (this.isUseSsl() ? 79 : 97);
-        final Object $database = this.getDatabase();
-        result = result * PRIME + ($database == null ? 43 : $database.hashCode());
-        final Object $address = this.getAddress();
-        result = result * PRIME + ($address == null ? 43 : $address.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "MySQLConnectionEndpoint(useSsl=" + this.isUseSsl() + ", database=" + this.getDatabase() + ", address=" + this.getAddress() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-report/src/main/java/de/dytanic/cloudnet/ext/report/CloudNetReportModule.java
+++ b/cloudnet-modules/cloudnet-report/src/main/java/de/dytanic/cloudnet/ext/report/CloudNetReportModule.java
@@ -11,8 +11,6 @@ import de.dytanic.cloudnet.ext.report.command.CommandReport;
 import de.dytanic.cloudnet.ext.report.listener.CloudNetReportListener;
 import de.dytanic.cloudnet.ext.report.util.PasteServerType;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -22,17 +20,17 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-@Getter
 public final class CloudNetReportModule extends NodeCloudNetModule {
 
-    @Getter
     private static CloudNetReportModule instance;
 
-    @Setter
     private volatile Class<? extends Event> eventClass;
 
-    @Getter
     private File savingRecordsDirectory;
+
+    public static CloudNetReportModule getInstance() {
+        return CloudNetReportModule.instance;
+    }
 
     @ModuleTask(order = 127, event = ModuleLifeCycle.LOADED)
     public void init() {
@@ -107,5 +105,17 @@ public final class CloudNetReportModule extends NodeCloudNetModule {
         }
 
         return null;
+    }
+
+    public Class<? extends Event> getEventClass() {
+        return this.eventClass;
+    }
+
+    public File getSavingRecordsDirectory() {
+        return this.savingRecordsDirectory;
+    }
+
+    public void setEventClass(Class<? extends Event> eventClass) {
+        this.eventClass = eventClass;
     }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/AbstractSignManagement.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/AbstractSignManagement.java
@@ -8,8 +8,6 @@ import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.network.def.PacketConstants;
 import de.dytanic.cloudnet.driver.service.ServiceEnvironmentType;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.Collection;
 import java.util.List;
@@ -18,12 +16,13 @@ import java.util.function.Function;
 
 public abstract class AbstractSignManagement {
 
-    @Getter
     protected static AbstractSignManagement instance;
 
-    @Getter
-    @Setter
     protected List<Sign> signs;
+
+    public static AbstractSignManagement getInstance() {
+        return AbstractSignManagement.instance;
+    }
 
     public abstract void onRegisterService(ServiceInfoSnapshot serviceInfoSnapshot);
 
@@ -105,5 +104,13 @@ public abstract class AbstractSignManagement {
                                 serviceInfoSnapshot.getServiceId().getEnvironment() == ServiceEnvironmentType.GLOWSTONE
                 )
                 ;
+    }
+
+    public List<Sign> getSigns() {
+        return this.signs;
+    }
+
+    public void setSigns(List<Sign> signs) {
+        this.signs = signs;
     }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/Sign.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/Sign.java
@@ -2,9 +2,13 @@ package de.dytanic.cloudnet.ext.signs;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 
+@ToString
+@EqualsAndHashCode
 public class Sign implements Comparable<Sign> {
 
     public static final Type TYPE = new TypeToken<Sign>() {
@@ -82,58 +86,4 @@ public class Sign implements Comparable<Sign> {
         this.serviceInfoSnapshot = serviceInfoSnapshot;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof Sign)) return false;
-        final Sign other = (Sign) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (this.getSignId() != other.getSignId()) return false;
-        final Object this$providedGroup = this.getProvidedGroup();
-        final Object other$providedGroup = other.getProvidedGroup();
-        if (this$providedGroup == null ? other$providedGroup != null : !this$providedGroup.equals(other$providedGroup))
-            return false;
-        final Object this$targetGroup = this.getTargetGroup();
-        final Object other$targetGroup = other.getTargetGroup();
-        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
-            return false;
-        final Object this$templatePath = this.getTemplatePath();
-        final Object other$templatePath = other.getTemplatePath();
-        if (this$templatePath == null ? other$templatePath != null : !this$templatePath.equals(other$templatePath))
-            return false;
-        final Object this$worldPosition = this.getWorldPosition();
-        final Object other$worldPosition = other.getWorldPosition();
-        if (this$worldPosition == null ? other$worldPosition != null : !this$worldPosition.equals(other$worldPosition))
-            return false;
-        final Object this$serviceInfoSnapshot = this.getServiceInfoSnapshot();
-        final Object other$serviceInfoSnapshot = other.getServiceInfoSnapshot();
-        if (this$serviceInfoSnapshot == null ? other$serviceInfoSnapshot != null : !this$serviceInfoSnapshot.equals(other$serviceInfoSnapshot))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof Sign;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final long $signId = this.getSignId();
-        result = result * PRIME + (int) ($signId >>> 32 ^ $signId);
-        final Object $providedGroup = this.getProvidedGroup();
-        result = result * PRIME + ($providedGroup == null ? 43 : $providedGroup.hashCode());
-        final Object $targetGroup = this.getTargetGroup();
-        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
-        final Object $templatePath = this.getTemplatePath();
-        result = result * PRIME + ($templatePath == null ? 43 : $templatePath.hashCode());
-        final Object $worldPosition = this.getWorldPosition();
-        result = result * PRIME + ($worldPosition == null ? 43 : $worldPosition.hashCode());
-        final Object $serviceInfoSnapshot = this.getServiceInfoSnapshot();
-        result = result * PRIME + ($serviceInfoSnapshot == null ? 43 : $serviceInfoSnapshot.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "Sign(signId=" + this.getSignId() + ", providedGroup=" + this.getProvidedGroup() + ", targetGroup=" + this.getTargetGroup() + ", templatePath=" + this.getTemplatePath() + ", worldPosition=" + this.getWorldPosition() + ", serviceInfoSnapshot=" + this.getServiceInfoSnapshot() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/Sign.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/Sign.java
@@ -2,11 +2,9 @@ package de.dytanic.cloudnet.ext.signs;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Data;
 
 import java.lang.reflect.Type;
 
-@Data
 public class Sign implements Comparable<Sign> {
 
     public static final Type TYPE = new TypeToken<Sign>() {
@@ -34,5 +32,108 @@ public class Sign implements Comparable<Sign> {
     @Override
     public int compareTo(Sign o) {
         return Long.compare(signId, o.getSignId());
+    }
+
+    public long getSignId() {
+        return this.signId;
+    }
+
+    public String getProvidedGroup() {
+        return this.providedGroup;
+    }
+
+    public String getTargetGroup() {
+        return this.targetGroup;
+    }
+
+    public String getTemplatePath() {
+        return this.templatePath;
+    }
+
+    public SignPosition getWorldPosition() {
+        return this.worldPosition;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
+
+    public void setSignId(long signId) {
+        this.signId = signId;
+    }
+
+    public void setProvidedGroup(String providedGroup) {
+        this.providedGroup = providedGroup;
+    }
+
+    public void setTargetGroup(String targetGroup) {
+        this.targetGroup = targetGroup;
+    }
+
+    public void setTemplatePath(String templatePath) {
+        this.templatePath = templatePath;
+    }
+
+    public void setWorldPosition(SignPosition worldPosition) {
+        this.worldPosition = worldPosition;
+    }
+
+    public void setServiceInfoSnapshot(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Sign)) return false;
+        final Sign other = (Sign) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (this.getSignId() != other.getSignId()) return false;
+        final Object this$providedGroup = this.getProvidedGroup();
+        final Object other$providedGroup = other.getProvidedGroup();
+        if (this$providedGroup == null ? other$providedGroup != null : !this$providedGroup.equals(other$providedGroup))
+            return false;
+        final Object this$targetGroup = this.getTargetGroup();
+        final Object other$targetGroup = other.getTargetGroup();
+        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
+            return false;
+        final Object this$templatePath = this.getTemplatePath();
+        final Object other$templatePath = other.getTemplatePath();
+        if (this$templatePath == null ? other$templatePath != null : !this$templatePath.equals(other$templatePath))
+            return false;
+        final Object this$worldPosition = this.getWorldPosition();
+        final Object other$worldPosition = other.getWorldPosition();
+        if (this$worldPosition == null ? other$worldPosition != null : !this$worldPosition.equals(other$worldPosition))
+            return false;
+        final Object this$serviceInfoSnapshot = this.getServiceInfoSnapshot();
+        final Object other$serviceInfoSnapshot = other.getServiceInfoSnapshot();
+        if (this$serviceInfoSnapshot == null ? other$serviceInfoSnapshot != null : !this$serviceInfoSnapshot.equals(other$serviceInfoSnapshot))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof Sign;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final long $signId = this.getSignId();
+        result = result * PRIME + (int) ($signId >>> 32 ^ $signId);
+        final Object $providedGroup = this.getProvidedGroup();
+        result = result * PRIME + ($providedGroup == null ? 43 : $providedGroup.hashCode());
+        final Object $targetGroup = this.getTargetGroup();
+        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
+        final Object $templatePath = this.getTemplatePath();
+        result = result * PRIME + ($templatePath == null ? 43 : $templatePath.hashCode());
+        final Object $worldPosition = this.getWorldPosition();
+        result = result * PRIME + ($worldPosition == null ? 43 : $worldPosition.hashCode());
+        final Object $serviceInfoSnapshot = this.getServiceInfoSnapshot();
+        result = result * PRIME + ($serviceInfoSnapshot == null ? 43 : $serviceInfoSnapshot.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "Sign(signId=" + this.getSignId() + ", providedGroup=" + this.getProvidedGroup() + ", targetGroup=" + this.getTargetGroup() + ", templatePath=" + this.getTemplatePath() + ", worldPosition=" + this.getWorldPosition() + ", serviceInfoSnapshot=" + this.getServiceInfoSnapshot() + ")";
     }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfiguration.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfiguration.java
@@ -1,17 +1,11 @@
 package de.dytanic.cloudnet.ext.signs;
 
 import com.google.gson.reflect.TypeToken;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SignConfiguration {
 
     public static final Type TYPE = new TypeToken<SignConfiguration>() {
@@ -21,4 +15,60 @@ public class SignConfiguration {
 
     protected Map<String, String> messages;
 
+    public SignConfiguration(Collection<SignConfigurationEntry> configurations, Map<String, String> messages) {
+        this.configurations = configurations;
+        this.messages = messages;
+    }
+
+    public SignConfiguration() {
+    }
+
+    public Collection<SignConfigurationEntry> getConfigurations() {
+        return this.configurations;
+    }
+
+    public Map<String, String> getMessages() {
+        return this.messages;
+    }
+
+    public void setConfigurations(Collection<SignConfigurationEntry> configurations) {
+        this.configurations = configurations;
+    }
+
+    public void setMessages(Map<String, String> messages) {
+        this.messages = messages;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SignConfiguration)) return false;
+        final SignConfiguration other = (SignConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$configurations = this.getConfigurations();
+        final Object other$configurations = other.getConfigurations();
+        if (this$configurations == null ? other$configurations != null : !this$configurations.equals(other$configurations))
+            return false;
+        final Object this$messages = this.getMessages();
+        final Object other$messages = other.getMessages();
+        if (this$messages == null ? other$messages != null : !this$messages.equals(other$messages)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SignConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $configurations = this.getConfigurations();
+        result = result * PRIME + ($configurations == null ? 43 : $configurations.hashCode());
+        final Object $messages = this.getMessages();
+        result = result * PRIME + ($messages == null ? 43 : $messages.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SignConfiguration(configurations=" + this.getConfigurations() + ", messages=" + this.getMessages() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfiguration.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfiguration.java
@@ -1,11 +1,15 @@
 package de.dytanic.cloudnet.ext.signs;
 
 import com.google.gson.reflect.TypeToken;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
 
+@ToString
+@EqualsAndHashCode
 public class SignConfiguration {
 
     public static final Type TYPE = new TypeToken<SignConfiguration>() {
@@ -39,36 +43,4 @@ public class SignConfiguration {
         this.messages = messages;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SignConfiguration)) return false;
-        final SignConfiguration other = (SignConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$configurations = this.getConfigurations();
-        final Object other$configurations = other.getConfigurations();
-        if (this$configurations == null ? other$configurations != null : !this$configurations.equals(other$configurations))
-            return false;
-        final Object this$messages = this.getMessages();
-        final Object other$messages = other.getMessages();
-        if (this$messages == null ? other$messages != null : !this$messages.equals(other$messages)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SignConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $configurations = this.getConfigurations();
-        result = result * PRIME + ($configurations == null ? 43 : $configurations.hashCode());
-        final Object $messages = this.getMessages();
-        result = result * PRIME + ($messages == null ? 43 : $messages.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SignConfiguration(configurations=" + this.getConfigurations() + ", messages=" + this.getMessages() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfigurationEntry.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfigurationEntry.java
@@ -1,14 +1,7 @@
 package de.dytanic.cloudnet.ext.signs;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.Collection;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SignConfigurationEntry {
 
     protected String targetGroup;
@@ -21,4 +14,147 @@ public class SignConfigurationEntry {
 
     protected SignLayoutConfiguration startingLayouts, searchLayouts;
 
+    public SignConfigurationEntry(String targetGroup, boolean switchToSearchingWhenServiceIsFull, Collection<SignConfigurationTaskEntry> taskLayouts, SignLayout defaultOnlineLayout, SignLayout defaultEmptyLayout, SignLayout defaultFullLayout, SignLayoutConfiguration startingLayouts, SignLayoutConfiguration searchLayouts) {
+        this.targetGroup = targetGroup;
+        this.switchToSearchingWhenServiceIsFull = switchToSearchingWhenServiceIsFull;
+        this.taskLayouts = taskLayouts;
+        this.defaultOnlineLayout = defaultOnlineLayout;
+        this.defaultEmptyLayout = defaultEmptyLayout;
+        this.defaultFullLayout = defaultFullLayout;
+        this.startingLayouts = startingLayouts;
+        this.searchLayouts = searchLayouts;
+    }
+
+    public SignConfigurationEntry() {
+    }
+
+    public String getTargetGroup() {
+        return this.targetGroup;
+    }
+
+    public boolean isSwitchToSearchingWhenServiceIsFull() {
+        return this.switchToSearchingWhenServiceIsFull;
+    }
+
+    public Collection<SignConfigurationTaskEntry> getTaskLayouts() {
+        return this.taskLayouts;
+    }
+
+    public SignLayout getDefaultOnlineLayout() {
+        return this.defaultOnlineLayout;
+    }
+
+    public SignLayout getDefaultEmptyLayout() {
+        return this.defaultEmptyLayout;
+    }
+
+    public SignLayout getDefaultFullLayout() {
+        return this.defaultFullLayout;
+    }
+
+    public SignLayoutConfiguration getStartingLayouts() {
+        return this.startingLayouts;
+    }
+
+    public SignLayoutConfiguration getSearchLayouts() {
+        return this.searchLayouts;
+    }
+
+    public void setTargetGroup(String targetGroup) {
+        this.targetGroup = targetGroup;
+    }
+
+    public void setSwitchToSearchingWhenServiceIsFull(boolean switchToSearchingWhenServiceIsFull) {
+        this.switchToSearchingWhenServiceIsFull = switchToSearchingWhenServiceIsFull;
+    }
+
+    public void setTaskLayouts(Collection<SignConfigurationTaskEntry> taskLayouts) {
+        this.taskLayouts = taskLayouts;
+    }
+
+    public void setDefaultOnlineLayout(SignLayout defaultOnlineLayout) {
+        this.defaultOnlineLayout = defaultOnlineLayout;
+    }
+
+    public void setDefaultEmptyLayout(SignLayout defaultEmptyLayout) {
+        this.defaultEmptyLayout = defaultEmptyLayout;
+    }
+
+    public void setDefaultFullLayout(SignLayout defaultFullLayout) {
+        this.defaultFullLayout = defaultFullLayout;
+    }
+
+    public void setStartingLayouts(SignLayoutConfiguration startingLayouts) {
+        this.startingLayouts = startingLayouts;
+    }
+
+    public void setSearchLayouts(SignLayoutConfiguration searchLayouts) {
+        this.searchLayouts = searchLayouts;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SignConfigurationEntry)) return false;
+        final SignConfigurationEntry other = (SignConfigurationEntry) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$targetGroup = this.getTargetGroup();
+        final Object other$targetGroup = other.getTargetGroup();
+        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
+            return false;
+        if (this.isSwitchToSearchingWhenServiceIsFull() != other.isSwitchToSearchingWhenServiceIsFull()) return false;
+        final Object this$taskLayouts = this.getTaskLayouts();
+        final Object other$taskLayouts = other.getTaskLayouts();
+        if (this$taskLayouts == null ? other$taskLayouts != null : !this$taskLayouts.equals(other$taskLayouts))
+            return false;
+        final Object this$defaultOnlineLayout = this.getDefaultOnlineLayout();
+        final Object other$defaultOnlineLayout = other.getDefaultOnlineLayout();
+        if (this$defaultOnlineLayout == null ? other$defaultOnlineLayout != null : !this$defaultOnlineLayout.equals(other$defaultOnlineLayout))
+            return false;
+        final Object this$defaultEmptyLayout = this.getDefaultEmptyLayout();
+        final Object other$defaultEmptyLayout = other.getDefaultEmptyLayout();
+        if (this$defaultEmptyLayout == null ? other$defaultEmptyLayout != null : !this$defaultEmptyLayout.equals(other$defaultEmptyLayout))
+            return false;
+        final Object this$defaultFullLayout = this.getDefaultFullLayout();
+        final Object other$defaultFullLayout = other.getDefaultFullLayout();
+        if (this$defaultFullLayout == null ? other$defaultFullLayout != null : !this$defaultFullLayout.equals(other$defaultFullLayout))
+            return false;
+        final Object this$startingLayouts = this.getStartingLayouts();
+        final Object other$startingLayouts = other.getStartingLayouts();
+        if (this$startingLayouts == null ? other$startingLayouts != null : !this$startingLayouts.equals(other$startingLayouts))
+            return false;
+        final Object this$searchLayouts = this.getSearchLayouts();
+        final Object other$searchLayouts = other.getSearchLayouts();
+        if (this$searchLayouts == null ? other$searchLayouts != null : !this$searchLayouts.equals(other$searchLayouts))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SignConfigurationEntry;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $targetGroup = this.getTargetGroup();
+        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
+        result = result * PRIME + (this.isSwitchToSearchingWhenServiceIsFull() ? 79 : 97);
+        final Object $taskLayouts = this.getTaskLayouts();
+        result = result * PRIME + ($taskLayouts == null ? 43 : $taskLayouts.hashCode());
+        final Object $defaultOnlineLayout = this.getDefaultOnlineLayout();
+        result = result * PRIME + ($defaultOnlineLayout == null ? 43 : $defaultOnlineLayout.hashCode());
+        final Object $defaultEmptyLayout = this.getDefaultEmptyLayout();
+        result = result * PRIME + ($defaultEmptyLayout == null ? 43 : $defaultEmptyLayout.hashCode());
+        final Object $defaultFullLayout = this.getDefaultFullLayout();
+        result = result * PRIME + ($defaultFullLayout == null ? 43 : $defaultFullLayout.hashCode());
+        final Object $startingLayouts = this.getStartingLayouts();
+        result = result * PRIME + ($startingLayouts == null ? 43 : $startingLayouts.hashCode());
+        final Object $searchLayouts = this.getSearchLayouts();
+        result = result * PRIME + ($searchLayouts == null ? 43 : $searchLayouts.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SignConfigurationEntry(targetGroup=" + this.getTargetGroup() + ", switchToSearchingWhenServiceIsFull=" + this.isSwitchToSearchingWhenServiceIsFull() + ", taskLayouts=" + this.getTaskLayouts() + ", defaultOnlineLayout=" + this.getDefaultOnlineLayout() + ", defaultEmptyLayout=" + this.getDefaultEmptyLayout() + ", defaultFullLayout=" + this.getDefaultFullLayout() + ", startingLayouts=" + this.getStartingLayouts() + ", searchLayouts=" + this.getSearchLayouts() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfigurationEntry.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfigurationEntry.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.ext.signs;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.Collection;
 
+@ToString
+@EqualsAndHashCode
 public class SignConfigurationEntry {
 
     protected String targetGroup;
@@ -92,69 +97,4 @@ public class SignConfigurationEntry {
         this.searchLayouts = searchLayouts;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SignConfigurationEntry)) return false;
-        final SignConfigurationEntry other = (SignConfigurationEntry) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$targetGroup = this.getTargetGroup();
-        final Object other$targetGroup = other.getTargetGroup();
-        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
-            return false;
-        if (this.isSwitchToSearchingWhenServiceIsFull() != other.isSwitchToSearchingWhenServiceIsFull()) return false;
-        final Object this$taskLayouts = this.getTaskLayouts();
-        final Object other$taskLayouts = other.getTaskLayouts();
-        if (this$taskLayouts == null ? other$taskLayouts != null : !this$taskLayouts.equals(other$taskLayouts))
-            return false;
-        final Object this$defaultOnlineLayout = this.getDefaultOnlineLayout();
-        final Object other$defaultOnlineLayout = other.getDefaultOnlineLayout();
-        if (this$defaultOnlineLayout == null ? other$defaultOnlineLayout != null : !this$defaultOnlineLayout.equals(other$defaultOnlineLayout))
-            return false;
-        final Object this$defaultEmptyLayout = this.getDefaultEmptyLayout();
-        final Object other$defaultEmptyLayout = other.getDefaultEmptyLayout();
-        if (this$defaultEmptyLayout == null ? other$defaultEmptyLayout != null : !this$defaultEmptyLayout.equals(other$defaultEmptyLayout))
-            return false;
-        final Object this$defaultFullLayout = this.getDefaultFullLayout();
-        final Object other$defaultFullLayout = other.getDefaultFullLayout();
-        if (this$defaultFullLayout == null ? other$defaultFullLayout != null : !this$defaultFullLayout.equals(other$defaultFullLayout))
-            return false;
-        final Object this$startingLayouts = this.getStartingLayouts();
-        final Object other$startingLayouts = other.getStartingLayouts();
-        if (this$startingLayouts == null ? other$startingLayouts != null : !this$startingLayouts.equals(other$startingLayouts))
-            return false;
-        final Object this$searchLayouts = this.getSearchLayouts();
-        final Object other$searchLayouts = other.getSearchLayouts();
-        if (this$searchLayouts == null ? other$searchLayouts != null : !this$searchLayouts.equals(other$searchLayouts))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SignConfigurationEntry;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $targetGroup = this.getTargetGroup();
-        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
-        result = result * PRIME + (this.isSwitchToSearchingWhenServiceIsFull() ? 79 : 97);
-        final Object $taskLayouts = this.getTaskLayouts();
-        result = result * PRIME + ($taskLayouts == null ? 43 : $taskLayouts.hashCode());
-        final Object $defaultOnlineLayout = this.getDefaultOnlineLayout();
-        result = result * PRIME + ($defaultOnlineLayout == null ? 43 : $defaultOnlineLayout.hashCode());
-        final Object $defaultEmptyLayout = this.getDefaultEmptyLayout();
-        result = result * PRIME + ($defaultEmptyLayout == null ? 43 : $defaultEmptyLayout.hashCode());
-        final Object $defaultFullLayout = this.getDefaultFullLayout();
-        result = result * PRIME + ($defaultFullLayout == null ? 43 : $defaultFullLayout.hashCode());
-        final Object $startingLayouts = this.getStartingLayouts();
-        result = result * PRIME + ($startingLayouts == null ? 43 : $startingLayouts.hashCode());
-        final Object $searchLayouts = this.getSearchLayouts();
-        result = result * PRIME + ($searchLayouts == null ? 43 : $searchLayouts.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SignConfigurationEntry(targetGroup=" + this.getTargetGroup() + ", switchToSearchingWhenServiceIsFull=" + this.isSwitchToSearchingWhenServiceIsFull() + ", taskLayouts=" + this.getTaskLayouts() + ", defaultOnlineLayout=" + this.getDefaultOnlineLayout() + ", defaultEmptyLayout=" + this.getDefaultEmptyLayout() + ", defaultFullLayout=" + this.getDefaultFullLayout() + ", startingLayouts=" + this.getStartingLayouts() + ", searchLayouts=" + this.getSearchLayouts() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfigurationTaskEntry.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfigurationTaskEntry.java
@@ -1,16 +1,95 @@
 package de.dytanic.cloudnet.ext.signs;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SignConfigurationTaskEntry {
 
     protected String task;
 
     protected SignLayout onlineLayout, emptyLayout, fullLayout;
 
+    public SignConfigurationTaskEntry(String task, SignLayout onlineLayout, SignLayout emptyLayout, SignLayout fullLayout) {
+        this.task = task;
+        this.onlineLayout = onlineLayout;
+        this.emptyLayout = emptyLayout;
+        this.fullLayout = fullLayout;
+    }
+
+    public SignConfigurationTaskEntry() {
+    }
+
+    public String getTask() {
+        return this.task;
+    }
+
+    public SignLayout getOnlineLayout() {
+        return this.onlineLayout;
+    }
+
+    public SignLayout getEmptyLayout() {
+        return this.emptyLayout;
+    }
+
+    public SignLayout getFullLayout() {
+        return this.fullLayout;
+    }
+
+    public void setTask(String task) {
+        this.task = task;
+    }
+
+    public void setOnlineLayout(SignLayout onlineLayout) {
+        this.onlineLayout = onlineLayout;
+    }
+
+    public void setEmptyLayout(SignLayout emptyLayout) {
+        this.emptyLayout = emptyLayout;
+    }
+
+    public void setFullLayout(SignLayout fullLayout) {
+        this.fullLayout = fullLayout;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SignConfigurationTaskEntry)) return false;
+        final SignConfigurationTaskEntry other = (SignConfigurationTaskEntry) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$task = this.getTask();
+        final Object other$task = other.getTask();
+        if (this$task == null ? other$task != null : !this$task.equals(other$task)) return false;
+        final Object this$onlineLayout = this.getOnlineLayout();
+        final Object other$onlineLayout = other.getOnlineLayout();
+        if (this$onlineLayout == null ? other$onlineLayout != null : !this$onlineLayout.equals(other$onlineLayout))
+            return false;
+        final Object this$emptyLayout = this.getEmptyLayout();
+        final Object other$emptyLayout = other.getEmptyLayout();
+        if (this$emptyLayout == null ? other$emptyLayout != null : !this$emptyLayout.equals(other$emptyLayout))
+            return false;
+        final Object this$fullLayout = this.getFullLayout();
+        final Object other$fullLayout = other.getFullLayout();
+        if (this$fullLayout == null ? other$fullLayout != null : !this$fullLayout.equals(other$fullLayout))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SignConfigurationTaskEntry;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $task = this.getTask();
+        result = result * PRIME + ($task == null ? 43 : $task.hashCode());
+        final Object $onlineLayout = this.getOnlineLayout();
+        result = result * PRIME + ($onlineLayout == null ? 43 : $onlineLayout.hashCode());
+        final Object $emptyLayout = this.getEmptyLayout();
+        result = result * PRIME + ($emptyLayout == null ? 43 : $emptyLayout.hashCode());
+        final Object $fullLayout = this.getFullLayout();
+        result = result * PRIME + ($fullLayout == null ? 43 : $fullLayout.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SignConfigurationTaskEntry(task=" + this.getTask() + ", onlineLayout=" + this.getOnlineLayout() + ", emptyLayout=" + this.getEmptyLayout() + ", fullLayout=" + this.getFullLayout() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfigurationTaskEntry.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignConfigurationTaskEntry.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.ext.signs;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class SignConfigurationTaskEntry {
 
     protected String task;
@@ -48,48 +53,4 @@ public class SignConfigurationTaskEntry {
         this.fullLayout = fullLayout;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SignConfigurationTaskEntry)) return false;
-        final SignConfigurationTaskEntry other = (SignConfigurationTaskEntry) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$task = this.getTask();
-        final Object other$task = other.getTask();
-        if (this$task == null ? other$task != null : !this$task.equals(other$task)) return false;
-        final Object this$onlineLayout = this.getOnlineLayout();
-        final Object other$onlineLayout = other.getOnlineLayout();
-        if (this$onlineLayout == null ? other$onlineLayout != null : !this$onlineLayout.equals(other$onlineLayout))
-            return false;
-        final Object this$emptyLayout = this.getEmptyLayout();
-        final Object other$emptyLayout = other.getEmptyLayout();
-        if (this$emptyLayout == null ? other$emptyLayout != null : !this$emptyLayout.equals(other$emptyLayout))
-            return false;
-        final Object this$fullLayout = this.getFullLayout();
-        final Object other$fullLayout = other.getFullLayout();
-        if (this$fullLayout == null ? other$fullLayout != null : !this$fullLayout.equals(other$fullLayout))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SignConfigurationTaskEntry;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $task = this.getTask();
-        result = result * PRIME + ($task == null ? 43 : $task.hashCode());
-        final Object $onlineLayout = this.getOnlineLayout();
-        result = result * PRIME + ($onlineLayout == null ? 43 : $onlineLayout.hashCode());
-        final Object $emptyLayout = this.getEmptyLayout();
-        result = result * PRIME + ($emptyLayout == null ? 43 : $emptyLayout.hashCode());
-        final Object $fullLayout = this.getFullLayout();
-        result = result * PRIME + ($fullLayout == null ? 43 : $fullLayout.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SignConfigurationTaskEntry(task=" + this.getTask() + ", onlineLayout=" + this.getOnlineLayout() + ", emptyLayout=" + this.getEmptyLayout() + ", fullLayout=" + this.getFullLayout() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignLayout.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignLayout.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.ext.signs;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class SignLayout {
 
     protected String[] lines;
@@ -41,34 +46,4 @@ public class SignLayout {
         this.subId = subId;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SignLayout)) return false;
-        final SignLayout other = (SignLayout) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (!java.util.Arrays.deepEquals(this.getLines(), other.getLines())) return false;
-        final Object this$blockType = this.getBlockType();
-        final Object other$blockType = other.getBlockType();
-        if (this$blockType == null ? other$blockType != null : !this$blockType.equals(other$blockType)) return false;
-        if (this.getSubId() != other.getSubId()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SignLayout;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getLines());
-        final Object $blockType = this.getBlockType();
-        result = result * PRIME + ($blockType == null ? 43 : $blockType.hashCode());
-        result = result * PRIME + this.getSubId();
-        return result;
-    }
-
-    public String toString() {
-        return "SignLayout(lines=" + java.util.Arrays.deepToString(this.getLines()) + ", blockType=" + this.getBlockType() + ", subId=" + this.getSubId() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignLayout.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignLayout.java
@@ -1,12 +1,5 @@
 package de.dytanic.cloudnet.ext.signs;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SignLayout {
 
     protected String[] lines;
@@ -15,4 +8,67 @@ public class SignLayout {
 
     protected int subId;
 
+    public SignLayout(String[] lines, String blockType, int subId) {
+        this.lines = lines;
+        this.blockType = blockType;
+        this.subId = subId;
+    }
+
+    public SignLayout() {
+    }
+
+    public String[] getLines() {
+        return this.lines;
+    }
+
+    public String getBlockType() {
+        return this.blockType;
+    }
+
+    public int getSubId() {
+        return this.subId;
+    }
+
+    public void setLines(String[] lines) {
+        this.lines = lines;
+    }
+
+    public void setBlockType(String blockType) {
+        this.blockType = blockType;
+    }
+
+    public void setSubId(int subId) {
+        this.subId = subId;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SignLayout)) return false;
+        final SignLayout other = (SignLayout) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (!java.util.Arrays.deepEquals(this.getLines(), other.getLines())) return false;
+        final Object this$blockType = this.getBlockType();
+        final Object other$blockType = other.getBlockType();
+        if (this$blockType == null ? other$blockType != null : !this$blockType.equals(other$blockType)) return false;
+        if (this.getSubId() != other.getSubId()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SignLayout;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getLines());
+        final Object $blockType = this.getBlockType();
+        result = result * PRIME + ($blockType == null ? 43 : $blockType.hashCode());
+        result = result * PRIME + this.getSubId();
+        return result;
+    }
+
+    public String toString() {
+        return "SignLayout(lines=" + java.util.Arrays.deepToString(this.getLines()) + ", blockType=" + this.getBlockType() + ", subId=" + this.getSubId() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignLayoutConfiguration.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignLayoutConfiguration.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.ext.signs;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
+@ToString
+@EqualsAndHashCode
 public class SignLayoutConfiguration {
 
     protected List<SignLayout> signLayouts;
@@ -32,33 +37,4 @@ public class SignLayoutConfiguration {
         this.animationsPerSecond = animationsPerSecond;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SignLayoutConfiguration)) return false;
-        final SignLayoutConfiguration other = (SignLayoutConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$signLayouts = this.getSignLayouts();
-        final Object other$signLayouts = other.getSignLayouts();
-        if (this$signLayouts == null ? other$signLayouts != null : !this$signLayouts.equals(other$signLayouts))
-            return false;
-        if (this.getAnimationsPerSecond() != other.getAnimationsPerSecond()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SignLayoutConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $signLayouts = this.getSignLayouts();
-        result = result * PRIME + ($signLayouts == null ? 43 : $signLayouts.hashCode());
-        result = result * PRIME + this.getAnimationsPerSecond();
-        return result;
-    }
-
-    public String toString() {
-        return "SignLayoutConfiguration(signLayouts=" + this.getSignLayouts() + ", animationsPerSecond=" + this.getAnimationsPerSecond() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignLayoutConfiguration.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignLayoutConfiguration.java
@@ -1,18 +1,64 @@
 package de.dytanic.cloudnet.ext.signs;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.List;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SignLayoutConfiguration {
 
     protected List<SignLayout> signLayouts;
 
     protected int animationsPerSecond;
 
+    public SignLayoutConfiguration(List<SignLayout> signLayouts, int animationsPerSecond) {
+        this.signLayouts = signLayouts;
+        this.animationsPerSecond = animationsPerSecond;
+    }
+
+    public SignLayoutConfiguration() {
+    }
+
+    public List<SignLayout> getSignLayouts() {
+        return this.signLayouts;
+    }
+
+    public int getAnimationsPerSecond() {
+        return this.animationsPerSecond;
+    }
+
+    public void setSignLayouts(List<SignLayout> signLayouts) {
+        this.signLayouts = signLayouts;
+    }
+
+    public void setAnimationsPerSecond(int animationsPerSecond) {
+        this.animationsPerSecond = animationsPerSecond;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SignLayoutConfiguration)) return false;
+        final SignLayoutConfiguration other = (SignLayoutConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$signLayouts = this.getSignLayouts();
+        final Object other$signLayouts = other.getSignLayouts();
+        if (this$signLayouts == null ? other$signLayouts != null : !this$signLayouts.equals(other$signLayouts))
+            return false;
+        if (this.getAnimationsPerSecond() != other.getAnimationsPerSecond()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SignLayoutConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $signLayouts = this.getSignLayouts();
+        result = result * PRIME + ($signLayouts == null ? 43 : $signLayouts.hashCode());
+        result = result * PRIME + this.getAnimationsPerSecond();
+        return result;
+    }
+
+    public String toString() {
+        return "SignLayoutConfiguration(signLayouts=" + this.getSignLayouts() + ", animationsPerSecond=" + this.getAnimationsPerSecond() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignPosition.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignPosition.java
@@ -1,16 +1,124 @@
 package de.dytanic.cloudnet.ext.signs;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SignPosition {
 
     protected double x, y, z, yaw, pitch;
 
     protected String group, world;
 
+    public SignPosition(double x, double y, double z, double yaw, double pitch, String group, String world) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.yaw = yaw;
+        this.pitch = pitch;
+        this.group = group;
+        this.world = world;
+    }
+
+    public SignPosition() {
+    }
+
+    public double getX() {
+        return this.x;
+    }
+
+    public double getY() {
+        return this.y;
+    }
+
+    public double getZ() {
+        return this.z;
+    }
+
+    public double getYaw() {
+        return this.yaw;
+    }
+
+    public double getPitch() {
+        return this.pitch;
+    }
+
+    public String getGroup() {
+        return this.group;
+    }
+
+    public String getWorld() {
+        return this.world;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public void setZ(double z) {
+        this.z = z;
+    }
+
+    public void setYaw(double yaw) {
+        this.yaw = yaw;
+    }
+
+    public void setPitch(double pitch) {
+        this.pitch = pitch;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public void setWorld(String world) {
+        this.world = world;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SignPosition)) return false;
+        final SignPosition other = (SignPosition) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (Double.compare(this.getX(), other.getX()) != 0) return false;
+        if (Double.compare(this.getY(), other.getY()) != 0) return false;
+        if (Double.compare(this.getZ(), other.getZ()) != 0) return false;
+        if (Double.compare(this.getYaw(), other.getYaw()) != 0) return false;
+        if (Double.compare(this.getPitch(), other.getPitch()) != 0) return false;
+        final Object this$group = this.getGroup();
+        final Object other$group = other.getGroup();
+        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
+        final Object this$world = this.getWorld();
+        final Object other$world = other.getWorld();
+        if (this$world == null ? other$world != null : !this$world.equals(other$world)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SignPosition;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final long $x = Double.doubleToLongBits(this.getX());
+        result = result * PRIME + (int) ($x >>> 32 ^ $x);
+        final long $y = Double.doubleToLongBits(this.getY());
+        result = result * PRIME + (int) ($y >>> 32 ^ $y);
+        final long $z = Double.doubleToLongBits(this.getZ());
+        result = result * PRIME + (int) ($z >>> 32 ^ $z);
+        final long $yaw = Double.doubleToLongBits(this.getYaw());
+        result = result * PRIME + (int) ($yaw >>> 32 ^ $yaw);
+        final long $pitch = Double.doubleToLongBits(this.getPitch());
+        result = result * PRIME + (int) ($pitch >>> 32 ^ $pitch);
+        final Object $group = this.getGroup();
+        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
+        final Object $world = this.getWorld();
+        result = result * PRIME + ($world == null ? 43 : $world.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SignPosition(x=" + this.getX() + ", y=" + this.getY() + ", z=" + this.getZ() + ", yaw=" + this.getYaw() + ", pitch=" + this.getPitch() + ", group=" + this.getGroup() + ", world=" + this.getWorld() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignPosition.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/SignPosition.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.ext.signs;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class SignPosition {
 
     protected double x, y, z, yaw, pitch;
@@ -75,50 +80,4 @@ public class SignPosition {
         this.world = world;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SignPosition)) return false;
-        final SignPosition other = (SignPosition) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (Double.compare(this.getX(), other.getX()) != 0) return false;
-        if (Double.compare(this.getY(), other.getY()) != 0) return false;
-        if (Double.compare(this.getZ(), other.getZ()) != 0) return false;
-        if (Double.compare(this.getYaw(), other.getYaw()) != 0) return false;
-        if (Double.compare(this.getPitch(), other.getPitch()) != 0) return false;
-        final Object this$group = this.getGroup();
-        final Object other$group = other.getGroup();
-        if (this$group == null ? other$group != null : !this$group.equals(other$group)) return false;
-        final Object this$world = this.getWorld();
-        final Object other$world = other.getWorld();
-        if (this$world == null ? other$world != null : !this$world.equals(other$world)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SignPosition;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final long $x = Double.doubleToLongBits(this.getX());
-        result = result * PRIME + (int) ($x >>> 32 ^ $x);
-        final long $y = Double.doubleToLongBits(this.getY());
-        result = result * PRIME + (int) ($y >>> 32 ^ $y);
-        final long $z = Double.doubleToLongBits(this.getZ());
-        result = result * PRIME + (int) ($z >>> 32 ^ $z);
-        final long $yaw = Double.doubleToLongBits(this.getYaw());
-        result = result * PRIME + (int) ($yaw >>> 32 ^ $yaw);
-        final long $pitch = Double.doubleToLongBits(this.getPitch());
-        result = result * PRIME + (int) ($pitch >>> 32 ^ $pitch);
-        final Object $group = this.getGroup();
-        result = result * PRIME + ($group == null ? 43 : $group.hashCode());
-        final Object $world = this.getWorld();
-        result = result * PRIME + ($world == null ? 43 : $world.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SignPosition(x=" + this.getX() + ", y=" + this.getY() + ", z=" + this.getZ() + ", yaw=" + this.getYaw() + ", pitch=" + this.getPitch() + ", group=" + this.getGroup() + ", world=" + this.getWorld() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/bukkit/BukkitCloudNetSignsPlugin.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/bukkit/BukkitCloudNetSignsPlugin.java
@@ -5,17 +5,19 @@ import de.dytanic.cloudnet.ext.signs.bukkit.command.CommandCloudSign;
 import de.dytanic.cloudnet.ext.signs.bukkit.listener.BukkitCloudNetSignListener;
 import de.dytanic.cloudnet.ext.signs.bukkit.listener.BukkitSignInteractionListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class BukkitCloudNetSignsPlugin extends JavaPlugin {
 
-    @Getter
     private static BukkitCloudNetSignsPlugin instance;
 
     public BukkitCloudNetSignsPlugin() {
         instance = this;
+    }
+
+    public static BukkitCloudNetSignsPlugin getInstance() {
+        return BukkitCloudNetSignsPlugin.instance;
     }
 
     @Override

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/bukkit/BukkitSignManagement.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/bukkit/BukkitSignManagement.java
@@ -11,8 +11,6 @@ import de.dytanic.cloudnet.driver.service.ServiceLifeCycle;
 import de.dytanic.cloudnet.driver.service.ServiceTemplate;
 import de.dytanic.cloudnet.ext.signs.*;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -25,13 +23,11 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
-@Getter
 public final class BukkitSignManagement extends AbstractSignManagement {
 
     private static final Comparator<Map.Entry<UUID, Pair<ServiceInfoSnapshot, ServiceInfoState>>>
             ENTRY_COMPARATOR = new ServiceInfoSnapshotEntryComparator(),
             ENTRY_COMPARATOR_2 = new ServiceInfoSnapshotEntryComparator2();
-    @Getter
     private static BukkitSignManagement instance;
     private final Map<UUID, Pair<ServiceInfoSnapshot, ServiceInfoState>> services = Maps.newConcurrentHashMap();
 
@@ -51,6 +47,10 @@ public final class BukkitSignManagement extends AbstractSignManagement {
 
         this.executeSearchingTask();
         this.executeStartingTask();
+    }
+
+    public static BukkitSignManagement getInstance() {
+        return BukkitSignManagement.instance;
     }
 
     @Override
@@ -588,8 +588,18 @@ public final class BukkitSignManagement extends AbstractSignManagement {
         CloudNetDriver.getInstance().getTaskScheduler().schedule(this::updateSigns);
     }
 
-    @Getter
-    @AllArgsConstructor
+    public Map<UUID, Pair<ServiceInfoSnapshot, ServiceInfoState>> getServices() {
+        return this.services;
+    }
+
+    public BukkitCloudNetSignsPlugin getPlugin() {
+        return this.plugin;
+    }
+
+    public AtomicInteger[] getIndexes() {
+        return this.indexes;
+    }
+
     private enum ServiceInfoState {
         STOPPED(0),
         STARTING(1),
@@ -599,6 +609,13 @@ public final class BukkitSignManagement extends AbstractSignManagement {
 
         private final int value;
 
+        private ServiceInfoState(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return this.value;
+        }
     }
 
     private static final class ServiceInfoSnapshotEntryComparator implements Comparator<Map.Entry<UUID, Pair<ServiceInfoSnapshot, ServiceInfoState>>> {

--- a/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/node/CloudNetSignsModule.java
+++ b/cloudnet-modules/cloudnet-signs/src/main/java/de/dytanic/cloudnet/ext/signs/node/CloudNetSignsModule.java
@@ -16,8 +16,6 @@ import de.dytanic.cloudnet.ext.signs.node.http.V1SignConfigurationHttpHandler;
 import de.dytanic.cloudnet.ext.signs.node.listener.CloudNetSignsModuleListener;
 import de.dytanic.cloudnet.ext.signs.node.listener.IncludePluginListener;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.io.File;
 import java.util.Collection;
@@ -27,18 +25,18 @@ public final class CloudNetSignsModule extends NodeCloudNetModule {
 
     private static final String SIGN_STORE_DOCUMENT = "signs_store";
 
-    @Getter
     private static CloudNetSignsModule instance;
 
-    @Getter
-    @Setter
     private SignConfiguration signConfiguration;
 
-    @Getter
     private File configurationFile;
 
     public CloudNetSignsModule() {
         instance = this;
+    }
+
+    public static CloudNetSignsModule getInstance() {
+        return CloudNetSignsModule.instance;
     }
 
     @ModuleTask(order = 127, event = ModuleLifeCycle.STARTED)
@@ -108,5 +106,17 @@ public final class CloudNetSignsModule extends NodeCloudNetModule {
             document = new JsonDocument();
 
         database.update(SIGN_STORE_DOCUMENT, document.append("signs", signs));
+    }
+
+    public SignConfiguration getSignConfiguration() {
+        return this.signConfiguration;
+    }
+
+    public File getConfigurationFile() {
+        return this.configurationFile;
+    }
+
+    public void setSignConfiguration(SignConfiguration signConfiguration) {
+        this.signConfiguration = signConfiguration;
     }
 }

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetServiceSmartProfile.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetServiceSmartProfile.java
@@ -1,10 +1,14 @@
 package de.dytanic.cloudnet.ext.smart;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public final class CloudNetServiceSmartProfile extends BasicJsonDocPropertyable {
 
     private final UUID uniqueId;
@@ -24,36 +28,4 @@ public final class CloudNetServiceSmartProfile extends BasicJsonDocPropertyable 
         return this.autoStopCount;
     }
 
-    public String toString() {
-        return "CloudNetServiceSmartProfile(uniqueId=" + this.getUniqueId() + ", autoStopCount=" + this.getAutoStopCount() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof CloudNetServiceSmartProfile)) return false;
-        final CloudNetServiceSmartProfile other = (CloudNetServiceSmartProfile) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$uniqueId = this.getUniqueId();
-        final Object other$uniqueId = other.getUniqueId();
-        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
-        final Object this$autoStopCount = this.getAutoStopCount();
-        final Object other$autoStopCount = other.getAutoStopCount();
-        if (this$autoStopCount == null ? other$autoStopCount != null : !this$autoStopCount.equals(other$autoStopCount))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof CloudNetServiceSmartProfile;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uniqueId = this.getUniqueId();
-        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
-        final Object $autoStopCount = this.getAutoStopCount();
-        result = result * PRIME + ($autoStopCount == null ? 43 : $autoStopCount.hashCode());
-        return result;
-    }
 }

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetServiceSmartProfile.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetServiceSmartProfile.java
@@ -1,20 +1,59 @@
 package de.dytanic.cloudnet.ext.smart;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@Data
-@RequiredArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public final class CloudNetServiceSmartProfile extends BasicJsonDocPropertyable {
 
     private final UUID uniqueId;
 
     private final AtomicInteger autoStopCount;
 
+    public CloudNetServiceSmartProfile(UUID uniqueId, AtomicInteger autoStopCount) {
+        this.uniqueId = uniqueId;
+        this.autoStopCount = autoStopCount;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public AtomicInteger getAutoStopCount() {
+        return this.autoStopCount;
+    }
+
+    public String toString() {
+        return "CloudNetServiceSmartProfile(uniqueId=" + this.getUniqueId() + ", autoStopCount=" + this.getAutoStopCount() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CloudNetServiceSmartProfile)) return false;
+        final CloudNetServiceSmartProfile other = (CloudNetServiceSmartProfile) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$uniqueId = this.getUniqueId();
+        final Object other$uniqueId = other.getUniqueId();
+        if (this$uniqueId == null ? other$uniqueId != null : !this$uniqueId.equals(other$uniqueId)) return false;
+        final Object this$autoStopCount = this.getAutoStopCount();
+        final Object other$autoStopCount = other.getAutoStopCount();
+        if (this$autoStopCount == null ? other$autoStopCount != null : !this$autoStopCount.equals(other$autoStopCount))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof CloudNetServiceSmartProfile;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $uniqueId = this.getUniqueId();
+        result = result * PRIME + ($uniqueId == null ? 43 : $uniqueId.hashCode());
+        final Object $autoStopCount = this.getAutoStopCount();
+        result = result * PRIME + ($autoStopCount == null ? 43 : $autoStopCount.hashCode());
+        return result;
+    }
 }

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetSmartModule.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetSmartModule.java
@@ -18,20 +18,17 @@ import de.dytanic.cloudnet.ext.smart.listener.CloudServiceListener;
 import de.dytanic.cloudnet.ext.smart.template.TemplateInstaller;
 import de.dytanic.cloudnet.ext.smart.util.SmartServiceTaskConfig;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
-import lombok.Getter;
 
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
-@Getter
 public final class CloudNetSmartModule extends NodeCloudNetModule {
 
     private static final Type SMART_SERVICE_TASKS_CONFIGURATIONS = new TypeToken<Collection<SmartServiceTaskConfig>>() {
     }.getType();
 
-    @Getter
     private static CloudNetSmartModule instance;
 
     private final Map<UUID, CloudNetServiceSmartProfile> providedSmartServices = Maps.newConcurrentHashMap();
@@ -42,6 +39,10 @@ public final class CloudNetSmartModule extends NodeCloudNetModule {
 
     public CloudNetSmartModule() {
         instance = this;
+    }
+
+    public static CloudNetSmartModule getInstance() {
+        return CloudNetSmartModule.instance;
     }
 
     @ModuleTask(order = 127, event = ModuleLifeCycle.STARTED)
@@ -200,5 +201,13 @@ public final class CloudNetSmartModule extends NodeCloudNetModule {
 
         getConfig().append("smartTasks", configs);
         saveConfig();
+    }
+
+    public Map<UUID, CloudNetServiceSmartProfile> getProvidedSmartServices() {
+        return this.providedSmartServices;
+    }
+
+    public Collection<SmartServiceTaskConfig> getSmartServiceTaskConfigurations() {
+        return this.smartServiceTaskConfigurations;
     }
 }

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/util/SmartServiceTaskConfig.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/util/SmartServiceTaskConfig.java
@@ -1,7 +1,11 @@
 package de.dytanic.cloudnet.ext.smart.util;
 
 import de.dytanic.cloudnet.ext.smart.template.TemplateInstaller;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
+@ToString
+@EqualsAndHashCode
 public class SmartServiceTaskConfig implements Comparable<SmartServiceTaskConfig> {
 
     protected String task;
@@ -155,62 +159,4 @@ public class SmartServiceTaskConfig implements Comparable<SmartServiceTaskConfig
         this.templateInstaller = templateInstaller;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SmartServiceTaskConfig)) return false;
-        final SmartServiceTaskConfig other = (SmartServiceTaskConfig) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$task = this.getTask();
-        final Object other$task = other.getTask();
-        if (this$task == null ? other$task != null : !this$task.equals(other$task)) return false;
-        if (this.getPriority() != other.getPriority()) return false;
-        if (this.isDirectTemplatesAndInclusionsSetup() != other.isDirectTemplatesAndInclusionsSetup()) return false;
-        if (this.getPreparedServices() != other.getPreparedServices()) return false;
-        if (this.getMinServiceOnlineCount() != other.getMinServiceOnlineCount()) return false;
-        if (this.isDynamicMemoryAllocation() != other.isDynamicMemoryAllocation()) return false;
-        if (this.getDynamicMemoryAllocationRange() != other.getDynamicMemoryAllocationRange()) return false;
-        if (this.getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture() != other.getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture())
-            return false;
-        if (this.getAutoStopTimeByUnusedServiceInSeconds() != other.getAutoStopTimeByUnusedServiceInSeconds())
-            return false;
-        if (this.isSwitchToPreparedServiceAfterAutoStopTimeByUnusedService() != other.isSwitchToPreparedServiceAfterAutoStopTimeByUnusedService())
-            return false;
-        if (this.getPercentOfPlayersForANewServiceByInstance() != other.getPercentOfPlayersForANewServiceByInstance())
-            return false;
-        if (this.getForAnewInstanceDelayTimeInSeconds() != other.getForAnewInstanceDelayTimeInSeconds()) return false;
-        final Object this$templateInstaller = this.getTemplateInstaller();
-        final Object other$templateInstaller = other.getTemplateInstaller();
-        if (this$templateInstaller == null ? other$templateInstaller != null : !this$templateInstaller.equals(other$templateInstaller))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SmartServiceTaskConfig;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $task = this.getTask();
-        result = result * PRIME + ($task == null ? 43 : $task.hashCode());
-        result = result * PRIME + this.getPriority();
-        result = result * PRIME + (this.isDirectTemplatesAndInclusionsSetup() ? 79 : 97);
-        result = result * PRIME + this.getPreparedServices();
-        result = result * PRIME + this.getMinServiceOnlineCount();
-        result = result * PRIME + (this.isDynamicMemoryAllocation() ? 79 : 97);
-        result = result * PRIME + this.getDynamicMemoryAllocationRange();
-        result = result * PRIME + this.getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture();
-        result = result * PRIME + this.getAutoStopTimeByUnusedServiceInSeconds();
-        result = result * PRIME + (this.isSwitchToPreparedServiceAfterAutoStopTimeByUnusedService() ? 79 : 97);
-        result = result * PRIME + this.getPercentOfPlayersForANewServiceByInstance();
-        result = result * PRIME + this.getForAnewInstanceDelayTimeInSeconds();
-        final Object $templateInstaller = this.getTemplateInstaller();
-        result = result * PRIME + ($templateInstaller == null ? 43 : $templateInstaller.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SmartServiceTaskConfig(task=" + this.getTask() + ", priority=" + this.getPriority() + ", directTemplatesAndInclusionsSetup=" + this.isDirectTemplatesAndInclusionsSetup() + ", preparedServices=" + this.getPreparedServices() + ", minServiceOnlineCount=" + this.getMinServiceOnlineCount() + ", dynamicMemoryAllocation=" + this.isDynamicMemoryAllocation() + ", dynamicMemoryAllocationRange=" + this.getDynamicMemoryAllocationRange() + ", percentOfPlayersToCheckShouldAutoStopTheServiceInFuture=" + this.getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture() + ", autoStopTimeByUnusedServiceInSeconds=" + this.getAutoStopTimeByUnusedServiceInSeconds() + ", switchToPreparedServiceAfterAutoStopTimeByUnusedService=" + this.isSwitchToPreparedServiceAfterAutoStopTimeByUnusedService() + ", percentOfPlayersForANewServiceByInstance=" + this.getPercentOfPlayersForANewServiceByInstance() + ", forAnewInstanceDelayTimeInSeconds=" + this.getForAnewInstanceDelayTimeInSeconds() + ", templateInstaller=" + this.getTemplateInstaller() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/util/SmartServiceTaskConfig.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/util/SmartServiceTaskConfig.java
@@ -1,11 +1,7 @@
 package de.dytanic.cloudnet.ext.smart.util;
 
 import de.dytanic.cloudnet.ext.smart.template.TemplateInstaller;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
-@Data
-@AllArgsConstructor
 public class SmartServiceTaskConfig implements Comparable<SmartServiceTaskConfig> {
 
     protected String task;
@@ -34,8 +30,187 @@ public class SmartServiceTaskConfig implements Comparable<SmartServiceTaskConfig
 
     protected TemplateInstaller templateInstaller;
 
+    public SmartServiceTaskConfig(String task, int priority, boolean directTemplatesAndInclusionsSetup, int preparedServices, int minServiceOnlineCount, boolean dynamicMemoryAllocation, int dynamicMemoryAllocationRange, int percentOfPlayersToCheckShouldAutoStopTheServiceInFuture, int autoStopTimeByUnusedServiceInSeconds, boolean switchToPreparedServiceAfterAutoStopTimeByUnusedService, int percentOfPlayersForANewServiceByInstance, int forAnewInstanceDelayTimeInSeconds, TemplateInstaller templateInstaller) {
+        this.task = task;
+        this.priority = priority;
+        this.directTemplatesAndInclusionsSetup = directTemplatesAndInclusionsSetup;
+        this.preparedServices = preparedServices;
+        this.minServiceOnlineCount = minServiceOnlineCount;
+        this.dynamicMemoryAllocation = dynamicMemoryAllocation;
+        this.dynamicMemoryAllocationRange = dynamicMemoryAllocationRange;
+        this.percentOfPlayersToCheckShouldAutoStopTheServiceInFuture = percentOfPlayersToCheckShouldAutoStopTheServiceInFuture;
+        this.autoStopTimeByUnusedServiceInSeconds = autoStopTimeByUnusedServiceInSeconds;
+        this.switchToPreparedServiceAfterAutoStopTimeByUnusedService = switchToPreparedServiceAfterAutoStopTimeByUnusedService;
+        this.percentOfPlayersForANewServiceByInstance = percentOfPlayersForANewServiceByInstance;
+        this.forAnewInstanceDelayTimeInSeconds = forAnewInstanceDelayTimeInSeconds;
+        this.templateInstaller = templateInstaller;
+    }
+
     @Override
     public int compareTo(SmartServiceTaskConfig o) {
         return priority + o.priority;
+    }
+
+    public String getTask() {
+        return this.task;
+    }
+
+    public int getPriority() {
+        return this.priority;
+    }
+
+    public boolean isDirectTemplatesAndInclusionsSetup() {
+        return this.directTemplatesAndInclusionsSetup;
+    }
+
+    public int getPreparedServices() {
+        return this.preparedServices;
+    }
+
+    public int getMinServiceOnlineCount() {
+        return this.minServiceOnlineCount;
+    }
+
+    public boolean isDynamicMemoryAllocation() {
+        return this.dynamicMemoryAllocation;
+    }
+
+    public int getDynamicMemoryAllocationRange() {
+        return this.dynamicMemoryAllocationRange;
+    }
+
+    public int getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture() {
+        return this.percentOfPlayersToCheckShouldAutoStopTheServiceInFuture;
+    }
+
+    public int getAutoStopTimeByUnusedServiceInSeconds() {
+        return this.autoStopTimeByUnusedServiceInSeconds;
+    }
+
+    public boolean isSwitchToPreparedServiceAfterAutoStopTimeByUnusedService() {
+        return this.switchToPreparedServiceAfterAutoStopTimeByUnusedService;
+    }
+
+    public int getPercentOfPlayersForANewServiceByInstance() {
+        return this.percentOfPlayersForANewServiceByInstance;
+    }
+
+    public int getForAnewInstanceDelayTimeInSeconds() {
+        return this.forAnewInstanceDelayTimeInSeconds;
+    }
+
+    public TemplateInstaller getTemplateInstaller() {
+        return this.templateInstaller;
+    }
+
+    public void setTask(String task) {
+        this.task = task;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public void setDirectTemplatesAndInclusionsSetup(boolean directTemplatesAndInclusionsSetup) {
+        this.directTemplatesAndInclusionsSetup = directTemplatesAndInclusionsSetup;
+    }
+
+    public void setPreparedServices(int preparedServices) {
+        this.preparedServices = preparedServices;
+    }
+
+    public void setMinServiceOnlineCount(int minServiceOnlineCount) {
+        this.minServiceOnlineCount = minServiceOnlineCount;
+    }
+
+    public void setDynamicMemoryAllocation(boolean dynamicMemoryAllocation) {
+        this.dynamicMemoryAllocation = dynamicMemoryAllocation;
+    }
+
+    public void setDynamicMemoryAllocationRange(int dynamicMemoryAllocationRange) {
+        this.dynamicMemoryAllocationRange = dynamicMemoryAllocationRange;
+    }
+
+    public void setPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture(int percentOfPlayersToCheckShouldAutoStopTheServiceInFuture) {
+        this.percentOfPlayersToCheckShouldAutoStopTheServiceInFuture = percentOfPlayersToCheckShouldAutoStopTheServiceInFuture;
+    }
+
+    public void setAutoStopTimeByUnusedServiceInSeconds(int autoStopTimeByUnusedServiceInSeconds) {
+        this.autoStopTimeByUnusedServiceInSeconds = autoStopTimeByUnusedServiceInSeconds;
+    }
+
+    public void setSwitchToPreparedServiceAfterAutoStopTimeByUnusedService(boolean switchToPreparedServiceAfterAutoStopTimeByUnusedService) {
+        this.switchToPreparedServiceAfterAutoStopTimeByUnusedService = switchToPreparedServiceAfterAutoStopTimeByUnusedService;
+    }
+
+    public void setPercentOfPlayersForANewServiceByInstance(int percentOfPlayersForANewServiceByInstance) {
+        this.percentOfPlayersForANewServiceByInstance = percentOfPlayersForANewServiceByInstance;
+    }
+
+    public void setForAnewInstanceDelayTimeInSeconds(int forAnewInstanceDelayTimeInSeconds) {
+        this.forAnewInstanceDelayTimeInSeconds = forAnewInstanceDelayTimeInSeconds;
+    }
+
+    public void setTemplateInstaller(TemplateInstaller templateInstaller) {
+        this.templateInstaller = templateInstaller;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SmartServiceTaskConfig)) return false;
+        final SmartServiceTaskConfig other = (SmartServiceTaskConfig) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$task = this.getTask();
+        final Object other$task = other.getTask();
+        if (this$task == null ? other$task != null : !this$task.equals(other$task)) return false;
+        if (this.getPriority() != other.getPriority()) return false;
+        if (this.isDirectTemplatesAndInclusionsSetup() != other.isDirectTemplatesAndInclusionsSetup()) return false;
+        if (this.getPreparedServices() != other.getPreparedServices()) return false;
+        if (this.getMinServiceOnlineCount() != other.getMinServiceOnlineCount()) return false;
+        if (this.isDynamicMemoryAllocation() != other.isDynamicMemoryAllocation()) return false;
+        if (this.getDynamicMemoryAllocationRange() != other.getDynamicMemoryAllocationRange()) return false;
+        if (this.getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture() != other.getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture())
+            return false;
+        if (this.getAutoStopTimeByUnusedServiceInSeconds() != other.getAutoStopTimeByUnusedServiceInSeconds())
+            return false;
+        if (this.isSwitchToPreparedServiceAfterAutoStopTimeByUnusedService() != other.isSwitchToPreparedServiceAfterAutoStopTimeByUnusedService())
+            return false;
+        if (this.getPercentOfPlayersForANewServiceByInstance() != other.getPercentOfPlayersForANewServiceByInstance())
+            return false;
+        if (this.getForAnewInstanceDelayTimeInSeconds() != other.getForAnewInstanceDelayTimeInSeconds()) return false;
+        final Object this$templateInstaller = this.getTemplateInstaller();
+        final Object other$templateInstaller = other.getTemplateInstaller();
+        if (this$templateInstaller == null ? other$templateInstaller != null : !this$templateInstaller.equals(other$templateInstaller))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SmartServiceTaskConfig;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $task = this.getTask();
+        result = result * PRIME + ($task == null ? 43 : $task.hashCode());
+        result = result * PRIME + this.getPriority();
+        result = result * PRIME + (this.isDirectTemplatesAndInclusionsSetup() ? 79 : 97);
+        result = result * PRIME + this.getPreparedServices();
+        result = result * PRIME + this.getMinServiceOnlineCount();
+        result = result * PRIME + (this.isDynamicMemoryAllocation() ? 79 : 97);
+        result = result * PRIME + this.getDynamicMemoryAllocationRange();
+        result = result * PRIME + this.getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture();
+        result = result * PRIME + this.getAutoStopTimeByUnusedServiceInSeconds();
+        result = result * PRIME + (this.isSwitchToPreparedServiceAfterAutoStopTimeByUnusedService() ? 79 : 97);
+        result = result * PRIME + this.getPercentOfPlayersForANewServiceByInstance();
+        result = result * PRIME + this.getForAnewInstanceDelayTimeInSeconds();
+        final Object $templateInstaller = this.getTemplateInstaller();
+        result = result * PRIME + ($templateInstaller == null ? 43 : $templateInstaller.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SmartServiceTaskConfig(task=" + this.getTask() + ", priority=" + this.getPriority() + ", directTemplatesAndInclusionsSetup=" + this.isDirectTemplatesAndInclusionsSetup() + ", preparedServices=" + this.getPreparedServices() + ", minServiceOnlineCount=" + this.getMinServiceOnlineCount() + ", dynamicMemoryAllocation=" + this.isDynamicMemoryAllocation() + ", dynamicMemoryAllocationRange=" + this.getDynamicMemoryAllocationRange() + ", percentOfPlayersToCheckShouldAutoStopTheServiceInFuture=" + this.getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture() + ", autoStopTimeByUnusedServiceInSeconds=" + this.getAutoStopTimeByUnusedServiceInSeconds() + ", switchToPreparedServiceAfterAutoStopTimeByUnusedService=" + this.isSwitchToPreparedServiceAfterAutoStopTimeByUnusedService() + ", percentOfPlayersForANewServiceByInstance=" + this.getPercentOfPlayersForANewServiceByInstance() + ", forAnewInstanceDelayTimeInSeconds=" + this.getForAnewInstanceDelayTimeInSeconds() + ", templateInstaller=" + this.getTemplateInstaller() + ")";
     }
 }

--- a/cloudnet-modules/cloudnet-storage-ftp/src/main/java/de/dytanic/cloudnet/ext/storage/ftp/FTPTemplateStorage.java
+++ b/cloudnet-modules/cloudnet-storage-ftp/src/main/java/de/dytanic/cloudnet/ext/storage/ftp/FTPTemplateStorage.java
@@ -13,7 +13,6 @@ import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.driver.service.ServiceTemplate;
 import de.dytanic.cloudnet.template.ITemplateStorage;
-import lombok.Getter;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPSClient;
@@ -28,7 +27,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
-@Getter
 public final class FTPTemplateStorage implements ITemplateStorage {
 
     private static final LogLevel LOG_LEVEL = new LogLevel("ftp/ftps", "FTP/FTPS", 1, true);
@@ -428,5 +426,9 @@ public final class FTPTemplateStorage implements ITemplateStorage {
             } catch (IOException ignored) {
             }
         }
+    }
+
+    public JsonDocument getDocument() {
+        return this.document;
     }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyConfiguration.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyConfiguration.java
@@ -1,17 +1,11 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
 import com.google.gson.reflect.TypeToken;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SyncProxyConfiguration {
 
     public static final Type TYPE = new TypeToken<SyncProxyConfiguration>() {
@@ -23,4 +17,75 @@ public class SyncProxyConfiguration {
 
     protected Map<String, String> messages;
 
+    public SyncProxyConfiguration(Collection<SyncProxyProxyLoginConfiguration> loginConfigurations, Collection<SyncProxyTabListConfiguration> tabListConfigurations, Map<String, String> messages) {
+        this.loginConfigurations = loginConfigurations;
+        this.tabListConfigurations = tabListConfigurations;
+        this.messages = messages;
+    }
+
+    public SyncProxyConfiguration() {
+    }
+
+    public Collection<SyncProxyProxyLoginConfiguration> getLoginConfigurations() {
+        return this.loginConfigurations;
+    }
+
+    public Collection<SyncProxyTabListConfiguration> getTabListConfigurations() {
+        return this.tabListConfigurations;
+    }
+
+    public Map<String, String> getMessages() {
+        return this.messages;
+    }
+
+    public void setLoginConfigurations(Collection<SyncProxyProxyLoginConfiguration> loginConfigurations) {
+        this.loginConfigurations = loginConfigurations;
+    }
+
+    public void setTabListConfigurations(Collection<SyncProxyTabListConfiguration> tabListConfigurations) {
+        this.tabListConfigurations = tabListConfigurations;
+    }
+
+    public void setMessages(Map<String, String> messages) {
+        this.messages = messages;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SyncProxyConfiguration)) return false;
+        final SyncProxyConfiguration other = (SyncProxyConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$loginConfigurations = this.getLoginConfigurations();
+        final Object other$loginConfigurations = other.getLoginConfigurations();
+        if (this$loginConfigurations == null ? other$loginConfigurations != null : !this$loginConfigurations.equals(other$loginConfigurations))
+            return false;
+        final Object this$tabListConfigurations = this.getTabListConfigurations();
+        final Object other$tabListConfigurations = other.getTabListConfigurations();
+        if (this$tabListConfigurations == null ? other$tabListConfigurations != null : !this$tabListConfigurations.equals(other$tabListConfigurations))
+            return false;
+        final Object this$messages = this.getMessages();
+        final Object other$messages = other.getMessages();
+        if (this$messages == null ? other$messages != null : !this$messages.equals(other$messages)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SyncProxyConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $loginConfigurations = this.getLoginConfigurations();
+        result = result * PRIME + ($loginConfigurations == null ? 43 : $loginConfigurations.hashCode());
+        final Object $tabListConfigurations = this.getTabListConfigurations();
+        result = result * PRIME + ($tabListConfigurations == null ? 43 : $tabListConfigurations.hashCode());
+        final Object $messages = this.getMessages();
+        result = result * PRIME + ($messages == null ? 43 : $messages.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SyncProxyConfiguration(loginConfigurations=" + this.getLoginConfigurations() + ", tabListConfigurations=" + this.getTabListConfigurations() + ", messages=" + this.getMessages() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyConfiguration.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyConfiguration.java
@@ -1,11 +1,15 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
 import com.google.gson.reflect.TypeToken;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
 
+@ToString
+@EqualsAndHashCode
 public class SyncProxyConfiguration {
 
     public static final Type TYPE = new TypeToken<SyncProxyConfiguration>() {
@@ -50,42 +54,4 @@ public class SyncProxyConfiguration {
         this.messages = messages;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SyncProxyConfiguration)) return false;
-        final SyncProxyConfiguration other = (SyncProxyConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$loginConfigurations = this.getLoginConfigurations();
-        final Object other$loginConfigurations = other.getLoginConfigurations();
-        if (this$loginConfigurations == null ? other$loginConfigurations != null : !this$loginConfigurations.equals(other$loginConfigurations))
-            return false;
-        final Object this$tabListConfigurations = this.getTabListConfigurations();
-        final Object other$tabListConfigurations = other.getTabListConfigurations();
-        if (this$tabListConfigurations == null ? other$tabListConfigurations != null : !this$tabListConfigurations.equals(other$tabListConfigurations))
-            return false;
-        final Object this$messages = this.getMessages();
-        final Object other$messages = other.getMessages();
-        if (this$messages == null ? other$messages != null : !this$messages.equals(other$messages)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SyncProxyConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $loginConfigurations = this.getLoginConfigurations();
-        result = result * PRIME + ($loginConfigurations == null ? 43 : $loginConfigurations.hashCode());
-        final Object $tabListConfigurations = this.getTabListConfigurations();
-        result = result * PRIME + ($tabListConfigurations == null ? 43 : $tabListConfigurations.hashCode());
-        final Object $messages = this.getMessages();
-        result = result * PRIME + ($messages == null ? 43 : $messages.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SyncProxyConfiguration(loginConfigurations=" + this.getLoginConfigurations() + ", tabListConfigurations=" + this.getTabListConfigurations() + ", messages=" + this.getMessages() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyMotd.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyMotd.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class SyncProxyMotd {
 
     protected String firstLine, secondLine;
@@ -72,48 +77,4 @@ public class SyncProxyMotd {
         this.protocolText = protocolText;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SyncProxyMotd)) return false;
-        final SyncProxyMotd other = (SyncProxyMotd) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$firstLine = this.getFirstLine();
-        final Object other$firstLine = other.getFirstLine();
-        if (this$firstLine == null ? other$firstLine != null : !this$firstLine.equals(other$firstLine)) return false;
-        final Object this$secondLine = this.getSecondLine();
-        final Object other$secondLine = other.getSecondLine();
-        if (this$secondLine == null ? other$secondLine != null : !this$secondLine.equals(other$secondLine))
-            return false;
-        if (this.isAutoSlot() != other.isAutoSlot()) return false;
-        if (this.getAutoSlotMaxPlayersDistance() != other.getAutoSlotMaxPlayersDistance()) return false;
-        if (!java.util.Arrays.deepEquals(this.getPlayerInfo(), other.getPlayerInfo())) return false;
-        final Object this$protocolText = this.getProtocolText();
-        final Object other$protocolText = other.getProtocolText();
-        if (this$protocolText == null ? other$protocolText != null : !this$protocolText.equals(other$protocolText))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SyncProxyMotd;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $firstLine = this.getFirstLine();
-        result = result * PRIME + ($firstLine == null ? 43 : $firstLine.hashCode());
-        final Object $secondLine = this.getSecondLine();
-        result = result * PRIME + ($secondLine == null ? 43 : $secondLine.hashCode());
-        result = result * PRIME + (this.isAutoSlot() ? 79 : 97);
-        result = result * PRIME + this.getAutoSlotMaxPlayersDistance();
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getPlayerInfo());
-        final Object $protocolText = this.getProtocolText();
-        result = result * PRIME + ($protocolText == null ? 43 : $protocolText.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SyncProxyMotd(firstLine=" + this.getFirstLine() + ", secondLine=" + this.getSecondLine() + ", autoSlot=" + this.isAutoSlot() + ", autoSlotMaxPlayersDistance=" + this.getAutoSlotMaxPlayersDistance() + ", playerInfo=" + java.util.Arrays.deepToString(this.getPlayerInfo()) + ", protocolText=" + this.getProtocolText() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyMotd.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyMotd.java
@@ -1,12 +1,5 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SyncProxyMotd {
 
     protected String firstLine, secondLine;
@@ -19,4 +12,108 @@ public class SyncProxyMotd {
 
     protected String protocolText;
 
+    public SyncProxyMotd(String firstLine, String secondLine, boolean autoSlot, int autoSlotMaxPlayersDistance, String[] playerInfo, String protocolText) {
+        this.firstLine = firstLine;
+        this.secondLine = secondLine;
+        this.autoSlot = autoSlot;
+        this.autoSlotMaxPlayersDistance = autoSlotMaxPlayersDistance;
+        this.playerInfo = playerInfo;
+        this.protocolText = protocolText;
+    }
+
+    public SyncProxyMotd() {
+    }
+
+    public String getFirstLine() {
+        return this.firstLine;
+    }
+
+    public String getSecondLine() {
+        return this.secondLine;
+    }
+
+    public boolean isAutoSlot() {
+        return this.autoSlot;
+    }
+
+    public int getAutoSlotMaxPlayersDistance() {
+        return this.autoSlotMaxPlayersDistance;
+    }
+
+    public String[] getPlayerInfo() {
+        return this.playerInfo;
+    }
+
+    public String getProtocolText() {
+        return this.protocolText;
+    }
+
+    public void setFirstLine(String firstLine) {
+        this.firstLine = firstLine;
+    }
+
+    public void setSecondLine(String secondLine) {
+        this.secondLine = secondLine;
+    }
+
+    public void setAutoSlot(boolean autoSlot) {
+        this.autoSlot = autoSlot;
+    }
+
+    public void setAutoSlotMaxPlayersDistance(int autoSlotMaxPlayersDistance) {
+        this.autoSlotMaxPlayersDistance = autoSlotMaxPlayersDistance;
+    }
+
+    public void setPlayerInfo(String[] playerInfo) {
+        this.playerInfo = playerInfo;
+    }
+
+    public void setProtocolText(String protocolText) {
+        this.protocolText = protocolText;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SyncProxyMotd)) return false;
+        final SyncProxyMotd other = (SyncProxyMotd) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$firstLine = this.getFirstLine();
+        final Object other$firstLine = other.getFirstLine();
+        if (this$firstLine == null ? other$firstLine != null : !this$firstLine.equals(other$firstLine)) return false;
+        final Object this$secondLine = this.getSecondLine();
+        final Object other$secondLine = other.getSecondLine();
+        if (this$secondLine == null ? other$secondLine != null : !this$secondLine.equals(other$secondLine))
+            return false;
+        if (this.isAutoSlot() != other.isAutoSlot()) return false;
+        if (this.getAutoSlotMaxPlayersDistance() != other.getAutoSlotMaxPlayersDistance()) return false;
+        if (!java.util.Arrays.deepEquals(this.getPlayerInfo(), other.getPlayerInfo())) return false;
+        final Object this$protocolText = this.getProtocolText();
+        final Object other$protocolText = other.getProtocolText();
+        if (this$protocolText == null ? other$protocolText != null : !this$protocolText.equals(other$protocolText))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SyncProxyMotd;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $firstLine = this.getFirstLine();
+        result = result * PRIME + ($firstLine == null ? 43 : $firstLine.hashCode());
+        final Object $secondLine = this.getSecondLine();
+        result = result * PRIME + ($secondLine == null ? 43 : $secondLine.hashCode());
+        result = result * PRIME + (this.isAutoSlot() ? 79 : 97);
+        result = result * PRIME + this.getAutoSlotMaxPlayersDistance();
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getPlayerInfo());
+        final Object $protocolText = this.getProtocolText();
+        result = result * PRIME + ($protocolText == null ? 43 : $protocolText.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SyncProxyMotd(firstLine=" + this.getFirstLine() + ", secondLine=" + this.getSecondLine() + ", autoSlot=" + this.isAutoSlot() + ", autoSlotMaxPlayersDistance=" + this.getAutoSlotMaxPlayersDistance() + ", playerInfo=" + java.util.Arrays.deepToString(this.getPlayerInfo()) + ", protocolText=" + this.getProtocolText() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyProxyLoginConfiguration.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyProxyLoginConfiguration.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
+@ToString
+@EqualsAndHashCode
 public class SyncProxyProxyLoginConfiguration {
 
     protected String targetGroup;
@@ -76,51 +81,4 @@ public class SyncProxyProxyLoginConfiguration {
         this.maintenanceMotds = maintenanceMotds;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SyncProxyProxyLoginConfiguration)) return false;
-        final SyncProxyProxyLoginConfiguration other = (SyncProxyProxyLoginConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$targetGroup = this.getTargetGroup();
-        final Object other$targetGroup = other.getTargetGroup();
-        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
-            return false;
-        if (this.isMaintenance() != other.isMaintenance()) return false;
-        if (this.getMaxPlayers() != other.getMaxPlayers()) return false;
-        final Object this$whitelist = this.getWhitelist();
-        final Object other$whitelist = other.getWhitelist();
-        if (this$whitelist == null ? other$whitelist != null : !this$whitelist.equals(other$whitelist)) return false;
-        final Object this$motds = this.getMotds();
-        final Object other$motds = other.getMotds();
-        if (this$motds == null ? other$motds != null : !this$motds.equals(other$motds)) return false;
-        final Object this$maintenanceMotds = this.getMaintenanceMotds();
-        final Object other$maintenanceMotds = other.getMaintenanceMotds();
-        if (this$maintenanceMotds == null ? other$maintenanceMotds != null : !this$maintenanceMotds.equals(other$maintenanceMotds))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SyncProxyProxyLoginConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $targetGroup = this.getTargetGroup();
-        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
-        result = result * PRIME + (this.isMaintenance() ? 79 : 97);
-        result = result * PRIME + this.getMaxPlayers();
-        final Object $whitelist = this.getWhitelist();
-        result = result * PRIME + ($whitelist == null ? 43 : $whitelist.hashCode());
-        final Object $motds = this.getMotds();
-        result = result * PRIME + ($motds == null ? 43 : $motds.hashCode());
-        final Object $maintenanceMotds = this.getMaintenanceMotds();
-        result = result * PRIME + ($maintenanceMotds == null ? 43 : $maintenanceMotds.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SyncProxyProxyLoginConfiguration(targetGroup=" + this.getTargetGroup() + ", maintenance=" + this.isMaintenance() + ", maxPlayers=" + this.getMaxPlayers() + ", whitelist=" + this.getWhitelist() + ", motds=" + this.getMotds() + ", maintenanceMotds=" + this.getMaintenanceMotds() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyProxyLoginConfiguration.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyProxyLoginConfiguration.java
@@ -1,14 +1,7 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.List;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SyncProxyProxyLoginConfiguration {
 
     protected String targetGroup;
@@ -23,4 +16,111 @@ public class SyncProxyProxyLoginConfiguration {
 
     protected List<SyncProxyMotd> maintenanceMotds;
 
+    public SyncProxyProxyLoginConfiguration(String targetGroup, boolean maintenance, int maxPlayers, List<String> whitelist, List<SyncProxyMotd> motds, List<SyncProxyMotd> maintenanceMotds) {
+        this.targetGroup = targetGroup;
+        this.maintenance = maintenance;
+        this.maxPlayers = maxPlayers;
+        this.whitelist = whitelist;
+        this.motds = motds;
+        this.maintenanceMotds = maintenanceMotds;
+    }
+
+    public SyncProxyProxyLoginConfiguration() {
+    }
+
+    public String getTargetGroup() {
+        return this.targetGroup;
+    }
+
+    public boolean isMaintenance() {
+        return this.maintenance;
+    }
+
+    public int getMaxPlayers() {
+        return this.maxPlayers;
+    }
+
+    public List<String> getWhitelist() {
+        return this.whitelist;
+    }
+
+    public List<SyncProxyMotd> getMotds() {
+        return this.motds;
+    }
+
+    public List<SyncProxyMotd> getMaintenanceMotds() {
+        return this.maintenanceMotds;
+    }
+
+    public void setTargetGroup(String targetGroup) {
+        this.targetGroup = targetGroup;
+    }
+
+    public void setMaintenance(boolean maintenance) {
+        this.maintenance = maintenance;
+    }
+
+    public void setMaxPlayers(int maxPlayers) {
+        this.maxPlayers = maxPlayers;
+    }
+
+    public void setWhitelist(List<String> whitelist) {
+        this.whitelist = whitelist;
+    }
+
+    public void setMotds(List<SyncProxyMotd> motds) {
+        this.motds = motds;
+    }
+
+    public void setMaintenanceMotds(List<SyncProxyMotd> maintenanceMotds) {
+        this.maintenanceMotds = maintenanceMotds;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SyncProxyProxyLoginConfiguration)) return false;
+        final SyncProxyProxyLoginConfiguration other = (SyncProxyProxyLoginConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$targetGroup = this.getTargetGroup();
+        final Object other$targetGroup = other.getTargetGroup();
+        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
+            return false;
+        if (this.isMaintenance() != other.isMaintenance()) return false;
+        if (this.getMaxPlayers() != other.getMaxPlayers()) return false;
+        final Object this$whitelist = this.getWhitelist();
+        final Object other$whitelist = other.getWhitelist();
+        if (this$whitelist == null ? other$whitelist != null : !this$whitelist.equals(other$whitelist)) return false;
+        final Object this$motds = this.getMotds();
+        final Object other$motds = other.getMotds();
+        if (this$motds == null ? other$motds != null : !this$motds.equals(other$motds)) return false;
+        final Object this$maintenanceMotds = this.getMaintenanceMotds();
+        final Object other$maintenanceMotds = other.getMaintenanceMotds();
+        if (this$maintenanceMotds == null ? other$maintenanceMotds != null : !this$maintenanceMotds.equals(other$maintenanceMotds))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SyncProxyProxyLoginConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $targetGroup = this.getTargetGroup();
+        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
+        result = result * PRIME + (this.isMaintenance() ? 79 : 97);
+        result = result * PRIME + this.getMaxPlayers();
+        final Object $whitelist = this.getWhitelist();
+        result = result * PRIME + ($whitelist == null ? 43 : $whitelist.hashCode());
+        final Object $motds = this.getMotds();
+        result = result * PRIME + ($motds == null ? 43 : $motds.hashCode());
+        final Object $maintenanceMotds = this.getMaintenanceMotds();
+        result = result * PRIME + ($maintenanceMotds == null ? 43 : $maintenanceMotds.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SyncProxyProxyLoginConfiguration(targetGroup=" + this.getTargetGroup() + ", maintenance=" + this.isMaintenance() + ", maxPlayers=" + this.getMaxPlayers() + ", whitelist=" + this.getWhitelist() + ", motds=" + this.getMotds() + ", maintenanceMotds=" + this.getMaintenanceMotds() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyTabList.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyTabList.java
@@ -1,5 +1,10 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class SyncProxyTabList {
 
     protected String header;
@@ -30,35 +35,4 @@ public class SyncProxyTabList {
         this.footer = footer;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SyncProxyTabList)) return false;
-        final SyncProxyTabList other = (SyncProxyTabList) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$header = this.getHeader();
-        final Object other$header = other.getHeader();
-        if (this$header == null ? other$header != null : !this$header.equals(other$header)) return false;
-        final Object this$footer = this.getFooter();
-        final Object other$footer = other.getFooter();
-        if (this$footer == null ? other$footer != null : !this$footer.equals(other$footer)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SyncProxyTabList;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $header = this.getHeader();
-        result = result * PRIME + ($header == null ? 43 : $header.hashCode());
-        final Object $footer = this.getFooter();
-        result = result * PRIME + ($footer == null ? 43 : $footer.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "SyncProxyTabList(header=" + this.getHeader() + ", footer=" + this.getFooter() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyTabList.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyTabList.java
@@ -1,16 +1,64 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SyncProxyTabList {
 
     protected String header;
 
     protected String footer;
 
+    public SyncProxyTabList(String header, String footer) {
+        this.header = header;
+        this.footer = footer;
+    }
+
+    public SyncProxyTabList() {
+    }
+
+    public String getHeader() {
+        return this.header;
+    }
+
+    public String getFooter() {
+        return this.footer;
+    }
+
+    public void setHeader(String header) {
+        this.header = header;
+    }
+
+    public void setFooter(String footer) {
+        this.footer = footer;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SyncProxyTabList)) return false;
+        final SyncProxyTabList other = (SyncProxyTabList) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$header = this.getHeader();
+        final Object other$header = other.getHeader();
+        if (this$header == null ? other$header != null : !this$header.equals(other$header)) return false;
+        final Object this$footer = this.getFooter();
+        final Object other$footer = other.getFooter();
+        if (this$footer == null ? other$footer != null : !this$footer.equals(other$footer)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SyncProxyTabList;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $header = this.getHeader();
+        result = result * PRIME + ($header == null ? 43 : $header.hashCode());
+        final Object $footer = this.getFooter();
+        result = result * PRIME + ($footer == null ? 43 : $footer.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "SyncProxyTabList(header=" + this.getHeader() + ", footer=" + this.getFooter() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyTabListConfiguration.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyTabListConfiguration.java
@@ -1,7 +1,12 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
+@ToString
+@EqualsAndHashCode
 public class SyncProxyTabListConfiguration {
 
     protected String targetGroup;
@@ -43,38 +48,4 @@ public class SyncProxyTabListConfiguration {
         this.animationsPerSecond = animationsPerSecond;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof SyncProxyTabListConfiguration)) return false;
-        final SyncProxyTabListConfiguration other = (SyncProxyTabListConfiguration) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$targetGroup = this.getTargetGroup();
-        final Object other$targetGroup = other.getTargetGroup();
-        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
-            return false;
-        final Object this$entries = this.getEntries();
-        final Object other$entries = other.getEntries();
-        if (this$entries == null ? other$entries != null : !this$entries.equals(other$entries)) return false;
-        if (this.getAnimationsPerSecond() != other.getAnimationsPerSecond()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof SyncProxyTabListConfiguration;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $targetGroup = this.getTargetGroup();
-        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
-        final Object $entries = this.getEntries();
-        result = result * PRIME + ($entries == null ? 43 : $entries.hashCode());
-        result = result * PRIME + this.getAnimationsPerSecond();
-        return result;
-    }
-
-    public String toString() {
-        return "SyncProxyTabListConfiguration(targetGroup=" + this.getTargetGroup() + ", entries=" + this.getEntries() + ", animationsPerSecond=" + this.getAnimationsPerSecond() + ")";
-    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyTabListConfiguration.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyTabListConfiguration.java
@@ -1,14 +1,7 @@
 package de.dytanic.cloudnet.ext.syncproxy;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.List;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SyncProxyTabListConfiguration {
 
     protected String targetGroup;
@@ -17,4 +10,71 @@ public class SyncProxyTabListConfiguration {
 
     protected int animationsPerSecond;
 
+    public SyncProxyTabListConfiguration(String targetGroup, List<SyncProxyTabList> entries, int animationsPerSecond) {
+        this.targetGroup = targetGroup;
+        this.entries = entries;
+        this.animationsPerSecond = animationsPerSecond;
+    }
+
+    public SyncProxyTabListConfiguration() {
+    }
+
+    public String getTargetGroup() {
+        return this.targetGroup;
+    }
+
+    public List<SyncProxyTabList> getEntries() {
+        return this.entries;
+    }
+
+    public int getAnimationsPerSecond() {
+        return this.animationsPerSecond;
+    }
+
+    public void setTargetGroup(String targetGroup) {
+        this.targetGroup = targetGroup;
+    }
+
+    public void setEntries(List<SyncProxyTabList> entries) {
+        this.entries = entries;
+    }
+
+    public void setAnimationsPerSecond(int animationsPerSecond) {
+        this.animationsPerSecond = animationsPerSecond;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof SyncProxyTabListConfiguration)) return false;
+        final SyncProxyTabListConfiguration other = (SyncProxyTabListConfiguration) o;
+        if (!other.canEqual((Object) this)) return false;
+        final Object this$targetGroup = this.getTargetGroup();
+        final Object other$targetGroup = other.getTargetGroup();
+        if (this$targetGroup == null ? other$targetGroup != null : !this$targetGroup.equals(other$targetGroup))
+            return false;
+        final Object this$entries = this.getEntries();
+        final Object other$entries = other.getEntries();
+        if (this$entries == null ? other$entries != null : !this$entries.equals(other$entries)) return false;
+        if (this.getAnimationsPerSecond() != other.getAnimationsPerSecond()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof SyncProxyTabListConfiguration;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $targetGroup = this.getTargetGroup();
+        result = result * PRIME + ($targetGroup == null ? 43 : $targetGroup.hashCode());
+        final Object $entries = this.getEntries();
+        result = result * PRIME + ($entries == null ? 43 : $entries.hashCode());
+        result = result * PRIME + this.getAnimationsPerSecond();
+        return result;
+    }
+
+    public String toString() {
+        return "SyncProxyTabListConfiguration(targetGroup=" + this.getTargetGroup() + ", entries=" + this.getEntries() + ", animationsPerSecond=" + this.getAnimationsPerSecond() + ")";
+    }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeCloudNetSyncProxyPlugin.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeCloudNetSyncProxyPlugin.java
@@ -11,7 +11,6 @@ import de.dytanic.cloudnet.ext.syncproxy.bungee.listener.BungeeProxyLoginConfigu
 import de.dytanic.cloudnet.ext.syncproxy.bungee.listener.BungeeProxyTabListConfigurationImplListener;
 import de.dytanic.cloudnet.ext.syncproxy.bungee.listener.BungeeSyncProxyCloudNetListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -26,12 +25,10 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@Getter
 public final class BungeeCloudNetSyncProxyPlugin extends Plugin {
 
     private static final DateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm:ss");
 
-    @Getter
     private static BungeeCloudNetSyncProxyPlugin instance;
 
     /*= ---------------------------------------------------------------------- =*/
@@ -46,6 +43,10 @@ public final class BungeeCloudNetSyncProxyPlugin extends Plugin {
 
     public BungeeCloudNetSyncProxyPlugin() {
         instance = this;
+    }
+
+    public static BungeeCloudNetSyncProxyPlugin getInstance() {
+        return BungeeCloudNetSyncProxyPlugin.instance;
     }
 
     @Override
@@ -216,5 +217,21 @@ public final class BungeeCloudNetSyncProxyPlugin extends Plugin {
                     getOnlineCountOfProxies().put(serviceInfoSnapshot.getServiceId().getUniqueId(),
                             serviceInfoSnapshot.getProperties().getInt(SyncProxyConstants.SYNC_PROXY_SERVICE_INFO_SNAPSHOT_ONLINE_COUNT));
         }
+    }
+
+    public Map<UUID, Integer> getOnlineCountOfProxies() {
+        return this.onlineCountOfProxies;
+    }
+
+    public AtomicInteger getTabListEntryIndex() {
+        return this.tabListEntryIndex;
+    }
+
+    public String getTabListHeader() {
+        return this.tabListHeader;
+    }
+
+    public String getTabListFooter() {
+        return this.tabListFooter;
     }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/util/LoginPendingConnectionCommandSender.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/util/LoginPendingConnectionCommandSender.java
@@ -2,7 +2,6 @@ package de.dytanic.cloudnet.ext.syncproxy.bungee.util;
 
 import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.collection.Iterables;
-import lombok.Getter;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.event.LoginEvent;
@@ -11,7 +10,6 @@ import net.md_5.bungee.api.event.PermissionCheckEvent;
 import java.util.Collection;
 import java.util.UUID;
 
-@Getter
 public class LoginPendingConnectionCommandSender implements CommandSender {
 
     private final Collection<String> permissions = Iterables.newArrayList(), groups = Iterables.newArrayList();
@@ -75,5 +73,21 @@ public class LoginPendingConnectionCommandSender implements CommandSender {
             this.permissions.add(permission.toLowerCase());
         else
             this.permissions.remove(permission.toLowerCase());
+    }
+
+    public Collection<String> getPermissions() {
+        return this.permissions;
+    }
+
+    public Collection<String> getGroups() {
+        return this.groups;
+    }
+
+    public LoginEvent getLoginEvent() {
+        return this.loginEvent;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
     }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/node/CloudNetSyncProxyModule.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/node/CloudNetSyncProxyModule.java
@@ -9,25 +9,23 @@ import de.dytanic.cloudnet.ext.syncproxy.node.http.V1SyncProxyConfigurationHttpH
 import de.dytanic.cloudnet.ext.syncproxy.node.listener.IncludePluginListener;
 import de.dytanic.cloudnet.ext.syncproxy.node.listener.SyncProxyConfigUpdateListener;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.io.File;
 
 public final class CloudNetSyncProxyModule extends NodeCloudNetModule {
 
-    @Getter
     private static CloudNetSyncProxyModule instance;
 
-    @Getter
-    @Setter
     private SyncProxyConfiguration syncProxyConfiguration;
 
-    @Getter
     private File configurationFile;
 
     public CloudNetSyncProxyModule() {
         instance = this;
+    }
+
+    public static CloudNetSyncProxyModule getInstance() {
+        return CloudNetSyncProxyModule.instance;
     }
 
     @ModuleTask(order = 127, event = ModuleLifeCycle.STARTED)
@@ -50,5 +48,17 @@ public final class CloudNetSyncProxyModule extends NodeCloudNetModule {
     public void registerHttpHandlers() {
         getCloudNet().getHttpServer().registerHandler("/api/v1/modules/syncproxy/config",
                 new V1SyncProxyConfigurationHttpHandler("cloudnet.http.v1.modules.syncproxy.config"));
+    }
+
+    public SyncProxyConfiguration getSyncProxyConfiguration() {
+        return this.syncProxyConfiguration;
+    }
+
+    public File getConfigurationFile() {
+        return this.configurationFile;
+    }
+
+    public void setSyncProxyConfiguration(SyncProxyConfiguration syncProxyConfiguration) {
+        this.syncProxyConfiguration = syncProxyConfiguration;
     }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/proxprox/ProxProxCloudNetSyncProxyPlugin.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/proxprox/ProxProxCloudNetSyncProxyPlugin.java
@@ -18,18 +18,15 @@ import io.gomint.proxprox.api.plugin.Plugin;
 import io.gomint.proxprox.api.plugin.annotation.Description;
 import io.gomint.proxprox.api.plugin.annotation.Name;
 import io.gomint.proxprox.api.plugin.annotation.Version;
-import lombok.Getter;
 
 import java.util.Map;
 import java.util.UUID;
 
-@Getter
 @Name("CloudNet-SyncProxy")
 @Version(major = 1, minor = 0)
 @Description("CloudNet extension, which implement the multi Proxy server synchronization bridge technology and some small features")
 public final class ProxProxCloudNetSyncProxyPlugin extends Plugin {
 
-    @Getter
     private static ProxProxCloudNetSyncProxyPlugin instance;
     private final Map<UUID, Integer> onlineCountOfProxies = Maps.newConcurrentHashMap();
 
@@ -43,6 +40,10 @@ public final class ProxProxCloudNetSyncProxyPlugin extends Plugin {
 
     public static ProxProx getProxyServer() {
         return ProxProx.instance;
+    }
+
+    public static ProxProxCloudNetSyncProxyPlugin getInstance() {
+        return ProxProxCloudNetSyncProxyPlugin.instance;
     }
 
     @Override
@@ -114,5 +115,9 @@ public final class ProxProxCloudNetSyncProxyPlugin extends Plugin {
                     getOnlineCountOfProxies().put(serviceInfoSnapshot.getServiceId().getUniqueId(),
                             serviceInfoSnapshot.getProperties().getInt(SyncProxyConstants.SYNC_PROXY_SERVICE_INFO_SNAPSHOT_ONLINE_COUNT));
         }
+    }
+
+    public Map<UUID, Integer> getOnlineCountOfProxies() {
+        return this.onlineCountOfProxies;
     }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/velocity/VelocityCloudNetSyncProxyPlugin.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/velocity/VelocityCloudNetSyncProxyPlugin.java
@@ -18,7 +18,6 @@ import de.dytanic.cloudnet.ext.syncproxy.velocity.listener.VelocityProxyLoginCon
 import de.dytanic.cloudnet.ext.syncproxy.velocity.listener.VelocityProxyTabListConfigurationImplListener;
 import de.dytanic.cloudnet.ext.syncproxy.velocity.listener.VelocitySyncProxyCloudNetListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
 import net.kyori.text.TextComponent;
 
 import java.text.DateFormat;
@@ -28,7 +27,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@Getter
 @Plugin(
         id = "cloudnet_syncproxy_velocity",
         name = "CloudNet-SyncProxy",
@@ -43,7 +41,6 @@ public final class VelocityCloudNetSyncProxyPlugin {
 
     private static final DateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm:ss");
 
-    @Getter
     private static VelocityCloudNetSyncProxyPlugin instance;
 
     private final ProxyServer proxyServer;
@@ -63,6 +60,10 @@ public final class VelocityCloudNetSyncProxyPlugin {
         instance = this;
 
         this.proxyServer = proxyServer;
+    }
+
+    public static VelocityCloudNetSyncProxyPlugin getInstance() {
+        return VelocityCloudNetSyncProxyPlugin.instance;
     }
 
     @Subscribe
@@ -218,4 +219,23 @@ public final class VelocityCloudNetSyncProxyPlugin {
         }
     }
 
+    public ProxyServer getProxyServer() {
+        return this.proxyServer;
+    }
+
+    public Map<UUID, Integer> getOnlineCountOfProxies() {
+        return this.onlineCountOfProxies;
+    }
+
+    public AtomicInteger getTabListEntryIndex() {
+        return this.tabListEntryIndex;
+    }
+
+    public String getTabListHeader() {
+        return this.tabListHeader;
+    }
+
+    public String getTabListFooter() {
+        return this.tabListFooter;
+    }
 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -37,7 +37,6 @@ import de.dytanic.cloudnet.wrapper.network.NetworkClientChannelHandler;
 import de.dytanic.cloudnet.wrapper.network.listener.*;
 import de.dytanic.cloudnet.wrapper.network.packet.PacketClientServiceInfoUpdate;
 import de.dytanic.cloudnet.wrapper.runtime.RuntimeApplicationClassLoader;
-import lombok.Getter;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -71,13 +70,11 @@ public final class Wrapper extends CloudNetDriver {
      *
      * @see IWrapperConfiguration
      */
-    @Getter
     private final IWrapperConfiguration config = new DocumentWrapperConfiguration();
 
     /**
      * The default workDirectory of this process as File instance
      */
-    @Getter
     private final File workDirectory = new File(".");
 
     /*= ----------------------------------------------------------- =*/
@@ -85,7 +82,6 @@ public final class Wrapper extends CloudNetDriver {
     /**
      * The commandline arguments from the main() method of Main class by the application wrapper
      */
-    @Getter
     private final List<String> commandLineArguments;
 
     /**
@@ -93,7 +89,6 @@ public final class Wrapper extends CloudNetDriver {
      *
      * @see CloudNetDriver
      */
-    @Getter
     private final INetworkClient networkClient;
 
     /*= ----------------------------------------------------------- =*/
@@ -105,7 +100,6 @@ public final class Wrapper extends CloudNetDriver {
     /**
      * The single task thread of the scheduler of the wrapper application
      */
-    @Getter
     private final Thread mainThread = Thread.currentThread();
     private final Function<Pair<JsonDocument, byte[]>, Void> VOID_FUNCTION = new Function<Pair<JsonDocument, byte[]>, Void>() {
         @Override
@@ -119,7 +113,6 @@ public final class Wrapper extends CloudNetDriver {
      * The ServiceInfoSnapshot instances. The current ServiceInfoSnapshot instance is the last send object snapshot
      * from this process. The lastServiceInfoSnapshot is the element which was send before.
      */
-    @Getter
     private ServiceInfoSnapshot
             lastServiceInfoSnapShot = this.config.getServiceInfoSnapshot(),
             currentServiceInfoSnapshot = this.config.getServiceInfoSnapshot();
@@ -2595,5 +2588,33 @@ public final class Wrapper extends CloudNetDriver {
 
         eventManager.callEvent(new ApplicationPostStartEvent(this, main, applicationThread, appClassLoader));
         return true;
+    }
+
+    public IWrapperConfiguration getConfig() {
+        return this.config;
+    }
+
+    public File getWorkDirectory() {
+        return this.workDirectory;
+    }
+
+    public List<String> getCommandLineArguments() {
+        return this.commandLineArguments;
+    }
+
+    public INetworkClient getNetworkClient() {
+        return this.networkClient;
+    }
+
+    public Thread getMainThread() {
+        return this.mainThread;
+    }
+
+    public ServiceInfoSnapshot getLastServiceInfoSnapShot() {
+        return this.lastServiceInfoSnapShot;
+    }
+
+    public ServiceInfoSnapshot getCurrentServiceInfoSnapshot() {
+        return this.currentServiceInfoSnapshot;
     }
 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/conf/DocumentWrapperConfiguration.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/conf/DocumentWrapperConfiguration.java
@@ -5,7 +5,6 @@ import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.driver.service.ServiceConfiguration;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
 
 import java.lang.reflect.Type;
 import java.nio.file.Path;
@@ -17,7 +16,6 @@ import java.nio.file.Paths;
  *
  * @see IWrapperConfiguration
  */
-@Getter
 public final class DocumentWrapperConfiguration implements IWrapperConfiguration {
 
     private static final Path WRAPPER_CONFIG = Paths.get(System.getProperty("cloudnet.wrapper.config.path", ".wrapper/wrapper.json"));
@@ -50,5 +48,25 @@ public final class DocumentWrapperConfiguration implements IWrapperConfiguration
         this.serviceConfiguration = document.get("serviceConfiguration", SERVICE_CFG_TYPE);
         this.serviceInfoSnapshot = document.get("serviceInfoSnapshot", SERVICE_INFO_TYPE);
         this.sslConfig = document.getDocument("sslConfig");
+    }
+
+    public String getConnectionKey() {
+        return this.connectionKey;
+    }
+
+    public HostAndPort getTargetListener() {
+        return this.targetListener;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
+
+    public ServiceConfiguration getServiceConfiguration() {
+        return this.serviceConfiguration;
+    }
+
+    public JsonDocument getSslConfig() {
+        return this.sslConfig;
     }
 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/event/ApplicationEnvironmentEvent.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/event/ApplicationEnvironmentEvent.java
@@ -3,9 +3,6 @@ package de.dytanic.cloudnet.wrapper.event;
 import de.dytanic.cloudnet.driver.event.Event;
 import de.dytanic.cloudnet.driver.service.ServiceEnvironmentType;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
 
 /**
  * This event is called before the actual Jar archive of the application is searched.
@@ -14,8 +11,6 @@ import lombok.Setter;
  * @see ServiceEnvironmentType
  * @see Event
  */
-@Getter
-@AllArgsConstructor
 public final class ApplicationEnvironmentEvent extends Event {
 
     /**
@@ -30,7 +25,22 @@ public final class ApplicationEnvironmentEvent extends Event {
      *
      * @see ServiceEnvironmentType
      */
-    @Setter
     private ServiceEnvironmentType environmentType;
 
+    public ApplicationEnvironmentEvent(Wrapper cloudNetWrapper, ServiceEnvironmentType environmentType) {
+        this.cloudNetWrapper = cloudNetWrapper;
+        this.environmentType = environmentType;
+    }
+
+    public Wrapper getCloudNetWrapper() {
+        return this.cloudNetWrapper;
+    }
+
+    public ServiceEnvironmentType getEnvironmentType() {
+        return this.environmentType;
+    }
+
+    public void setEnvironmentType(ServiceEnvironmentType environmentType) {
+        this.environmentType = environmentType;
+    }
 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/event/ApplicationPostStartEvent.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/event/ApplicationPostStartEvent.java
@@ -2,8 +2,6 @@ package de.dytanic.cloudnet.wrapper.event;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * This event is only interesting for wrapper modules.
@@ -11,8 +9,6 @@ import lombok.RequiredArgsConstructor;
  *
  * @see DriverEvent
  */
-@Getter
-@RequiredArgsConstructor
 public final class ApplicationPostStartEvent extends DriverEvent {
 
     /**
@@ -37,4 +33,26 @@ public final class ApplicationPostStartEvent extends DriverEvent {
      */
     private final ClassLoader classLoader;
 
+    public ApplicationPostStartEvent(Wrapper cloudNetWrapper, Class<?> clazz, Thread applicationThread, ClassLoader classLoader) {
+        this.cloudNetWrapper = cloudNetWrapper;
+        this.clazz = clazz;
+        this.applicationThread = applicationThread;
+        this.classLoader = classLoader;
+    }
+
+    public Wrapper getCloudNetWrapper() {
+        return this.cloudNetWrapper;
+    }
+
+    public Class<?> getClazz() {
+        return this.clazz;
+    }
+
+    public Thread getApplicationThread() {
+        return this.applicationThread;
+    }
+
+    public ClassLoader getClassLoader() {
+        return this.classLoader;
+    }
 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/event/ApplicationPreStartEvent.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/event/ApplicationPreStartEvent.java
@@ -2,8 +2,6 @@ package de.dytanic.cloudnet.wrapper.event;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.wrapper.Wrapper;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Collection;
 import java.util.jar.Manifest;
@@ -14,8 +12,6 @@ import java.util.jar.Manifest;
  *
  * @see DriverEvent
  */
-@Getter
-@RequiredArgsConstructor
 public final class ApplicationPreStartEvent extends DriverEvent {
 
     /**
@@ -42,4 +38,26 @@ public final class ApplicationPreStartEvent extends DriverEvent {
      */
     private final Collection<String> arguments;
 
+    public ApplicationPreStartEvent(Wrapper cloudNetWrapper, Class<?> clazz, Manifest manifest, Collection<String> arguments) {
+        this.cloudNetWrapper = cloudNetWrapper;
+        this.clazz = clazz;
+        this.manifest = manifest;
+        this.arguments = arguments;
+    }
+
+    public Wrapper getCloudNetWrapper() {
+        return this.cloudNetWrapper;
+    }
+
+    public Class<?> getClazz() {
+        return this.clazz;
+    }
+
+    public Manifest getManifest() {
+        return this.manifest;
+    }
+
+    public Collection<String> getArguments() {
+        return this.arguments;
+    }
 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/event/service/ServiceInfoSnapshotConfigureEvent.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/event/service/ServiceInfoSnapshotConfigureEvent.java
@@ -2,8 +2,6 @@ package de.dytanic.cloudnet.wrapper.event.service;
 
 import de.dytanic.cloudnet.driver.event.Event;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * The event is called when a new ServiceInfoSnapshot has been created to update this service.
@@ -14,8 +12,6 @@ import lombok.RequiredArgsConstructor;
  * @see ServiceInfoSnapshot
  * @see Event
  */
-@Getter
-@RequiredArgsConstructor
 public class ServiceInfoSnapshotConfigureEvent extends Event {
 
     /**
@@ -24,4 +20,11 @@ public class ServiceInfoSnapshotConfigureEvent extends Event {
      */
     private final ServiceInfoSnapshot serviceInfoSnapshot;
 
+    public ServiceInfoSnapshotConfigureEvent(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/network/listener/PacketServerAuthorizationResponseListener.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/network/listener/PacketServerAuthorizationResponseListener.java
@@ -3,21 +3,22 @@ package de.dytanic.cloudnet.wrapper.network.listener;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
 import de.dytanic.cloudnet.driver.network.protocol.IPacketListener;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-@RequiredArgsConstructor
 public final class PacketServerAuthorizationResponseListener implements IPacketListener {
 
     private final ReentrantLock lock;
 
     private final Condition condition;
 
-    @Getter
     private boolean result;
+
+    public PacketServerAuthorizationResponseListener(ReentrantLock lock, Condition condition) {
+        this.lock = lock;
+        this.condition = condition;
+    }
 
     @Override
     public void handle(INetworkChannel channel, IPacket packet) throws Exception {
@@ -31,5 +32,9 @@ public final class PacketServerAuthorizationResponseListener implements IPacketL
                 lock.unlock();
             }
         }
+    }
+
+    public boolean isResult() {
+        return this.result;
     }
 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/runtime/RuntimeAgent.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/runtime/RuntimeAgent.java
@@ -1,7 +1,5 @@
 package de.dytanic.cloudnet.wrapper.runtime;
 
-import lombok.Getter;
-
 import java.lang.instrument.Instrumentation;
 
 /**
@@ -14,7 +12,6 @@ public final class RuntimeAgent {
      *
      * @see Instrumentation
      */
-    @Getter
     private static Instrumentation instrumentation;
 
     /**
@@ -22,5 +19,9 @@ public final class RuntimeAgent {
      */
     public static void premain(String string, Instrumentation inst) {
         instrumentation = inst;
+    }
+
+    public static Instrumentation getInstrumentation() {
+        return RuntimeAgent.instrumentation;
     }
 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/runtime/RuntimeApplicationClassLoader.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/runtime/RuntimeApplicationClassLoader.java
@@ -1,7 +1,5 @@
 package de.dytanic.cloudnet.wrapper.runtime;
 
-import lombok.Getter;
-
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -16,7 +14,6 @@ public final class RuntimeApplicationClassLoader extends URLClassLoader {
         ClassLoader.registerAsParallelCapable();
     }
 
-    @Getter
     private final ClassLoader cloudNetWrapperClassLoader;
 
     public RuntimeApplicationClassLoader(ClassLoader cloudNetWrapperClassLoader, URL url, ClassLoader parent) {
@@ -52,5 +49,9 @@ public final class RuntimeApplicationClassLoader extends URLClassLoader {
     @Override
     public boolean equals(Object obj) {
         return super.equals(obj) || cloudNetWrapperClassLoader.equals(obj);
+    }
+
+    public ClassLoader getCloudNetWrapperClassLoader() {
+        return this.cloudNetWrapperClassLoader;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -77,7 +77,6 @@ import de.dytanic.cloudnet.service.ICloudService;
 import de.dytanic.cloudnet.service.ICloudServiceManager;
 import de.dytanic.cloudnet.template.ITemplateStorage;
 import de.dytanic.cloudnet.template.LocalTemplateStorage;
-import lombok.Getter;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -102,59 +101,41 @@ public final class CloudNet extends CloudNetDriver {
 
     /*= --------------------------------------------------------------------------------------------------- =*/
 
-    @Getter
     private final ICommandMap commandMap = new DefaultCommandMap();
 
-    @Getter
     private final File moduleDirectory = new File(System.getProperty("cloudnet.modules.directory", "modules"));
 
-    @Getter
     private final IConfiguration config = new JsonConfiguration();
 
-    @Getter
     private final IConfigurationRegistry configurationRegistry = new JsonConfigurationRegistry(Paths.get(System.getProperty("cloudnet.registry.global.path", "local/registry")));
 
-    @Getter
     private final ICloudServiceManager cloudServiceManager = new DefaultCloudServiceManager();
 
-    @Getter
     private final IClusterNodeServerProvider clusterNodeServerProvider = new DefaultClusterNodeServerProvider();
 
-    @Getter
     private final ITaskScheduler networkTaskScheduler = new DefaultTaskScheduler();
 
     /*= ----------------------------------------------------------- =*/
 
-    @Getter
     private final List<String> commandLineArguments;
 
-    @Getter
     private final Properties commandLineProperties;
 
-    @Getter
     private final IConsole console;
 
-    @Getter
     private final QueuedConsoleLogHandler queuedConsoleLogHandler;
 
-    @Getter
     private final ConsoleCommandSender consoleCommandSender;
 
     /*= ----------------------------------------------------------- =*/
     private final Queue<ITask<?>> processQueue = Iterables.newConcurrentLinkedQueue();
-    @Getter
     private INetworkClient networkClient;
-    @Getter
     private INetworkServer networkServer;
-    @Getter
     private IHttpServer httpServer;
-    @Getter
     private IPermissionManagement permissionManagement;
 
     /*= ----------------------------------------------------------- =*/
-    @Getter
     private AbstractDatabaseProvider databaseProvider;
-    @Getter
     private volatile NetworkClusterNodeInfoSnapshot lastNetworkClusterNodeInfoSnapshot, currentNetworkClusterNodeInfoSnapshot;
 
     CloudNet(List<String> commandLineArguments, ILogger logger, IConsole console) {
@@ -2405,5 +2386,81 @@ public final class CloudNet extends CloudNetDriver {
         console.setPriority(Thread.MIN_PRIORITY);
         console.setDaemon(true);
         console.start();
+    }
+
+    public ICommandMap getCommandMap() {
+        return this.commandMap;
+    }
+
+    public File getModuleDirectory() {
+        return this.moduleDirectory;
+    }
+
+    public IConfiguration getConfig() {
+        return this.config;
+    }
+
+    public IConfigurationRegistry getConfigurationRegistry() {
+        return this.configurationRegistry;
+    }
+
+    public ICloudServiceManager getCloudServiceManager() {
+        return this.cloudServiceManager;
+    }
+
+    public IClusterNodeServerProvider getClusterNodeServerProvider() {
+        return this.clusterNodeServerProvider;
+    }
+
+    public ITaskScheduler getNetworkTaskScheduler() {
+        return this.networkTaskScheduler;
+    }
+
+    public List<String> getCommandLineArguments() {
+        return this.commandLineArguments;
+    }
+
+    public Properties getCommandLineProperties() {
+        return this.commandLineProperties;
+    }
+
+    public IConsole getConsole() {
+        return this.console;
+    }
+
+    public QueuedConsoleLogHandler getQueuedConsoleLogHandler() {
+        return this.queuedConsoleLogHandler;
+    }
+
+    public ConsoleCommandSender getConsoleCommandSender() {
+        return this.consoleCommandSender;
+    }
+
+    public INetworkClient getNetworkClient() {
+        return this.networkClient;
+    }
+
+    public INetworkServer getNetworkServer() {
+        return this.networkServer;
+    }
+
+    public IHttpServer getHttpServer() {
+        return this.httpServer;
+    }
+
+    public IPermissionManagement getPermissionManagement() {
+        return this.permissionManagement;
+    }
+
+    public AbstractDatabaseProvider getDatabaseProvider() {
+        return this.databaseProvider;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getLastNetworkClusterNodeInfoSnapshot() {
+        return this.lastNetworkClusterNodeInfoSnapshot;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getCurrentNetworkClusterNodeInfoSnapshot() {
+        return this.currentNetworkClusterNodeInfoSnapshot;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServer.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServer.java
@@ -15,8 +15,6 @@ import de.dytanic.cloudnet.driver.network.protocol.IPacket;
 import de.dytanic.cloudnet.driver.service.*;
 import de.dytanic.cloudnet.network.packet.PacketServerClusterChannelMessage;
 import de.dytanic.cloudnet.network.packet.PacketServerDeployLocalTemplate;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -27,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
-@Getter
 public final class DefaultClusterNodeServer implements IClusterNodeServer {
 
     private static final Type TYPE_COLLECTION_INTEGER = new TypeToken<Collection<Integer>>() {
@@ -37,13 +34,10 @@ public final class DefaultClusterNodeServer implements IClusterNodeServer {
 
     /*= -------------------------------------------------- =*/
 
-    @Setter
     private volatile NetworkClusterNodeInfoSnapshot nodeInfoSnapshot;
 
-    @Setter
     private NetworkClusterNode nodeInfo;
 
-    @Setter
     private INetworkChannel channel;
 
     DefaultClusterNodeServer(DefaultClusterNodeServerProvider provider, NetworkClusterNode nodeInfo) {
@@ -563,5 +557,33 @@ public final class DefaultClusterNodeServer implements IClusterNodeServer {
 
         this.nodeInfoSnapshot = null;
         this.channel = null;
+    }
+
+    public DefaultClusterNodeServerProvider getProvider() {
+        return this.provider;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNodeInfoSnapshot() {
+        return this.nodeInfoSnapshot;
+    }
+
+    public NetworkClusterNode getNodeInfo() {
+        return this.nodeInfo;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
+
+    public void setNodeInfoSnapshot(NetworkClusterNodeInfoSnapshot nodeInfoSnapshot) {
+        this.nodeInfoSnapshot = nodeInfoSnapshot;
+    }
+
+    public void setNodeInfo(NetworkClusterNode nodeInfo) {
+        this.nodeInfo = nodeInfo;
+    }
+
+    public void setChannel(INetworkChannel channel) {
+        this.channel = channel;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServerProvider.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServerProvider.java
@@ -9,13 +9,11 @@ import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNode;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
 import de.dytanic.cloudnet.driver.service.ServiceTemplate;
 import de.dytanic.cloudnet.network.packet.PacketServerDeployLocalTemplate;
-import lombok.Getter;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Predicate;
 
-@Getter
 public final class DefaultClusterNodeServerProvider implements IClusterNodeServerProvider {
 
     protected final Map<String, IClusterNodeServer> servers = Maps.newConcurrentHashMap();
@@ -90,5 +88,9 @@ public final class DefaultClusterNodeServerProvider implements IClusterNodeServe
             clusterNodeServer.close();
 
         this.servers.clear();
+    }
+
+    public Map<String, IClusterNodeServer> getServers() {
+        return this.servers;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/Command.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/Command.java
@@ -1,8 +1,13 @@
 package de.dytanic.cloudnet.command;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * Represents a command that should be execute
  */
+@ToString
+@EqualsAndHashCode
 public abstract class Command implements ICommandExecutor {
 
     protected String[] names;
@@ -69,45 +74,4 @@ public abstract class Command implements ICommandExecutor {
         return this.prefix;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof Command)) return false;
-        final Command other = (Command) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (!java.util.Arrays.deepEquals(this.getNames(), other.getNames())) return false;
-        final Object this$permission = this.getPermission();
-        final Object other$permission = other.getPermission();
-        if (this$permission == null ? other$permission != null : !this$permission.equals(other$permission))
-            return false;
-        final Object this$description = this.getDescription();
-        final Object other$description = other.getDescription();
-        if (this$description == null ? other$description != null : !this$description.equals(other$description))
-            return false;
-        final Object this$usage = this.getUsage();
-        final Object other$usage = other.getUsage();
-        if (this$usage == null ? other$usage != null : !this$usage.equals(other$usage)) return false;
-        final Object this$prefix = this.getPrefix();
-        final Object other$prefix = other.getPrefix();
-        if (this$prefix == null ? other$prefix != null : !this$prefix.equals(other$prefix)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof Command;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getNames());
-        final Object $permission = this.getPermission();
-        result = result * PRIME + ($permission == null ? 43 : $permission.hashCode());
-        final Object $description = this.getDescription();
-        result = result * PRIME + ($description == null ? 43 : $description.hashCode());
-        final Object $usage = this.getUsage();
-        result = result * PRIME + ($usage == null ? 43 : $usage.hashCode());
-        final Object $prefix = this.getPrefix();
-        result = result * PRIME + ($prefix == null ? 43 : $prefix.hashCode());
-        return result;
-    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/Command.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/Command.java
@@ -1,15 +1,8 @@
 package de.dytanic.cloudnet.command;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 /**
  * Represents a command that should be execute
  */
-@Getter
-@NoArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public abstract class Command implements ICommandExecutor {
 
     protected String[] names;
@@ -45,6 +38,9 @@ public abstract class Command implements ICommandExecutor {
         this.prefix = prefix;
     }
 
+    public Command() {
+    }
+
     public CommandInfo getInfo() {
         return new CommandInfo(this.names, permission, description, usage);
     }
@@ -53,4 +49,65 @@ public abstract class Command implements ICommandExecutor {
         return this.names != null && this.names.length > 0 && this.names[0] != null && !this.names[0].isEmpty();
     }
 
+    public String[] getNames() {
+        return this.names;
+    }
+
+    public String getPermission() {
+        return this.permission;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public String getUsage() {
+        return this.usage;
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Command)) return false;
+        final Command other = (Command) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (!java.util.Arrays.deepEquals(this.getNames(), other.getNames())) return false;
+        final Object this$permission = this.getPermission();
+        final Object other$permission = other.getPermission();
+        if (this$permission == null ? other$permission != null : !this$permission.equals(other$permission))
+            return false;
+        final Object this$description = this.getDescription();
+        final Object other$description = other.getDescription();
+        if (this$description == null ? other$description != null : !this$description.equals(other$description))
+            return false;
+        final Object this$usage = this.getUsage();
+        final Object other$usage = other.getUsage();
+        if (this$usage == null ? other$usage != null : !this$usage.equals(other$usage)) return false;
+        final Object this$prefix = this.getPrefix();
+        final Object other$prefix = other.getPrefix();
+        if (this$prefix == null ? other$prefix != null : !this$prefix.equals(other$prefix)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof Command;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getNames());
+        final Object $permission = this.getPermission();
+        result = result * PRIME + ($permission == null ? 43 : $permission.hashCode());
+        final Object $description = this.getDescription();
+        result = result * PRIME + ($description == null ? 43 : $description.hashCode());
+        final Object $usage = this.getUsage();
+        result = result * PRIME + ($usage == null ? 43 : $usage.hashCode());
+        final Object $prefix = this.getPrefix();
+        result = result * PRIME + ($prefix == null ? 43 : $prefix.hashCode());
+        return result;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/CommandInfo.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/CommandInfo.java
@@ -1,15 +1,8 @@
 package de.dytanic.cloudnet.command;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-
 /**
  * The commandInfo class allows to easy serialize the command information
  */
-@Getter
-@AllArgsConstructor
-@EqualsAndHashCode
 public class CommandInfo {
 
     /**
@@ -31,4 +24,64 @@ public class CommandInfo {
      * The easiest and important usage for the command
      */
     protected String usage;
+
+    public CommandInfo(String[] names, String permission, String description, String usage) {
+        this.names = names;
+        this.permission = permission;
+        this.description = description;
+        this.usage = usage;
+    }
+
+    public String[] getNames() {
+        return this.names;
+    }
+
+    public String getPermission() {
+        return this.permission;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public String getUsage() {
+        return this.usage;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CommandInfo)) return false;
+        final CommandInfo other = (CommandInfo) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (!java.util.Arrays.deepEquals(this.getNames(), other.getNames())) return false;
+        final Object this$permission = this.getPermission();
+        final Object other$permission = other.getPermission();
+        if (this$permission == null ? other$permission != null : !this$permission.equals(other$permission))
+            return false;
+        final Object this$description = this.getDescription();
+        final Object other$description = other.getDescription();
+        if (this$description == null ? other$description != null : !this$description.equals(other$description))
+            return false;
+        final Object this$usage = this.getUsage();
+        final Object other$usage = other.getUsage();
+        if (this$usage == null ? other$usage != null : !this$usage.equals(other$usage)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof CommandInfo;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + java.util.Arrays.deepHashCode(this.getNames());
+        final Object $permission = this.getPermission();
+        result = result * PRIME + ($permission == null ? 43 : $permission.hashCode());
+        final Object $description = this.getDescription();
+        result = result * PRIME + ($description == null ? 43 : $description.hashCode());
+        final Object $usage = this.getUsage();
+        result = result * PRIME + ($usage == null ? 43 : $usage.hashCode());
+        return result;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/CommandInfo.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/CommandInfo.java
@@ -1,8 +1,13 @@
 package de.dytanic.cloudnet.command;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * The commandInfo class allows to easy serialize the command information
  */
+@ToString
+@EqualsAndHashCode
 public class CommandInfo {
 
     /**
@@ -48,40 +53,4 @@ public class CommandInfo {
         return this.usage;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof CommandInfo)) return false;
-        final CommandInfo other = (CommandInfo) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (!java.util.Arrays.deepEquals(this.getNames(), other.getNames())) return false;
-        final Object this$permission = this.getPermission();
-        final Object other$permission = other.getPermission();
-        if (this$permission == null ? other$permission != null : !this$permission.equals(other$permission))
-            return false;
-        final Object this$description = this.getDescription();
-        final Object other$description = other.getDescription();
-        if (this$description == null ? other$description != null : !this$description.equals(other$description))
-            return false;
-        final Object this$usage = this.getUsage();
-        final Object other$usage = other.getUsage();
-        if (this$usage == null ? other$usage != null : !this$usage.equals(other$usage)) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof CommandInfo;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        result = result * PRIME + java.util.Arrays.deepHashCode(this.getNames());
-        final Object $permission = this.getPermission();
-        result = result * PRIME + ($permission == null ? 43 : $permission.hashCode());
-        final Object $description = this.getDescription();
-        result = result * PRIME + ($description == null ? 43 : $description.hashCode());
-        final Object $usage = this.getUsage();
-        result = result * PRIME + ($usage == null ? 43 : $usage.hashCode());
-        return result;
-    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/ConsoleCommandSender.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/ConsoleCommandSender.java
@@ -3,18 +3,20 @@ package de.dytanic.cloudnet.command;
 import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.logging.ILogger;
 import de.dytanic.cloudnet.common.logging.LogLevel;
-import lombok.AllArgsConstructor;
 
 /**
  * The ConsoleCommandSender represents the console of the application. The console has
  * all needed permissions.
  */
-@AllArgsConstructor
 public final class ConsoleCommandSender implements ICommandSender {
 
     private static final LogLevel CONSOLE_LEVEL = new LogLevel("console", "CONSOLE", 6, true);
 
     private final ILogger logger;
+
+    public ConsoleCommandSender(ILogger logger) {
+        this.logger = logger;
+    }
 
     /**
      * The console name is the first codename from CloudNet 3.0: "Tsunami"

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/DriverCommandSender.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/DriverCommandSender.java
@@ -1,7 +1,6 @@
 package de.dytanic.cloudnet.command;
 
 import de.dytanic.cloudnet.common.Validate;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -9,10 +8,13 @@ import java.util.Collection;
 /**
  * The driverCommandSender
  */
-@RequiredArgsConstructor
 public final class DriverCommandSender implements ICommandSender {
 
     private final Collection<String> messages;
+
+    public DriverCommandSender(Collection<String> messages) {
+        this.messages = messages;
+    }
 
     @Override
     public String getName() {

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/jline2/JLine2CommandCompleter.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/jline2/JLine2CommandCompleter.java
@@ -6,7 +6,6 @@ import de.dytanic.cloudnet.command.ITabCompleter;
 import de.dytanic.cloudnet.common.Properties;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import jline.console.completer.Completer;
-import lombok.AllArgsConstructor;
 
 import java.util.Collections;
 import java.util.List;
@@ -15,10 +14,13 @@ import java.util.function.Predicate;
 /**
  * JLine2 implementation of the completer for the JLine console
  */
-@AllArgsConstructor
 public final class JLine2CommandCompleter implements Completer {
 
     private final ICommandMap commandMap;
+
+    public JLine2CommandCompleter(ICommandMap commandMap) {
+        this.commandMap = commandMap;
+    }
 
     @Override
     public int complete(String buffer, int cursor, List<CharSequence> candidates) {

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/conf/ConfigurationOptionSSL.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/conf/ConfigurationOptionSSL.java
@@ -1,9 +1,13 @@
 package de.dytanic.cloudnet.conf;
 
 import de.dytanic.cloudnet.driver.network.ssl.SSLConfiguration;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.File;
 
+@ToString
+@EqualsAndHashCode
 public class ConfigurationOptionSSL {
 
     private boolean enabled, clientAuth;
@@ -70,47 +74,4 @@ public class ConfigurationOptionSSL {
         this.privateKeyPath = privateKeyPath;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof ConfigurationOptionSSL)) return false;
-        final ConfigurationOptionSSL other = (ConfigurationOptionSSL) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (this.isEnabled() != other.isEnabled()) return false;
-        if (this.isClientAuth() != other.isClientAuth()) return false;
-        final Object this$trustCertificatePath = this.getTrustCertificatePath();
-        final Object other$trustCertificatePath = other.getTrustCertificatePath();
-        if (this$trustCertificatePath == null ? other$trustCertificatePath != null : !this$trustCertificatePath.equals(other$trustCertificatePath))
-            return false;
-        final Object this$certificatePath = this.getCertificatePath();
-        final Object other$certificatePath = other.getCertificatePath();
-        if (this$certificatePath == null ? other$certificatePath != null : !this$certificatePath.equals(other$certificatePath))
-            return false;
-        final Object this$privateKeyPath = this.getPrivateKeyPath();
-        final Object other$privateKeyPath = other.getPrivateKeyPath();
-        if (this$privateKeyPath == null ? other$privateKeyPath != null : !this$privateKeyPath.equals(other$privateKeyPath))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof ConfigurationOptionSSL;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        result = result * PRIME + (this.isEnabled() ? 79 : 97);
-        result = result * PRIME + (this.isClientAuth() ? 79 : 97);
-        final Object $trustCertificatePath = this.getTrustCertificatePath();
-        result = result * PRIME + ($trustCertificatePath == null ? 43 : $trustCertificatePath.hashCode());
-        final Object $certificatePath = this.getCertificatePath();
-        result = result * PRIME + ($certificatePath == null ? 43 : $certificatePath.hashCode());
-        final Object $privateKeyPath = this.getPrivateKeyPath();
-        result = result * PRIME + ($privateKeyPath == null ? 43 : $privateKeyPath.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "ConfigurationOptionSSL(enabled=" + this.isEnabled() + ", clientAuth=" + this.isClientAuth() + ", trustCertificatePath=" + this.getTrustCertificatePath() + ", certificatePath=" + this.getCertificatePath() + ", privateKeyPath=" + this.getPrivateKeyPath() + ")";
-    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/conf/ConfigurationOptionSSL.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/conf/ConfigurationOptionSSL.java
@@ -1,20 +1,25 @@
 package de.dytanic.cloudnet.conf;
 
 import de.dytanic.cloudnet.driver.network.ssl.SSLConfiguration;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.io.File;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class ConfigurationOptionSSL {
 
     private boolean enabled, clientAuth;
 
     private String trustCertificatePath, certificatePath, privateKeyPath;
+
+    public ConfigurationOptionSSL(boolean enabled, boolean clientAuth, String trustCertificatePath, String certificatePath, String privateKeyPath) {
+        this.enabled = enabled;
+        this.clientAuth = clientAuth;
+        this.trustCertificatePath = trustCertificatePath;
+        this.certificatePath = certificatePath;
+        this.privateKeyPath = privateKeyPath;
+    }
+
+    public ConfigurationOptionSSL() {
+    }
 
     public SSLConfiguration toSslConfiguration() {
         return new SSLConfiguration(
@@ -23,5 +28,89 @@ public class ConfigurationOptionSSL {
                 certificatePath == null ? null : new File(certificatePath),
                 privateKeyPath == null ? null : new File(privateKeyPath)
         );
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public boolean isClientAuth() {
+        return this.clientAuth;
+    }
+
+    public String getTrustCertificatePath() {
+        return this.trustCertificatePath;
+    }
+
+    public String getCertificatePath() {
+        return this.certificatePath;
+    }
+
+    public String getPrivateKeyPath() {
+        return this.privateKeyPath;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setClientAuth(boolean clientAuth) {
+        this.clientAuth = clientAuth;
+    }
+
+    public void setTrustCertificatePath(String trustCertificatePath) {
+        this.trustCertificatePath = trustCertificatePath;
+    }
+
+    public void setCertificatePath(String certificatePath) {
+        this.certificatePath = certificatePath;
+    }
+
+    public void setPrivateKeyPath(String privateKeyPath) {
+        this.privateKeyPath = privateKeyPath;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ConfigurationOptionSSL)) return false;
+        final ConfigurationOptionSSL other = (ConfigurationOptionSSL) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (this.isEnabled() != other.isEnabled()) return false;
+        if (this.isClientAuth() != other.isClientAuth()) return false;
+        final Object this$trustCertificatePath = this.getTrustCertificatePath();
+        final Object other$trustCertificatePath = other.getTrustCertificatePath();
+        if (this$trustCertificatePath == null ? other$trustCertificatePath != null : !this$trustCertificatePath.equals(other$trustCertificatePath))
+            return false;
+        final Object this$certificatePath = this.getCertificatePath();
+        final Object other$certificatePath = other.getCertificatePath();
+        if (this$certificatePath == null ? other$certificatePath != null : !this$certificatePath.equals(other$certificatePath))
+            return false;
+        final Object this$privateKeyPath = this.getPrivateKeyPath();
+        final Object other$privateKeyPath = other.getPrivateKeyPath();
+        if (this$privateKeyPath == null ? other$privateKeyPath != null : !this$privateKeyPath.equals(other$privateKeyPath))
+            return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof ConfigurationOptionSSL;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + (this.isEnabled() ? 79 : 97);
+        result = result * PRIME + (this.isClientAuth() ? 79 : 97);
+        final Object $trustCertificatePath = this.getTrustCertificatePath();
+        result = result * PRIME + ($trustCertificatePath == null ? 43 : $trustCertificatePath.hashCode());
+        final Object $certificatePath = this.getCertificatePath();
+        result = result * PRIME + ($certificatePath == null ? 43 : $certificatePath.hashCode());
+        final Object $privateKeyPath = this.getPrivateKeyPath();
+        result = result * PRIME + ($privateKeyPath == null ? 43 : $privateKeyPath.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "ConfigurationOptionSSL(enabled=" + this.isEnabled() + ", clientAuth=" + this.isClientAuth() + ", trustCertificatePath=" + this.getTrustCertificatePath() + ", certificatePath=" + this.getCertificatePath() + ", privateKeyPath=" + this.getPrivateKeyPath() + ")";
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/conf/JsonConfiguration.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/conf/JsonConfiguration.java
@@ -8,8 +8,6 @@ import de.dytanic.cloudnet.common.unsafe.CPUUsageResolver;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import de.dytanic.cloudnet.driver.network.cluster.NetworkCluster;
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNode;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.lang.reflect.Type;
 import java.net.InetAddress;
@@ -25,7 +23,6 @@ import java.util.Collections;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-@Getter
 public final class JsonConfiguration implements IConfiguration {
 
     private static final Type
@@ -64,7 +61,6 @@ public final class JsonConfiguration implements IConfiguration {
 
     private String jVMCommand;
 
-    @Setter
     private String defaultHostAddress;
 
     @Override
@@ -251,5 +247,81 @@ public final class JsonConfiguration implements IConfiguration {
 
         this.httpListeners = httpListeners;
         this.save();
+    }
+
+    public JsonDocument getDocument() {
+        return this.document;
+    }
+
+    public NetworkClusterNode getIdentity() {
+        return this.identity;
+    }
+
+    public NetworkCluster getClusterConfig() {
+        return this.clusterConfig;
+    }
+
+    public Collection<String> getIpWhitelist() {
+        return this.ipWhitelist;
+    }
+
+    public double getMaxCPUUsageToStartServices() {
+        return this.maxCPUUsageToStartServices;
+    }
+
+    public boolean isParallelServiceStartSequence() {
+        return this.parallelServiceStartSequence;
+    }
+
+    public boolean isRunBlockedServiceStartTryLaterAutomatic() {
+        return this.runBlockedServiceStartTryLaterAutomatic;
+    }
+
+    public int getMaxMemory() {
+        return this.maxMemory;
+    }
+
+    public int getMaxServiceConsoleLogCacheSize() {
+        return this.maxServiceConsoleLogCacheSize;
+    }
+
+    public boolean isPrintErrorStreamLinesFromServices() {
+        return this.printErrorStreamLinesFromServices;
+    }
+
+    public boolean isDefaultJVMOptionParameters() {
+        return this.defaultJVMOptionParameters;
+    }
+
+    public String getHostAddress() {
+        return this.hostAddress;
+    }
+
+    public Collection<HostAndPort> getHttpListeners() {
+        return this.httpListeners;
+    }
+
+    public ConfigurationOptionSSL getClientSslConfig() {
+        return this.clientSslConfig;
+    }
+
+    public ConfigurationOptionSSL getServerSslConfig() {
+        return this.serverSslConfig;
+    }
+
+    public ConfigurationOptionSSL getWebSslConfig() {
+        return this.webSslConfig;
+    }
+
+    public String getJVMCommand() {
+        return this.jVMCommand;
+    }
+
+    public String getDefaultHostAddress() {
+        return this.defaultHostAddress;
+    }
+
+    public void setDefaultHostAddress(String defaultHostAddress) {
+        this.defaultHostAddress = defaultHostAddress;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/conf/JsonConfigurationRegistry.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/conf/JsonConfigurationRegistry.java
@@ -2,17 +2,11 @@ package de.dytanic.cloudnet.conf;
 
 import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-@Getter
-@ToString
-@EqualsAndHashCode
 public final class JsonConfigurationRegistry implements IConfigurationRegistry {
 
     private final int registryVersion = 1, lowestSupportedVersion = 1;
@@ -242,5 +236,52 @@ public final class JsonConfigurationRegistry implements IConfigurationRegistry {
                 this.entries = loaded.getDocument("entries");
 
         return this;
+    }
+
+    public int getRegistryVersion() {
+        return this.registryVersion;
+    }
+
+    public int getLowestSupportedVersion() {
+        return this.lowestSupportedVersion;
+    }
+
+    public Path getPath() {
+        return this.path;
+    }
+
+    public JsonDocument getEntries() {
+        return this.entries;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof JsonConfigurationRegistry)) return false;
+        final JsonConfigurationRegistry other = (JsonConfigurationRegistry) o;
+        if (this.getRegistryVersion() != other.getRegistryVersion()) return false;
+        if (this.getLowestSupportedVersion() != other.getLowestSupportedVersion()) return false;
+        final Object this$path = this.getPath();
+        final Object other$path = other.getPath();
+        if (this$path == null ? other$path != null : !this$path.equals(other$path)) return false;
+        final Object this$entries = this.getEntries();
+        final Object other$entries = other.getEntries();
+        if (this$entries == null ? other$entries != null : !this$entries.equals(other$entries)) return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + this.getRegistryVersion();
+        result = result * PRIME + this.getLowestSupportedVersion();
+        final Object $path = this.getPath();
+        result = result * PRIME + ($path == null ? 43 : $path.hashCode());
+        final Object $entries = this.getEntries();
+        result = result * PRIME + ($entries == null ? 43 : $entries.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "JsonConfigurationRegistry(registryVersion=" + this.getRegistryVersion() + ", lowestSupportedVersion=" + this.getLowestSupportedVersion() + ", path=" + this.getPath() + ", entries=" + this.getEntries() + ")";
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/conf/JsonConfigurationRegistry.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/conf/JsonConfigurationRegistry.java
@@ -2,11 +2,15 @@ package de.dytanic.cloudnet.conf;
 
 import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+@ToString
+@EqualsAndHashCode
 public final class JsonConfigurationRegistry implements IConfigurationRegistry {
 
     private final int registryVersion = 1, lowestSupportedVersion = 1;
@@ -254,34 +258,4 @@ public final class JsonConfigurationRegistry implements IConfigurationRegistry {
         return this.entries;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof JsonConfigurationRegistry)) return false;
-        final JsonConfigurationRegistry other = (JsonConfigurationRegistry) o;
-        if (this.getRegistryVersion() != other.getRegistryVersion()) return false;
-        if (this.getLowestSupportedVersion() != other.getLowestSupportedVersion()) return false;
-        final Object this$path = this.getPath();
-        final Object other$path = other.getPath();
-        if (this$path == null ? other$path != null : !this$path.equals(other$path)) return false;
-        final Object this$entries = this.getEntries();
-        final Object other$entries = other.getEntries();
-        if (this$entries == null ? other$entries != null : !this$entries.equals(other$entries)) return false;
-        return true;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        result = result * PRIME + this.getRegistryVersion();
-        result = result * PRIME + this.getLowestSupportedVersion();
-        final Object $path = this.getPath();
-        result = result * PRIME + ($path == null ? 43 : $path.hashCode());
-        final Object $entries = this.getEntries();
-        result = result * PRIME + ($entries == null ? 43 : $entries.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "JsonConfigurationRegistry(registryVersion=" + this.getRegistryVersion() + ", lowestSupportedVersion=" + this.getLowestSupportedVersion() + ", path=" + this.getPath() + ", entries=" + this.getEntries() + ")";
-    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/ConsoleColor.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/ConsoleColor.java
@@ -1,9 +1,7 @@
 package de.dytanic.cloudnet.console;
 
-import lombok.Getter;
 import org.fusesource.jansi.Ansi;
 
-@Getter
 public enum ConsoleColor {
 
     DEFAULT("default", '0', Ansi.ansi().a(Ansi.Attribute.RESET).fg(Ansi.Color.DEFAULT).boldOff().toString()),
@@ -43,5 +41,17 @@ public enum ConsoleColor {
     @Override
     public String toString() {
         return ansiCode;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getAnsiCode() {
+        return this.ansiCode;
+    }
+
+    public char getIndex() {
+        return this.index;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/ConsoleLogHandler.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/ConsoleLogHandler.java
@@ -2,14 +2,14 @@ package de.dytanic.cloudnet.console;
 
 import de.dytanic.cloudnet.common.logging.AbstractLogHandler;
 import de.dytanic.cloudnet.common.logging.LogEntry;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
 public final class ConsoleLogHandler extends AbstractLogHandler {
 
     private final IConsole console;
+
+    public ConsoleLogHandler(IConsole console) {
+        this.console = console;
+    }
 
     @Override
     public void handle(LogEntry logEntry) {
@@ -19,5 +19,9 @@ public final class ConsoleLogHandler extends AbstractLogHandler {
     @Override
     public void close() throws Exception {
 
+    }
+
+    public IConsole getConsole() {
+        return this.console;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine2Console.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine2Console.java
@@ -1,11 +1,8 @@
 package de.dytanic.cloudnet.console;
 
 import jline.console.ConsoleReader;
-import lombok.Getter;
-import lombok.Setter;
 import org.fusesource.jansi.AnsiConsole;
 
-@Getter
 public final class JLine2Console implements IConsole {
 
     private final ConsoleReader consoleReader;
@@ -15,7 +12,6 @@ public final class JLine2Console implements IConsole {
             version = System.getProperty("cloudnet.launcher.select.version"),
             prompt = System.getProperty("cloudnet.console.prompt", "&3%user%&0@&9%screen% &1=> ");
 
-    @Setter
     private String screenName = version;
 
     public JLine2Console() throws Exception {
@@ -99,5 +95,29 @@ public final class JLine2Console implements IConsole {
     @Override
     public void close() throws Exception {
         this.consoleReader.close();
+    }
+
+    public ConsoleReader getConsoleReader() {
+        return this.consoleReader;
+    }
+
+    public String getUser() {
+        return this.user;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public String getPrompt() {
+        return this.prompt;
+    }
+
+    public String getScreenName() {
+        return this.screenName;
+    }
+
+    public void setScreenName(String screenName) {
+        this.screenName = screenName;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/animation/CAProgressBar.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/animation/CAProgressBar.java
@@ -1,6 +1,8 @@
 package de.dytanic.cloudnet.console.animation;
 
 import de.dytanic.cloudnet.console.IConsole;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.fusesource.jansi.Ansi;
 
 import java.text.SimpleDateFormat;
@@ -28,6 +30,8 @@ import java.text.SimpleDateFormat;
  * }, 5, -1);
  * consoleProvider.invokeConsoleAnimation(progressBar);
  */
+@ToString
+@EqualsAndHashCode
 public class CAProgressBar {
 
     protected long updateInterval, targetGoal, barStart;
@@ -161,51 +165,4 @@ public class CAProgressBar {
         this.progressChar = progressChar;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof CAProgressBar)) return false;
-        final CAProgressBar other = (CAProgressBar) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (this.getUpdateInterval() != other.getUpdateInterval()) return false;
-        if (this.getTargetGoal() != other.getTargetGoal()) return false;
-        if (this.getBarStart() != other.getBarStart()) return false;
-        if (this.isExpand() != other.isExpand()) return false;
-        if (this.getProgressValue() != other.getProgressValue()) return false;
-        final Object this$prefix = this.getPrefix();
-        final Object other$prefix = other.getPrefix();
-        if (this$prefix == null ? other$prefix != null : !this$prefix.equals(other$prefix)) return false;
-        final Object this$suffix = this.getSuffix();
-        final Object other$suffix = other.getSuffix();
-        if (this$suffix == null ? other$suffix != null : !this$suffix.equals(other$suffix)) return false;
-        if (this.getProgressChar() != other.getProgressChar()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof CAProgressBar;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final long $updateInterval = this.getUpdateInterval();
-        result = result * PRIME + (int) ($updateInterval >>> 32 ^ $updateInterval);
-        final long $targetGoal = this.getTargetGoal();
-        result = result * PRIME + (int) ($targetGoal >>> 32 ^ $targetGoal);
-        final long $barStart = this.getBarStart();
-        result = result * PRIME + (int) ($barStart >>> 32 ^ $barStart);
-        result = result * PRIME + (this.isExpand() ? 79 : 97);
-        final long $progressValue = this.getProgressValue();
-        result = result * PRIME + (int) ($progressValue >>> 32 ^ $progressValue);
-        final Object $prefix = this.getPrefix();
-        result = result * PRIME + ($prefix == null ? 43 : $prefix.hashCode());
-        final Object $suffix = this.getSuffix();
-        result = result * PRIME + ($suffix == null ? 43 : $suffix.hashCode());
-        result = result * PRIME + this.getProgressChar();
-        return result;
-    }
-
-    public String toString() {
-        return "CAProgressBar(updateInterval=" + this.getUpdateInterval() + ", targetGoal=" + this.getTargetGoal() + ", barStart=" + this.getBarStart() + ", expand=" + this.isExpand() + ", progressValue=" + this.getProgressValue() + ", prefix=" + this.getPrefix() + ", suffix=" + this.getSuffix() + ", progressChar=" + this.getProgressChar() + ")";
-    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/animation/CAProgressBar.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/animation/CAProgressBar.java
@@ -1,9 +1,6 @@
 package de.dytanic.cloudnet.console.animation;
 
 import de.dytanic.cloudnet.console.IConsole;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 import org.fusesource.jansi.Ansi;
 
 import java.text.SimpleDateFormat;
@@ -31,9 +28,6 @@ import java.text.SimpleDateFormat;
  * }, 5, -1);
  * consoleProvider.invokeConsoleAnimation(progressBar);
  */
-@Data
-@ToString
-@EqualsAndHashCode(callSuper = false)
 public class CAProgressBar {
 
     protected long updateInterval, targetGoal, barStart;
@@ -103,4 +97,115 @@ public class CAProgressBar {
                 .replace("%value%", this.progressValue + "");
     }
 
+    public long getUpdateInterval() {
+        return this.updateInterval;
+    }
+
+    public long getTargetGoal() {
+        return this.targetGoal;
+    }
+
+    public long getBarStart() {
+        return this.barStart;
+    }
+
+    public boolean isExpand() {
+        return this.expand;
+    }
+
+    public long getProgressValue() {
+        return this.progressValue;
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+    public String getSuffix() {
+        return this.suffix;
+    }
+
+    public char getProgressChar() {
+        return this.progressChar;
+    }
+
+    public void setUpdateInterval(long updateInterval) {
+        this.updateInterval = updateInterval;
+    }
+
+    public void setTargetGoal(long targetGoal) {
+        this.targetGoal = targetGoal;
+    }
+
+    public void setBarStart(long barStart) {
+        this.barStart = barStart;
+    }
+
+    public void setExpand(boolean expand) {
+        this.expand = expand;
+    }
+
+    public void setProgressValue(long progressValue) {
+        this.progressValue = progressValue;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public void setSuffix(String suffix) {
+        this.suffix = suffix;
+    }
+
+    public void setProgressChar(char progressChar) {
+        this.progressChar = progressChar;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof CAProgressBar)) return false;
+        final CAProgressBar other = (CAProgressBar) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (this.getUpdateInterval() != other.getUpdateInterval()) return false;
+        if (this.getTargetGoal() != other.getTargetGoal()) return false;
+        if (this.getBarStart() != other.getBarStart()) return false;
+        if (this.isExpand() != other.isExpand()) return false;
+        if (this.getProgressValue() != other.getProgressValue()) return false;
+        final Object this$prefix = this.getPrefix();
+        final Object other$prefix = other.getPrefix();
+        if (this$prefix == null ? other$prefix != null : !this$prefix.equals(other$prefix)) return false;
+        final Object this$suffix = this.getSuffix();
+        final Object other$suffix = other.getSuffix();
+        if (this$suffix == null ? other$suffix != null : !this$suffix.equals(other$suffix)) return false;
+        if (this.getProgressChar() != other.getProgressChar()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof CAProgressBar;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final long $updateInterval = this.getUpdateInterval();
+        result = result * PRIME + (int) ($updateInterval >>> 32 ^ $updateInterval);
+        final long $targetGoal = this.getTargetGoal();
+        result = result * PRIME + (int) ($targetGoal >>> 32 ^ $targetGoal);
+        final long $barStart = this.getBarStart();
+        result = result * PRIME + (int) ($barStart >>> 32 ^ $barStart);
+        result = result * PRIME + (this.isExpand() ? 79 : 97);
+        final long $progressValue = this.getProgressValue();
+        result = result * PRIME + (int) ($progressValue >>> 32 ^ $progressValue);
+        final Object $prefix = this.getPrefix();
+        result = result * PRIME + ($prefix == null ? 43 : $prefix.hashCode());
+        final Object $suffix = this.getSuffix();
+        result = result * PRIME + ($suffix == null ? 43 : $suffix.hashCode());
+        result = result * PRIME + this.getProgressChar();
+        return result;
+    }
+
+    public String toString() {
+        return "CAProgressBar(updateInterval=" + this.getUpdateInterval() + ", targetGoal=" + this.getTargetGoal() + ", barStart=" + this.getBarStart() + ", expand=" + this.isExpand() + ", progressValue=" + this.getProgressValue() + ", prefix=" + this.getPrefix() + ", suffix=" + this.getSuffix() + ", progressChar=" + this.getProgressChar() + ")";
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/database/AbstractDatabaseProvider.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/database/AbstractDatabaseProvider.java
@@ -1,15 +1,11 @@
 package de.dytanic.cloudnet.database;
 
 import de.dytanic.cloudnet.common.INameable;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.Collection;
 
 public abstract class AbstractDatabaseProvider implements INameable, AutoCloseable {
 
-    @Getter
-    @Setter
     protected IDatabaseHandler databaseHandler;
 
     public abstract boolean init() throws Exception;
@@ -22,4 +18,11 @@ public abstract class AbstractDatabaseProvider implements INameable, AutoCloseab
 
     public abstract Collection<String> getDatabaseNames();
 
+    public IDatabaseHandler getDatabaseHandler() {
+        return this.databaseHandler;
+    }
+
+    public void setDatabaseHandler(IDatabaseHandler databaseHandler) {
+        this.databaseHandler = databaseHandler;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/database/h2/H2Database.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/database/h2/H2Database.java
@@ -7,7 +7,6 @@ import de.dytanic.cloudnet.common.concurrent.ITask;
 import de.dytanic.cloudnet.common.concurrent.IThrowableCallback;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.database.IDatabase;
-import lombok.Getter;
 
 import java.sql.ResultSet;
 import java.util.Collection;
@@ -18,7 +17,6 @@ import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 
-@Getter
 public final class H2Database implements IDatabase {
 
     private static final String TABLE_COLUMN_KEY = "Name", TABLE_COLUMN_VALUE = "Document";
@@ -432,5 +430,13 @@ public final class H2Database implements IDatabase {
 
     private <T> ITask<T> schedule(Callable<T> callable) {
         return schedule(callable);
+    }
+
+    public H2DatabaseProvider getDatabaseProvider() {
+        return this.databaseProvider;
+    }
+
+    public String getName() {
+        return this.name;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/cluster/NetworkChannelAuthClusterNodeSuccessEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/cluster/NetworkChannelAuthClusterNodeSuccessEvent.java
@@ -3,15 +3,23 @@ package de.dytanic.cloudnet.event.cluster;
 import de.dytanic.cloudnet.cluster.IClusterNodeServer;
 import de.dytanic.cloudnet.driver.event.Event;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NetworkChannelAuthClusterNodeSuccessEvent extends Event {
 
     private final IClusterNodeServer node;
 
     private final INetworkChannel channel;
 
+    public NetworkChannelAuthClusterNodeSuccessEvent(IClusterNodeServer node, INetworkChannel channel) {
+        this.node = node;
+        this.channel = channel;
+    }
+
+    public IClusterNodeServer getNode() {
+        return this.node;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/cluster/NetworkClusterChannelMessageReceiveEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/cluster/NetworkClusterChannelMessageReceiveEvent.java
@@ -3,9 +3,7 @@ package de.dytanic.cloudnet.event.cluster;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.event.events.network.NetworkEvent;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
-import lombok.Getter;
 
-@Getter
 public class NetworkClusterChannelMessageReceiveEvent extends NetworkEvent {
 
     private final String messageChannel, message;
@@ -22,5 +20,21 @@ public class NetworkClusterChannelMessageReceiveEvent extends NetworkEvent {
         this.message = message;
         this.header = header;
         this.body = body;
+    }
+
+    public String getMessageChannel() {
+        return this.messageChannel;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public JsonDocument getHeader() {
+        return this.header;
+    }
+
+    public byte[] getBody() {
+        return this.body;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/cluster/NetworkClusterNodeInfoConfigureEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/cluster/NetworkClusterNodeInfoConfigureEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.cluster;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNodeInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NetworkClusterNodeInfoConfigureEvent extends DriverEvent {
 
     private final NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot;
 
+    public NetworkClusterNodeInfoConfigureEvent(NetworkClusterNodeInfoSnapshot networkClusterNodeInfoSnapshot) {
+        this.networkClusterNodeInfoSnapshot = networkClusterNodeInfoSnapshot;
+    }
+
+    public NetworkClusterNodeInfoSnapshot getNetworkClusterNodeInfoSnapshot() {
+        return this.networkClusterNodeInfoSnapshot;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/command/CommandNotFoundEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/command/CommandNotFoundEvent.java
@@ -1,13 +1,16 @@
 package de.dytanic.cloudnet.event.command;
 
 import de.dytanic.cloudnet.driver.event.Event;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public class CommandNotFoundEvent extends Event {
 
     private final String commandLine;
 
+    public CommandNotFoundEvent(String commandLine) {
+        this.commandLine = commandLine;
+    }
+
+    public String getCommandLine() {
+        return this.commandLine;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/command/CommandPostProcessEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/command/CommandPostProcessEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.event.command;
 
 import de.dytanic.cloudnet.command.ICommandSender;
 import de.dytanic.cloudnet.driver.event.Event;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public class CommandPostProcessEvent extends Event {
 
     private final String commandLine;
 
     private final ICommandSender commandSender;
 
+    public CommandPostProcessEvent(String commandLine, ICommandSender commandSender) {
+        this.commandLine = commandLine;
+        this.commandSender = commandSender;
+    }
+
+    public String getCommandLine() {
+        return this.commandLine;
+    }
+
+    public ICommandSender getCommandSender() {
+        return this.commandSender;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/command/CommandPreProcessEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/command/CommandPreProcessEvent.java
@@ -3,18 +3,33 @@ package de.dytanic.cloudnet.event.command;
 import de.dytanic.cloudnet.command.ICommandSender;
 import de.dytanic.cloudnet.driver.event.Event;
 import de.dytanic.cloudnet.driver.event.ICancelable;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@RequiredArgsConstructor
 public class CommandPreProcessEvent extends Event implements ICancelable {
 
     private final String commandLine;
 
     private final ICommandSender commandSender;
 
-    @Setter
     private boolean cancelled = false;
+
+    public CommandPreProcessEvent(String commandLine, ICommandSender commandSender) {
+        this.commandLine = commandLine;
+        this.commandSender = commandSender;
+    }
+
+    public String getCommandLine() {
+        return this.commandLine;
+    }
+
+    public ICommandSender getCommandSender() {
+        return this.commandSender;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseClearEntriesEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseClearEntriesEvent.java
@@ -1,11 +1,7 @@
 package de.dytanic.cloudnet.event.database;
 
 import de.dytanic.cloudnet.database.IDatabase;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
 public class DatabaseClearEntriesEvent extends DatabaseEvent {
 
     public DatabaseClearEntriesEvent(IDatabase database) {

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseDeleteEntryEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseDeleteEntryEvent.java
@@ -1,11 +1,7 @@
 package de.dytanic.cloudnet.event.database;
 
 import de.dytanic.cloudnet.database.IDatabase;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
 public class DatabaseDeleteEntryEvent extends DatabaseEvent {
 
     private String key;
@@ -13,6 +9,14 @@ public class DatabaseDeleteEntryEvent extends DatabaseEvent {
     public DatabaseDeleteEntryEvent(IDatabase database, String key) {
         super(database);
 
+        this.key = key;
+    }
+
+    public String getKey() {
+        return this.key;
+    }
+
+    public void setKey(String key) {
         this.key = key;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.database;
 
 import de.dytanic.cloudnet.database.IDatabase;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 abstract class DatabaseEvent extends DriverEvent {
 
     private final IDatabase database;
 
+    public DatabaseEvent(IDatabase database) {
+        this.database = database;
+    }
+
+    public IDatabase getDatabase() {
+        return this.database;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseInsertEntryEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseInsertEntryEvent.java
@@ -2,11 +2,7 @@ package de.dytanic.cloudnet.event.database;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.database.IDatabase;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
 public class DatabaseInsertEntryEvent extends DatabaseEvent {
 
     private String key;
@@ -17,6 +13,22 @@ public class DatabaseInsertEntryEvent extends DatabaseEvent {
         super(database);
 
         this.key = key;
+        this.document = document;
+    }
+
+    public String getKey() {
+        return this.key;
+    }
+
+    public JsonDocument getDocument() {
+        return this.document;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setDocument(JsonDocument document) {
         this.document = document;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseUpdateEntryEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/database/DatabaseUpdateEntryEvent.java
@@ -2,11 +2,7 @@ package de.dytanic.cloudnet.event.database;
 
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.database.IDatabase;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
 public class DatabaseUpdateEntryEvent extends DatabaseEvent {
 
     private String key;
@@ -17,6 +13,22 @@ public class DatabaseUpdateEntryEvent extends DatabaseEvent {
         super(database);
 
         this.key = key;
+        this.document = document;
+    }
+
+    public String getKey() {
+        return this.key;
+    }
+
+    public JsonDocument getDocument() {
+        return this.document;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setDocument(JsonDocument document) {
         this.document = document;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/log/LoggingEntryEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/log/LoggingEntryEvent.java
@@ -2,12 +2,16 @@ package de.dytanic.cloudnet.event.log;
 
 import de.dytanic.cloudnet.common.logging.LogEntry;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class LoggingEntryEvent extends DriverEvent {
 
     private final LogEntry logEntry;
+
+    public LoggingEntryEvent(LogEntry logEntry) {
+        this.logEntry = logEntry;
+    }
+
+    public LogEntry getLogEntry() {
+        return this.logEntry;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelAuthCloudServiceSuccessEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelAuthCloudServiceSuccessEvent.java
@@ -3,15 +3,23 @@ package de.dytanic.cloudnet.event.network;
 import de.dytanic.cloudnet.driver.event.Event;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class NetworkChannelAuthCloudServiceSuccessEvent extends Event {
 
     private final ICloudService cloudService;
 
     private final INetworkChannel channel;
 
+    public NetworkChannelAuthCloudServiceSuccessEvent(ICloudService cloudService, INetworkChannel channel) {
+        this.cloudService = cloudService;
+        this.channel = channel;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
+
+    public INetworkChannel getChannel() {
+        return this.channel;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveCallablePacketEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveCallablePacketEvent.java
@@ -6,11 +6,9 @@ import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.network.def.PacketConstants;
 import de.dytanic.cloudnet.driver.network.protocol.IPacket;
 import de.dytanic.cloudnet.driver.network.protocol.Packet;
-import lombok.Getter;
 
 import java.util.UUID;
 
-@Getter
 public final class NetworkChannelReceiveCallablePacketEvent extends NetworkEvent {
 
     private final String channelName;
@@ -34,5 +32,25 @@ public final class NetworkChannelReceiveCallablePacketEvent extends NetworkEvent
 
     public void setCallbackPacket(JsonDocument header) {
         this.callbackPacket = new Packet(PacketConstants.INTERNAL_CALLABLE_CHANNEL, this.uniqueId, header, null);
+    }
+
+    public String getChannelName() {
+        return this.channelName;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public JsonDocument getHeader() {
+        return this.header;
+    }
+
+    public UUID getUniqueId() {
+        return this.uniqueId;
+    }
+
+    public IPacket getCallbackPacket() {
+        return this.callbackPacket;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveGroupConfigurationsUpdateEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveGroupConfigurationsUpdateEvent.java
@@ -4,9 +4,13 @@ import de.dytanic.cloudnet.driver.event.ICancelable;
 import de.dytanic.cloudnet.driver.event.events.network.NetworkEvent;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.service.GroupConfiguration;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public final class NetworkChannelReceiveGroupConfigurationsUpdateEvent extends NetworkEvent implements ICancelable {
 
     private List<GroupConfiguration> groupConfigurations;
@@ -34,35 +38,4 @@ public final class NetworkChannelReceiveGroupConfigurationsUpdateEvent extends N
         this.cancelled = cancelled;
     }
 
-    public String toString() {
-        return "NetworkChannelReceiveGroupConfigurationsUpdateEvent(groupConfigurations=" + this.getGroupConfigurations() + ", cancelled=" + this.isCancelled() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NetworkChannelReceiveGroupConfigurationsUpdateEvent))
-            return false;
-        final NetworkChannelReceiveGroupConfigurationsUpdateEvent other = (NetworkChannelReceiveGroupConfigurationsUpdateEvent) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (!super.equals(o)) return false;
-        final Object this$groupConfigurations = this.getGroupConfigurations();
-        final Object other$groupConfigurations = other.getGroupConfigurations();
-        if (this$groupConfigurations == null ? other$groupConfigurations != null : !this$groupConfigurations.equals(other$groupConfigurations))
-            return false;
-        if (this.isCancelled() != other.isCancelled()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof NetworkChannelReceiveGroupConfigurationsUpdateEvent;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = super.hashCode();
-        final Object $groupConfigurations = this.getGroupConfigurations();
-        result = result * PRIME + ($groupConfigurations == null ? 43 : $groupConfigurations.hashCode());
-        result = result * PRIME + (this.isCancelled() ? 79 : 97);
-        return result;
-    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveGroupConfigurationsUpdateEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveGroupConfigurationsUpdateEvent.java
@@ -4,13 +4,9 @@ import de.dytanic.cloudnet.driver.event.ICancelable;
 import de.dytanic.cloudnet.driver.event.events.network.NetworkEvent;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.service.GroupConfiguration;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public final class NetworkChannelReceiveGroupConfigurationsUpdateEvent extends NetworkEvent implements ICancelable {
 
     private List<GroupConfiguration> groupConfigurations;
@@ -20,5 +16,53 @@ public final class NetworkChannelReceiveGroupConfigurationsUpdateEvent extends N
     public NetworkChannelReceiveGroupConfigurationsUpdateEvent(INetworkChannel channel, List<GroupConfiguration> groupConfigurations) {
         super(channel);
         this.groupConfigurations = groupConfigurations;
+    }
+
+    public List<GroupConfiguration> getGroupConfigurations() {
+        return this.groupConfigurations;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setGroupConfigurations(List<GroupConfiguration> groupConfigurations) {
+        this.groupConfigurations = groupConfigurations;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public String toString() {
+        return "NetworkChannelReceiveGroupConfigurationsUpdateEvent(groupConfigurations=" + this.getGroupConfigurations() + ", cancelled=" + this.isCancelled() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NetworkChannelReceiveGroupConfigurationsUpdateEvent))
+            return false;
+        final NetworkChannelReceiveGroupConfigurationsUpdateEvent other = (NetworkChannelReceiveGroupConfigurationsUpdateEvent) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (!super.equals(o)) return false;
+        final Object this$groupConfigurations = this.getGroupConfigurations();
+        final Object other$groupConfigurations = other.getGroupConfigurations();
+        if (this$groupConfigurations == null ? other$groupConfigurations != null : !this$groupConfigurations.equals(other$groupConfigurations))
+            return false;
+        if (this.isCancelled() != other.isCancelled()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof NetworkChannelReceiveGroupConfigurationsUpdateEvent;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = super.hashCode();
+        final Object $groupConfigurations = this.getGroupConfigurations();
+        result = result * PRIME + ($groupConfigurations == null ? 43 : $groupConfigurations.hashCode());
+        result = result * PRIME + (this.isCancelled() ? 79 : 97);
+        return result;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveJsonFilePermissionsUpdateEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveJsonFilePermissionsUpdateEvent.java
@@ -5,13 +5,9 @@ import de.dytanic.cloudnet.driver.event.events.network.NetworkEvent;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.permission.PermissionGroup;
 import de.dytanic.cloudnet.driver.permission.PermissionUser;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public final class NetworkChannelReceiveJsonFilePermissionsUpdateEvent extends NetworkEvent implements ICancelable {
 
     private List<PermissionUser> permissionUsers;
@@ -24,5 +20,67 @@ public final class NetworkChannelReceiveJsonFilePermissionsUpdateEvent extends N
         super(channel);
         this.permissionUsers = permissionUsers;
         this.permissionGroups = permissionGroups;
+    }
+
+    public List<PermissionUser> getPermissionUsers() {
+        return this.permissionUsers;
+    }
+
+    public List<PermissionGroup> getPermissionGroups() {
+        return this.permissionGroups;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setPermissionUsers(List<PermissionUser> permissionUsers) {
+        this.permissionUsers = permissionUsers;
+    }
+
+    public void setPermissionGroups(List<PermissionGroup> permissionGroups) {
+        this.permissionGroups = permissionGroups;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public String toString() {
+        return "NetworkChannelReceiveJsonFilePermissionsUpdateEvent(permissionUsers=" + this.getPermissionUsers() + ", permissionGroups=" + this.getPermissionGroups() + ", cancelled=" + this.isCancelled() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NetworkChannelReceiveJsonFilePermissionsUpdateEvent))
+            return false;
+        final NetworkChannelReceiveJsonFilePermissionsUpdateEvent other = (NetworkChannelReceiveJsonFilePermissionsUpdateEvent) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (!super.equals(o)) return false;
+        final Object this$permissionUsers = this.getPermissionUsers();
+        final Object other$permissionUsers = other.getPermissionUsers();
+        if (this$permissionUsers == null ? other$permissionUsers != null : !this$permissionUsers.equals(other$permissionUsers))
+            return false;
+        final Object this$permissionGroups = this.getPermissionGroups();
+        final Object other$permissionGroups = other.getPermissionGroups();
+        if (this$permissionGroups == null ? other$permissionGroups != null : !this$permissionGroups.equals(other$permissionGroups))
+            return false;
+        if (this.isCancelled() != other.isCancelled()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof NetworkChannelReceiveJsonFilePermissionsUpdateEvent;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = super.hashCode();
+        final Object $permissionUsers = this.getPermissionUsers();
+        result = result * PRIME + ($permissionUsers == null ? 43 : $permissionUsers.hashCode());
+        final Object $permissionGroups = this.getPermissionGroups();
+        result = result * PRIME + ($permissionGroups == null ? 43 : $permissionGroups.hashCode());
+        result = result * PRIME + (this.isCancelled() ? 79 : 97);
+        return result;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveJsonFilePermissionsUpdateEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveJsonFilePermissionsUpdateEvent.java
@@ -5,9 +5,13 @@ import de.dytanic.cloudnet.driver.event.events.network.NetworkEvent;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.permission.PermissionGroup;
 import de.dytanic.cloudnet.driver.permission.PermissionUser;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public final class NetworkChannelReceiveJsonFilePermissionsUpdateEvent extends NetworkEvent implements ICancelable {
 
     private List<PermissionUser> permissionUsers;
@@ -46,41 +50,4 @@ public final class NetworkChannelReceiveJsonFilePermissionsUpdateEvent extends N
         this.cancelled = cancelled;
     }
 
-    public String toString() {
-        return "NetworkChannelReceiveJsonFilePermissionsUpdateEvent(permissionUsers=" + this.getPermissionUsers() + ", permissionGroups=" + this.getPermissionGroups() + ", cancelled=" + this.isCancelled() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NetworkChannelReceiveJsonFilePermissionsUpdateEvent))
-            return false;
-        final NetworkChannelReceiveJsonFilePermissionsUpdateEvent other = (NetworkChannelReceiveJsonFilePermissionsUpdateEvent) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (!super.equals(o)) return false;
-        final Object this$permissionUsers = this.getPermissionUsers();
-        final Object other$permissionUsers = other.getPermissionUsers();
-        if (this$permissionUsers == null ? other$permissionUsers != null : !this$permissionUsers.equals(other$permissionUsers))
-            return false;
-        final Object this$permissionGroups = this.getPermissionGroups();
-        final Object other$permissionGroups = other.getPermissionGroups();
-        if (this$permissionGroups == null ? other$permissionGroups != null : !this$permissionGroups.equals(other$permissionGroups))
-            return false;
-        if (this.isCancelled() != other.isCancelled()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof NetworkChannelReceiveJsonFilePermissionsUpdateEvent;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = super.hashCode();
-        final Object $permissionUsers = this.getPermissionUsers();
-        result = result * PRIME + ($permissionUsers == null ? 43 : $permissionUsers.hashCode());
-        final Object $permissionGroups = this.getPermissionGroups();
-        result = result * PRIME + ($permissionGroups == null ? 43 : $permissionGroups.hashCode());
-        result = result * PRIME + (this.isCancelled() ? 79 : 97);
-        return result;
-    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveServiceTasksUpdateEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveServiceTasksUpdateEvent.java
@@ -4,13 +4,9 @@ import de.dytanic.cloudnet.driver.event.ICancelable;
 import de.dytanic.cloudnet.driver.event.events.network.NetworkEvent;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.service.ServiceTask;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public final class NetworkChannelReceiveServiceTasksUpdateEvent extends NetworkEvent implements ICancelable {
 
     private List<ServiceTask> serviceTasks;
@@ -20,5 +16,53 @@ public final class NetworkChannelReceiveServiceTasksUpdateEvent extends NetworkE
     public NetworkChannelReceiveServiceTasksUpdateEvent(INetworkChannel channel, List<ServiceTask> serviceTasks) {
         super(channel);
         this.serviceTasks = serviceTasks;
+    }
+
+    public List<ServiceTask> getServiceTasks() {
+        return this.serviceTasks;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setServiceTasks(List<ServiceTask> serviceTasks) {
+        this.serviceTasks = serviceTasks;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public String toString() {
+        return "NetworkChannelReceiveServiceTasksUpdateEvent(serviceTasks=" + this.getServiceTasks() + ", cancelled=" + this.isCancelled() + ")";
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof NetworkChannelReceiveServiceTasksUpdateEvent))
+            return false;
+        final NetworkChannelReceiveServiceTasksUpdateEvent other = (NetworkChannelReceiveServiceTasksUpdateEvent) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (!super.equals(o)) return false;
+        final Object this$serviceTasks = this.getServiceTasks();
+        final Object other$serviceTasks = other.getServiceTasks();
+        if (this$serviceTasks == null ? other$serviceTasks != null : !this$serviceTasks.equals(other$serviceTasks))
+            return false;
+        if (this.isCancelled() != other.isCancelled()) return false;
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof NetworkChannelReceiveServiceTasksUpdateEvent;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = super.hashCode();
+        final Object $serviceTasks = this.getServiceTasks();
+        result = result * PRIME + ($serviceTasks == null ? 43 : $serviceTasks.hashCode());
+        result = result * PRIME + (this.isCancelled() ? 79 : 97);
+        return result;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveServiceTasksUpdateEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/network/NetworkChannelReceiveServiceTasksUpdateEvent.java
@@ -4,9 +4,13 @@ import de.dytanic.cloudnet.driver.event.ICancelable;
 import de.dytanic.cloudnet.driver.event.events.network.NetworkEvent;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.service.ServiceTask;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public final class NetworkChannelReceiveServiceTasksUpdateEvent extends NetworkEvent implements ICancelable {
 
     private List<ServiceTask> serviceTasks;
@@ -34,35 +38,4 @@ public final class NetworkChannelReceiveServiceTasksUpdateEvent extends NetworkE
         this.cancelled = cancelled;
     }
 
-    public String toString() {
-        return "NetworkChannelReceiveServiceTasksUpdateEvent(serviceTasks=" + this.getServiceTasks() + ", cancelled=" + this.isCancelled() + ")";
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof NetworkChannelReceiveServiceTasksUpdateEvent))
-            return false;
-        final NetworkChannelReceiveServiceTasksUpdateEvent other = (NetworkChannelReceiveServiceTasksUpdateEvent) o;
-        if (!other.canEqual((Object) this)) return false;
-        if (!super.equals(o)) return false;
-        final Object this$serviceTasks = this.getServiceTasks();
-        final Object other$serviceTasks = other.getServiceTasks();
-        if (this$serviceTasks == null ? other$serviceTasks != null : !this$serviceTasks.equals(other$serviceTasks))
-            return false;
-        if (this.isCancelled() != other.isCancelled()) return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof NetworkChannelReceiveServiceTasksUpdateEvent;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = super.hashCode();
-        final Object $serviceTasks = this.getServiceTasks();
-        result = result * PRIME + ($serviceTasks == null ? 43 : $serviceTasks.hashCode());
-        result = result * PRIME + (this.isCancelled() ? 79 : 97);
-        return result;
-    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/permission/PermissionServiceSetEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/permission/PermissionServiceSetEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.permission;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
 public final class PermissionServiceSetEvent extends DriverEvent {
 
     private final IPermissionManagement permissionManager;
 
+    public PermissionServiceSetEvent(IPermissionManagement permissionManager) {
+        this.permissionManager = permissionManager;
+    }
+
+    public IPermissionManagement getPermissionManager() {
+        return this.permissionManager;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServiceConsoleLogReceiveEntryEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServiceConsoleLogReceiveEntryEvent.java
@@ -2,11 +2,7 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServiceConsoleLogReceiveEntryEvent extends DriverEvent {
 
     private final ServiceInfoSnapshot serviceInfoSnapshot;
@@ -15,4 +11,21 @@ public final class CloudServiceConsoleLogReceiveEntryEvent extends DriverEvent {
 
     private final boolean errorMessage;
 
+    public CloudServiceConsoleLogReceiveEntryEvent(ServiceInfoSnapshot serviceInfoSnapshot, String message, boolean errorMessage) {
+        this.serviceInfoSnapshot = serviceInfoSnapshot;
+        this.message = message;
+        this.errorMessage = errorMessage;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public boolean isErrorMessage() {
+        return this.errorMessage;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServiceCreateEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServiceCreateEvent.java
@@ -3,17 +3,26 @@ package de.dytanic.cloudnet.event.service;
 import de.dytanic.cloudnet.driver.event.ICancelable;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.service.ServiceConfiguration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServiceCreateEvent extends DriverEvent implements ICancelable {
 
     private final ServiceConfiguration serviceConfiguration;
 
-    @Setter
     private boolean cancelled;
 
+    public CloudServiceCreateEvent(ServiceConfiguration serviceConfiguration) {
+        this.serviceConfiguration = serviceConfiguration;
+    }
+
+    public ServiceConfiguration getServiceConfiguration() {
+        return this.serviceConfiguration;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServiceDeploymentEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServiceDeploymentEvent.java
@@ -5,12 +5,7 @@ import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.service.ServiceDeployment;
 import de.dytanic.cloudnet.service.ICloudService;
 import de.dytanic.cloudnet.template.ITemplateStorage;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServiceDeploymentEvent extends DriverEvent implements ICancelable {
 
     private final ICloudService cloudService;
@@ -19,7 +14,31 @@ public final class CloudServiceDeploymentEvent extends DriverEvent implements IC
 
     private final ServiceDeployment serviceDeployment;
 
-    @Setter
     private boolean cancelled;
 
+    public CloudServiceDeploymentEvent(ICloudService cloudService, ITemplateStorage templateStorage, ServiceDeployment serviceDeployment) {
+        this.cloudService = cloudService;
+        this.templateStorage = templateStorage;
+        this.serviceDeployment = serviceDeployment;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
+
+    public ITemplateStorage getTemplateStorage() {
+        return this.templateStorage;
+    }
+
+    public ServiceDeployment getServiceDeployment() {
+        return this.serviceDeployment;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostDeleteEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostDeleteEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePostDeleteEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
+    public CloudServicePostDeleteEvent(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostPrepareEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostPrepareEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePostPrepareEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
+    public CloudServicePostPrepareEvent(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostStartEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostStartEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePostStartEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
+    public CloudServicePostStartEvent(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostStartPrepareEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostStartPrepareEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePostStartPrepareEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
+    public CloudServicePostStartPrepareEvent(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostStopEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePostStopEvent.java
@@ -2,15 +2,23 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePostStopEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
     private final int exitValue;
 
+    public CloudServicePostStopEvent(ICloudService cloudService, int exitValue) {
+        this.cloudService = cloudService;
+        this.exitValue = exitValue;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
+
+    public int getExitValue() {
+        return this.exitValue;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreDeleteEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreDeleteEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePreDeleteEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
+    public CloudServicePreDeleteEvent(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreLoadInclusionEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreLoadInclusionEvent.java
@@ -4,14 +4,9 @@ import de.dytanic.cloudnet.driver.event.ICancelable;
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.service.ServiceRemoteInclusion;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 import java.net.URLConnection;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePreLoadInclusionEvent extends DriverEvent implements ICancelable {
 
     private final ICloudService cloudService;
@@ -20,7 +15,31 @@ public final class CloudServicePreLoadInclusionEvent extends DriverEvent impleme
 
     private final URLConnection connection;
 
-    @Setter
     private boolean cancelled;
 
+    public CloudServicePreLoadInclusionEvent(ICloudService cloudService, ServiceRemoteInclusion serviceRemoteInclusion, URLConnection connection) {
+        this.cloudService = cloudService;
+        this.serviceRemoteInclusion = serviceRemoteInclusion;
+        this.connection = connection;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
+
+    public ServiceRemoteInclusion getServiceRemoteInclusion() {
+        return this.serviceRemoteInclusion;
+    }
+
+    public URLConnection getConnection() {
+        return this.connection;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePrePrepareEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePrePrepareEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePrePrepareEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
+    public CloudServicePrePrepareEvent(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreStartEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreStartEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePreStartEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
+    public CloudServicePreStartEvent(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreStartPrepareEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreStartPrepareEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePreStartPrepareEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
+    public CloudServicePreStartPrepareEvent(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreStopEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServicePreStopEvent.java
@@ -2,13 +2,16 @@ package de.dytanic.cloudnet.event.service;
 
 import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.service.ICloudService;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServicePreStopEvent extends DriverEvent {
 
     private final ICloudService cloudService;
 
+    public CloudServicePreStopEvent(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServiceTemplateLoadEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/CloudServiceTemplateLoadEvent.java
@@ -5,12 +5,7 @@ import de.dytanic.cloudnet.driver.event.events.DriverEvent;
 import de.dytanic.cloudnet.driver.service.ServiceTemplate;
 import de.dytanic.cloudnet.service.ICloudService;
 import de.dytanic.cloudnet.template.ITemplateStorage;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@RequiredArgsConstructor
 public final class CloudServiceTemplateLoadEvent extends DriverEvent implements ICancelable {
 
     private final ICloudService cloudService;
@@ -19,7 +14,31 @@ public final class CloudServiceTemplateLoadEvent extends DriverEvent implements 
 
     private final ServiceTemplate template;
 
-    @Setter
     private boolean cancelled;
 
+    public CloudServiceTemplateLoadEvent(ICloudService cloudService, ITemplateStorage storage, ServiceTemplate template) {
+        this.cloudService = cloudService;
+        this.storage = storage;
+        this.template = template;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
+
+    public ITemplateStorage getStorage() {
+        return this.storage;
+    }
+
+    public ServiceTemplate getTemplate() {
+        return this.template;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/task/ServiceTaskAddEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/task/ServiceTaskAddEvent.java
@@ -4,19 +4,33 @@ import de.dytanic.cloudnet.driver.event.Event;
 import de.dytanic.cloudnet.driver.event.ICancelable;
 import de.dytanic.cloudnet.driver.service.ServiceTask;
 import de.dytanic.cloudnet.service.ICloudServiceManager;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@RequiredArgsConstructor
 public final class ServiceTaskAddEvent extends Event implements ICancelable {
 
     private final ICloudServiceManager cloudServiceManager;
 
     private final ServiceTask task;
 
-    @Setter
     private boolean cancelled;
 
+    public ServiceTaskAddEvent(ICloudServiceManager cloudServiceManager, ServiceTask task) {
+        this.cloudServiceManager = cloudServiceManager;
+        this.task = task;
+    }
+
+    public ICloudServiceManager getCloudServiceManager() {
+        return this.cloudServiceManager;
+    }
+
+    public ServiceTask getTask() {
+        return this.task;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/task/ServiceTaskRemoveEvent.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/event/service/task/ServiceTaskRemoveEvent.java
@@ -3,18 +3,33 @@ package de.dytanic.cloudnet.event.service.task;
 import de.dytanic.cloudnet.driver.event.Event;
 import de.dytanic.cloudnet.driver.service.ServiceTask;
 import de.dytanic.cloudnet.service.ICloudServiceManager;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@RequiredArgsConstructor
 public class ServiceTaskRemoveEvent extends Event {
 
     private final ICloudServiceManager cloudServiceManager;
 
     private final ServiceTask task;
 
-    @Setter
     private boolean cancelled;
+
+    public ServiceTaskRemoveEvent(ICloudServiceManager cloudServiceManager, ServiceTask task) {
+        this.cloudServiceManager = cloudServiceManager;
+        this.task = task;
+    }
+
+    public ICloudServiceManager getCloudServiceManager() {
+        return this.cloudServiceManager;
+    }
+
+    public ServiceTask getTask() {
+        return this.task;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/http/V1HttpHandler.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/http/V1HttpHandler.java
@@ -11,7 +11,6 @@ import de.dytanic.cloudnet.driver.network.http.HttpResponseCode;
 import de.dytanic.cloudnet.driver.network.http.IHttpContext;
 import de.dytanic.cloudnet.driver.network.http.MethodHttpHandlerAdapter;
 import de.dytanic.cloudnet.driver.permission.Permission;
-import lombok.Getter;
 
 import java.util.Collection;
 
@@ -24,7 +23,6 @@ public abstract class V1HttpHandler extends MethodHttpHandlerAdapter {
 
     protected static final V1HttpSession HTTP_SESSION = new V1HttpSession();
 
-    @Getter
     private final String permission;
 
     public V1HttpHandler(String permission) {
@@ -116,5 +114,9 @@ public abstract class V1HttpHandler extends MethodHttpHandlerAdapter {
 
     protected final CloudNet getCloudNet() {
         return CloudNet.getInstance();
+    }
+
+    public String getPermission() {
+        return this.permission;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/http/V1HttpSession.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/http/V1HttpSession.java
@@ -7,7 +7,6 @@ import de.dytanic.cloudnet.common.encrypt.EncryptTo;
 import de.dytanic.cloudnet.driver.network.http.HttpCookie;
 import de.dytanic.cloudnet.driver.network.http.IHttpContext;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
-import lombok.AllArgsConstructor;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -139,12 +138,18 @@ public final class V1HttpSession {
         ));
     }
 
-    @AllArgsConstructor
     public class SessionEntry {
 
         long creationTime, lastUsageMillis;
 
         String host, uniqueId, userUniqueId;
 
+        public SessionEntry(long creationTime, long lastUsageMillis, String host, String uniqueId, String userUniqueId) {
+            this.creationTime = creationTime;
+            this.lastUsageMillis = lastUsageMillis;
+            this.host = host;
+            this.uniqueId = uniqueId;
+            this.userUniqueId = userUniqueId;
+        }
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/log/QueuedConsoleLogHandler.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/log/QueuedConsoleLogHandler.java
@@ -5,14 +5,12 @@ import de.dytanic.cloudnet.common.logging.ILogHandler;
 import de.dytanic.cloudnet.common.logging.LogEntry;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.event.log.LoggingEntryEvent;
-import lombok.Getter;
 
 import java.util.Queue;
 
 /**
  * A logging handler for developers, that can easy handle and get the logging outputs from this node instance
  */
-@Getter
 public final class QueuedConsoleLogHandler implements ILogHandler {
 
     /**
@@ -32,5 +30,9 @@ public final class QueuedConsoleLogHandler implements ILogHandler {
 
     @Override
     public void close() {
+    }
+
+    public Queue<LogEntry> getCachedQueuedLogEntries() {
+        return this.cachedQueuedLogEntries;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagement.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagement.java
@@ -8,8 +8,6 @@ import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.database.AbstractDatabaseProvider;
 import de.dytanic.cloudnet.database.IDatabase;
 import de.dytanic.cloudnet.driver.permission.*;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.io.File;
 import java.util.*;
@@ -23,12 +21,8 @@ public final class DefaultDatabasePermissionManagement implements IPermissionMan
 
     private final File file = new File(System.getProperty("cloudnet.permissions.json.path", "local/permissions.json"));
 
-    @Getter
     private final Map<String, IPermissionGroup> permissionGroupsMap = Maps.newConcurrentHashMap();
-    @Getter
     private final Callable<AbstractDatabaseProvider> databaseProviderCallable;
-    @Getter
-    @Setter
     private IPermissionManagementHandler permissionManagementHandler;
 
     public DefaultDatabasePermissionManagement(Callable<AbstractDatabaseProvider> databaseProviderCallable) {
@@ -302,5 +296,21 @@ public final class DefaultDatabasePermissionManagement implements IPermissionMan
         }
 
         return null;
+    }
+
+    public Map<String, IPermissionGroup> getPermissionGroupsMap() {
+        return this.permissionGroupsMap;
+    }
+
+    public Callable<AbstractDatabaseProvider> getDatabaseProviderCallable() {
+        return this.databaseProviderCallable;
+    }
+
+    public IPermissionManagementHandler getPermissionManagementHandler() {
+        return this.permissionManagementHandler;
+    }
+
+    public void setPermissionManagementHandler(IPermissionManagementHandler permissionManagementHandler) {
+        this.permissionManagementHandler = permissionManagementHandler;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/permission/command/DefaultPermissionUserCommandSender.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/permission/command/DefaultPermissionUserCommandSender.java
@@ -4,13 +4,9 @@ import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Queue;
 
-@Getter
-@RequiredArgsConstructor
 public final class DefaultPermissionUserCommandSender implements IPermissionUserCommandSender {
 
     protected final IPermissionUser permissionUser;
@@ -18,6 +14,11 @@ public final class DefaultPermissionUserCommandSender implements IPermissionUser
     protected final IPermissionManagement permissionManagement;
 
     protected final Queue<String> writtenMessages = Iterables.newConcurrentLinkedQueue();
+
+    public DefaultPermissionUserCommandSender(IPermissionUser permissionUser, IPermissionManagement permissionManagement) {
+        this.permissionUser = permissionUser;
+        this.permissionManagement = permissionManagement;
+    }
 
     @Override
     public String getName() {
@@ -44,5 +45,17 @@ public final class DefaultPermissionUserCommandSender implements IPermissionUser
     @Override
     public boolean hasPermission(String permission) {
         return permissionManagement.hasPermission(this.permissionUser, permission);
+    }
+
+    public IPermissionUser getPermissionUser() {
+        return this.permissionUser;
+    }
+
+    public IPermissionManagement getPermissionManagement() {
+        return this.permissionManagement;
+    }
+
+    public Queue<String> getWrittenMessages() {
+        return this.writtenMessages;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
@@ -12,14 +12,12 @@ import de.dytanic.cloudnet.event.service.CloudServiceCreateEvent;
 import de.dytanic.cloudnet.event.service.task.ServiceTaskAddEvent;
 import de.dytanic.cloudnet.event.service.task.ServiceTaskRemoveEvent;
 import de.dytanic.cloudnet.util.PortValidator;
-import lombok.Getter;
 
 import java.io.File;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-@Getter
 public final class DefaultCloudServiceManager implements ICloudServiceManager {
 
     protected static final ICloudServiceFactory DEFAULT_FACTORY = new JVMCloudServiceFactory();
@@ -475,5 +473,29 @@ public final class DefaultCloudServiceManager implements ICloudServiceManager {
             port++;
 
         return port;
+    }
+
+    public File getTempDirectory() {
+        return this.tempDirectory;
+    }
+
+    public File getPersistenceServicesDirectory() {
+        return this.persistenceServicesDirectory;
+    }
+
+    public Map<UUID, ServiceInfoSnapshot> getGlobalServiceInfoSnapshots() {
+        return this.globalServiceInfoSnapshots;
+    }
+
+    public Map<UUID, ICloudService> getCloudServices() {
+        return this.cloudServices;
+    }
+
+    public Map<String, ICloudServiceFactory> getCloudServiceFactories() {
+        return this.cloudServiceFactories;
+    }
+
+    public DefaultCloudServiceManagerConfiguration getConfig() {
+        return this.config;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManagerConfiguration.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManagerConfiguration.java
@@ -5,7 +5,6 @@ import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.service.GroupConfiguration;
 import de.dytanic.cloudnet.driver.service.ServiceTask;
-import lombok.Getter;
 
 import java.lang.reflect.Type;
 import java.nio.file.Files;
@@ -14,7 +13,6 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 
-@Getter
 final class DefaultCloudServiceManagerConfiguration {
 
     private static final Type
@@ -48,5 +46,13 @@ final class DefaultCloudServiceManagerConfiguration {
 
     public void save() {
         new JsonDocument("groups", groups).append("tasks", tasks).write(TASK_CONFIG_FILE);
+    }
+
+    public List<ServiceTask> getTasks() {
+        return this.tasks;
+    }
+
+    public List<GroupConfiguration> getGroups() {
+        return this.groups;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultServiceConsoleLogCache.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultServiceConsoleLogCache.java
@@ -7,16 +7,11 @@ import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.service.ServiceLifeCycle;
 import de.dytanic.cloudnet.event.service.CloudServiceConsoleLogReceiveEntryEvent;
 import de.dytanic.cloudnet.network.packet.PacketServerConsoleLogEntryReceive;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Queue;
 
-@Getter
-@RequiredArgsConstructor
 public final class DefaultServiceConsoleLogCache implements IServiceConsoleLogCache {
 
     private final Queue<String> cachedLogMessages = Iterables.newConcurrentLinkedQueue();
@@ -31,13 +26,15 @@ public final class DefaultServiceConsoleLogCache implements IServiceConsoleLogCa
 
     //*=====================================================================================
 
-    @Getter
-    @Setter
     private boolean autoPrintReceivedInput;
 
     //*=====================================================================================
 
     private int len;
+
+    public DefaultServiceConsoleLogCache(ICloudService cloudService) {
+        this.cloudService = cloudService;
+    }
 
     @Override
     public synchronized IServiceConsoleLogCache update() {
@@ -81,5 +78,33 @@ public final class DefaultServiceConsoleLogCache implements IServiceConsoleLogCa
 
         if (this.autoPrintReceivedInput || printErrorIntoConsole)
             CloudNetDriver.getInstance().getLogger().log((printErrorIntoConsole ? LogLevel.WARNING : LogLevel.INFO), "[" + cloudService.getServiceId().getName() + "] " + text);
+    }
+
+    public Queue<String> getCachedLogMessages() {
+        return this.cachedLogMessages;
+    }
+
+    public byte[] getBuffer() {
+        return this.buffer;
+    }
+
+    public StringBuffer getStringBuffer() {
+        return this.stringBuffer;
+    }
+
+    public ICloudService getCloudService() {
+        return this.cloudService;
+    }
+
+    public int getLen() {
+        return this.len;
+    }
+
+    public boolean isAutoPrintReceivedInput() {
+        return this.autoPrintReceivedInput;
+    }
+
+    public void setAutoPrintReceivedInput(boolean autoPrintReceivedInput) {
+        this.autoPrintReceivedInput = autoPrintReceivedInput;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
@@ -18,8 +18,6 @@ import de.dytanic.cloudnet.driver.service.*;
 import de.dytanic.cloudnet.event.service.*;
 import de.dytanic.cloudnet.template.ITemplateStorage;
 import de.dytanic.cloudnet.template.LocalTemplateStorage;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.io.*;
 import java.net.URL;
@@ -33,7 +31,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.UnaryOperator;
 import java.util.jar.JarFile;
 
-@Getter
 final class JVMCloudService implements ICloudService {
 
     private static final String runtime = "jvm";
@@ -76,7 +73,6 @@ final class JVMCloudService implements ICloudService {
 
     /*= --------------------------------------------------------------------- =*/
 
-    @Setter
     private volatile INetworkChannel networkChannel;
 
     private volatile ServiceInfoSnapshot serviceInfoSnapshot, lastServiceInfoSnapshot;
@@ -894,5 +890,81 @@ final class JVMCloudService implements ICloudService {
             storage = CloudNetDriver.getInstance().getServicesRegistry().getService(ITemplateStorage.class, LocalTemplateStorage.LOCAL_TEMPLATE_STORAGE);
 
         return storage;
+    }
+
+    public List<ServiceDeployment> getDeployments() {
+        return this.deployments;
+    }
+
+    public Queue<ServiceRemoteInclusion> getWaitingIncludes() {
+        return this.waitingIncludes;
+    }
+
+    public Queue<ServiceTemplate> getWaitingTemplates() {
+        return this.waitingTemplates;
+    }
+
+    public DefaultServiceConsoleLogCache getServiceConsoleLogCache() {
+        return this.serviceConsoleLogCache;
+    }
+
+    public List<String> getGroups() {
+        return this.groups;
+    }
+
+    public Lock getLifeCycleLock() {
+        return this.lifeCycleLock;
+    }
+
+    public ServiceLifeCycle getLifeCycle() {
+        return this.lifeCycle;
+    }
+
+    public ICloudServiceManager getCloudServiceManager() {
+        return this.cloudServiceManager;
+    }
+
+    public ServiceConfiguration getServiceConfiguration() {
+        return this.serviceConfiguration;
+    }
+
+    public ServiceId getServiceId() {
+        return this.serviceId;
+    }
+
+    public File getDirectory() {
+        return this.directory;
+    }
+
+    public String getConnectionKey() {
+        return this.connectionKey;
+    }
+
+    public int getConfiguredMaxHeapMemory() {
+        return this.configuredMaxHeapMemory;
+    }
+
+    public INetworkChannel getNetworkChannel() {
+        return this.networkChannel;
+    }
+
+    public ServiceInfoSnapshot getServiceInfoSnapshot() {
+        return this.serviceInfoSnapshot;
+    }
+
+    public ServiceInfoSnapshot getLastServiceInfoSnapshot() {
+        return this.lastServiceInfoSnapshot;
+    }
+
+    public Process getProcess() {
+        return this.process;
+    }
+
+    public boolean isRestartState() {
+        return this.restartState;
+    }
+
+    public void setNetworkChannel(INetworkChannel networkChannel) {
+        this.networkChannel = networkChannel;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/LocalTemplateStorage.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/LocalTemplateStorage.java
@@ -4,7 +4,6 @@ import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.common.io.FileUtils;
 import de.dytanic.cloudnet.driver.service.ServiceTemplate;
-import lombok.Getter;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,7 +12,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
 
-@Getter
 public final class LocalTemplateStorage implements ITemplateStorage {
 
     public static final String LOCAL_TEMPLATE_STORAGE = "local";
@@ -191,5 +189,9 @@ public final class LocalTemplateStorage implements ITemplateStorage {
 
     @Override
     public void close() throws Exception {
+    }
+
+    public File getStorageDirectory() {
+        return this.storageDirectory;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/util/InstallableAppVersion.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/util/InstallableAppVersion.java
@@ -4,16 +4,12 @@ import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.driver.service.ServiceEnvironment;
 import de.dytanic.cloudnet.driver.service.ServiceEnvironmentType;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.function.Predicate;
 
-@Getter
-@RequiredArgsConstructor
 public final class InstallableAppVersion {
 
     public static final Collection<InstallableAppVersion> VERSIONS = Iterables.newArrayList();
@@ -150,6 +146,13 @@ public final class InstallableAppVersion {
     private final ServiceEnvironment environmentType;
     private final String version, url;
 
+    public InstallableAppVersion(ServiceEnvironmentType serviceEnvironment, ServiceEnvironment environmentType, String version, String url) {
+        this.serviceEnvironment = serviceEnvironment;
+        this.environmentType = environmentType;
+        this.version = version;
+        this.url = url;
+    }
+
     public static InstallableAppVersion getVersion(ServiceEnvironmentType serviceEnvironment, String version) {
         Validate.checkNotNull(version);
 
@@ -159,6 +162,22 @@ public final class InstallableAppVersion {
                 return installableAppVersion.getServiceEnvironment() == serviceEnvironment && installableAppVersion.getVersion().equalsIgnoreCase(version);
             }
         });
+    }
+
+    public ServiceEnvironmentType getServiceEnvironment() {
+        return this.serviceEnvironment;
+    }
+
+    public ServiceEnvironment getEnvironmentType() {
+        return this.environmentType;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public String getUrl() {
+        return this.url;
     }
 
     /*= -------------------------------------------------- =*/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
<!-- a brief description of the changes done in this pull request -->
"Delomboked" all classes. Some of them were "delomboked" by hand due to IntelliJ's Lombok plugin throwing multiple StackOverflow exceptions when trying to delombok Gradle module 'cloudnet-common'.

Goal is to provide a clear overview what the class(es) contain and what they do. This factors in setters, getters and constructors. No logic should be hidden, especially in such complex application like CloudNet. This doesn't account for `@EqualsAndHashCode` and `@ToString`.

CloudNet was compiled multiple times and the code has been analyzed by IntelliJ. No (compilation) errors. Proof provided below:

![Annotation 2019-06-06 202533](https://user-images.githubusercontent.com/50335928/59056777-4295d400-8899-11e9-83c7-d9ffff91ca30.png)
![Annotation 2019-06-06 202629](https://user-images.githubusercontent.com/50335928/59056858-62c59300-8899-11e9-9fcc-2580da675f2d.png)

This pull request is part of the issue linked below and will mark its co-responding checkbox as "done".

### related issues/discussions
<!-- put here any issues or discussions related to this pull request -->  
https://github.com/CloudNetService/CloudNet-v3/issues/25