### PR TITLE
Add proper lazy initialization for CloudPermissionsPermissionManagement#getInstance()

### DIFF
--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsPermissionManagement.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsPermissionManagement.java
@@ -19,6 +19,12 @@ public final class CloudPermissionsPermissionManagement implements IPermissionMa
 
     private static CloudPermissionsPermissionManagement instance;
 
+    public static CloudPermissionsPermissionManagement getInstance() {
+        return CloudPermissionsPermissionManagement.instance != null
+            ? CloudPermissionsPermissionManagement.instance
+            : (CloudPermissionsPermissionManagement.instance = new CloudPermissionsPermissionManagement());
+    }
+
     private final Map<String, IPermissionGroup> cachedPermissionGroups = Maps.newConcurrentHashMap();
 
     private final Map<UUID, IPermissionUser> cachedPermissionUsers = Maps.newConcurrentHashMap();
@@ -27,10 +33,6 @@ public final class CloudPermissionsPermissionManagement implements IPermissionMa
         instance = this;
 
         init();
-    }
-
-    public static CloudPermissionsPermissionManagement getInstance() {
-        return CloudPermissionsPermissionManagement.instance;
     }
 
     private void init() {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
<!-- a brief description of the changes done in this pull request -->
- Modified `CloudPermissionsPermissionManagement#getInstance()` to properly lazy-initialize the `CloudPermissionsPermissionManagement#instance` field upon function invocation

The lazy getter uses a ternary operation (`x == false ? doA() : doB()`) instead of a traditional `if-else`.

### related issues/discussions
<!-- put here any issues or discussions related to this pull request -->  
https://github.com/CloudNetService/CloudNet-v3/issues/37