### PR TITLE
Fixed wrong console output on "tasks task <name> set static <true : f…

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandTasks.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandTasks.java
@@ -223,7 +223,7 @@ public final class CommandTasks extends CommandDefault implements ITabCompleter 
                             case "static":
                                 serviceTask.setStaticServices(args[4].equalsIgnoreCase("true"));
                                 this.updateServiceTask(serviceTask);
-                                this.sendMessage0(sender, serviceTask.getName(), "staticServices", serviceTask.isAutoDeleteOnStop());
+                                this.sendMessage0(sender, serviceTask.getName(), "staticServices", serviceTask.isStaticServices());
                                 break;
                             case "env":
                                 try {


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
Modified the response message of the command "tasks task <name> set static <true : false>"


### related issues/discussions

