### PR TITLE
Added Team color support to use in newer mc versions

### DIFF
--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissionGroup.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissionGroup.java
@@ -18,6 +18,10 @@ public interface IPermissionGroup extends IPermissible {
 
     void setPrefix(String prefix);
 
+    String getColor();
+
+    void setColor(String color);
+
     String getSuffix();
 
     void setSuffix(String suffix);

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionGroup.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionGroup.java
@@ -24,7 +24,7 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
 
     protected Collection<String> groups;
 
-    private String prefix, suffix, display;
+    private String prefix, color, suffix, display;
 
     private int sortId;
 
@@ -37,19 +37,21 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
         this.potency = potency;
         this.groups = Iterables.newArrayList();
         this.prefix = "&7";
+        this.color = "&7";
         this.suffix = "&f";
         this.display = "&7";
         this.sortId = 0;
         this.defaultGroup = false;
     }
 
-    public PermissionGroup(String name, int potency, Collection<String> groups, String prefix, String suffix, String display, int sortId, boolean defaultGroup) {
+    public PermissionGroup(String name, int potency, Collection<String> groups, String prefix, String color, String suffix, String display, int sortId, boolean defaultGroup) {
         super();
 
         this.name = name;
         this.potency = potency;
         this.groups = groups;
         this.prefix = prefix;
+        this.color = color;
         this.suffix = suffix;
         this.display = display;
         this.sortId = sortId;
@@ -70,6 +72,14 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
 
     public void setPrefix(String prefix) {
         this.prefix = prefix;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
     }
 
     public String getSuffix() {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
@@ -112,26 +112,29 @@ public final class BukkitCloudNetCloudPermissionsPlugin extends JavaPlugin {
         if (team == null) team = all.getScoreboard().registerNewTeam(teamName);
 
         try {
-            Optional<Method> setColor = Optional.ofNullable(team.getClass().getDeclaredMethod("setColor", ChatColor.class));
-            if (setColor.isPresent()) {
-                Method method = setColor.get();
-                method.setAccessible(true);
-                if (permissionGroup.getColor().length() != 0) {
-                    method.invoke(team, ChatColor.getByChar(permissionGroup.getColor().replaceAll("&", "").replaceAll("§", "")));
-                } else {
-                    String color = ChatColor.getLastColors(permissionGroup.getPrefix().replace('&', '§'));
-                    permissionGroup.setColor(color);
-                    CloudPermissionsPermissionManagement.getInstance().updateGroup(permissionGroup);
-                    method.invoke(team, ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", "")));
-                }
+            Method method = team.getClass().getDeclaredMethod("setColor", ChatColor.class);
+            method.setAccessible(true);
+
+            String prefix = permissionGroup.getPrefix();
+            String color = permissionGroup.getColor();
+            String suffix = permissionGroup.getSuffix();
+
+            if (color != null && !color.isEmpty())
+                method.invoke(team, ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", "")));
+            else {
+                color = ChatColor.getLastColors(prefix.replace('&', '§'));
+                permissionGroup.setColor(color);
+                CloudPermissionsPermissionManagement.getInstance().updateGroup(permissionGroup);
+                method.invoke(team, ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", "")));
             }
+
             team.setPrefix(ChatColor.translateAlternateColorCodes('&',
-                    permissionGroup.getPrefix().length() > 16 ?
-                            shortenStringTo16Bytes(permissionGroup.getPrefix()) : permissionGroup.getPrefix()));
+                    prefix.length() > 16 ?
+                            shortenStringTo16Bytes(prefix) : prefix));
 
             team.setSuffix(ChatColor.translateAlternateColorCodes('&',
-                    permissionGroup.getSuffix().length() > 16 ?
-                            shortenStringTo16Bytes(permissionGroup.getSuffix()) : permissionGroup.getSuffix()));
+                    suffix.length() > 16 ?
+                            shortenStringTo16Bytes(suffix) : suffix));
         } catch (NoSuchMethodException ignored) {
         } catch (UnsupportedEncodingException | IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
@@ -19,7 +19,6 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
@@ -119,14 +119,20 @@ public final class BukkitCloudNetCloudPermissionsPlugin extends JavaPlugin {
             String color = permissionGroup.getColor();
             String suffix = permissionGroup.getSuffix();
 
-            if (color != null && !color.isEmpty())
-                method.invoke(team, ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", "")));
-            else {
+            if (color != null && !color.isEmpty()) {
+                ChatColor chatColor = ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", ""));
+                if (chatColor != null) {
+                    method.invoke(team, chatColor);
+                }
+            } else {
                 color = ChatColor.getLastColors(prefix.replace('&', '§'));
-                if (color != null) {
-                    permissionGroup.setColor(color);
-                    CloudPermissionsPermissionManagement.getInstance().updateGroup(permissionGroup);
-                    method.invoke(team, ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", "")));
+                if (color != null && !color.isEmpty()) {
+                    ChatColor chatColor = ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", ""));
+                    if (chatColor != null){
+                        permissionGroup.setColor(color);
+                        CloudPermissionsPermissionManagement.getInstance().updateGroup(permissionGroup);
+                        method.invoke(team, chatColor);
+                    }
                 }
             }
 

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
@@ -123,9 +123,11 @@ public final class BukkitCloudNetCloudPermissionsPlugin extends JavaPlugin {
                 method.invoke(team, ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", "")));
             else {
                 color = ChatColor.getLastColors(prefix.replace('&', '§'));
-                permissionGroup.setColor(color);
-                CloudPermissionsPermissionManagement.getInstance().updateGroup(permissionGroup);
-                method.invoke(team, ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", "")));
+                if (color != null) {
+                    permissionGroup.setColor(color);
+                    CloudPermissionsPermissionManagement.getInstance().updateGroup(permissionGroup);
+                    method.invoke(team, ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", "")));
+                }
             }
 
             team.setPrefix(ChatColor.translateAlternateColorCodes('&',

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -1814,6 +1814,7 @@ public final class CloudNet extends CloudNetDriver {
             adminPermissionGroup.addPermission("*");
             adminPermissionGroup.addPermission("Proxy", "*");
             adminPermissionGroup.setPrefix("&4Admin &8| &7");
+            adminPermissionGroup.setColor("&7");
             adminPermissionGroup.setSuffix("&f");
             adminPermissionGroup.setDisplay("&4");
             adminPermissionGroup.setSortId(10);
@@ -1824,6 +1825,7 @@ public final class CloudNet extends CloudNetDriver {
             defaultPermissionGroup.addPermission("bukkit.broadcast.user", true);
             defaultPermissionGroup.setDefaultGroup(true);
             defaultPermissionGroup.setPrefix("&7");
+            defaultPermissionGroup.setColor("&7");
             defaultPermissionGroup.setSuffix("&f");
             defaultPermissionGroup.setDisplay("&7");
             defaultPermissionGroup.setSortId(10);

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandPermissions.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandPermissions.java
@@ -355,21 +355,25 @@ public final class CommandPermissions extends CommandDefault implements ITabComp
                                 sender.sendMessage(
                                         LanguageManager.getMessage("command-permissions-group-update-property")
                                                 .replace("%group%", permissionGroup.getName())
-                                                .replace("%value%", args[3])
                                                 .replace("%property%", args[2])
+                                                .replace("%value%", args[3])
                                 );
                                 break;
                             case "setcolor":
 
-                                permissionGroup.setColor(args[3]);
-                                permissionManagement.updateGroup(permissionGroup);
-                                this.updateClusterNetwork();
-                                sender.sendMessage(
-                                        LanguageManager.getMessage("command-permissions-group-update-property")
-                                                .replace("%group%", permissionGroup.getName())
-                                                .replace("%value%", args[3])
-                                                .replace("%property%", args[2])
-                                );
+                                String color = args[3];
+
+                                if (color != null && color.length() == 2) {
+                                    permissionGroup.setColor(args[3]);
+                                    permissionManagement.updateGroup(permissionGroup);
+                                    this.updateClusterNetwork();
+                                    sender.sendMessage(
+                                            LanguageManager.getMessage("command-permissions-group-update-property")
+                                                    .replace("%group%", permissionGroup.getName())
+                                                    .replace("%property%", args[2])
+                                                    .replace("%value%", color.replaceAll("§", "[color]").replaceAll("&", "[color]"))
+                                    );
+                                }
                                 break;
                         }
                     }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandPermissions.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandPermissions.java
@@ -52,6 +52,7 @@ public final class CommandPermissions extends CommandDefault implements ITabComp
                     "perms group <name> setDefaultGroup <true : false>",
                     "perms group <name> setPrefix <prefix> | '_' as ' ' ",
                     "perms group <name> setSuffix <suffix> | '_' as ' ' ",
+                    "perms group <name> setColor <color>",
                     "perms group <name> add permission <permission> <potency>",
                     "perms group <name> add permission <permission> <potency> <time in days : lifetime>",
                     "perms group <name> add permission <permission> <potency> <time in days : lifetime> <target>",
@@ -358,6 +359,18 @@ public final class CommandPermissions extends CommandDefault implements ITabComp
                                                 .replace("%property%", args[2])
                                 );
                                 break;
+                            case "setcolor":
+
+                                permissionGroup.setColor(args[3]);
+                                permissionManagement.updateGroup(permissionGroup);
+                                this.updateClusterNetwork();
+                                sender.sendMessage(
+                                        LanguageManager.getMessage("command-permissions-group-update-property")
+                                                .replace("%group%", permissionGroup.getName())
+                                                .replace("%value%", args[3])
+                                                .replace("%property%", args[2])
+                                );
+                                break;
                         }
                     }
                     if (args.length >= 5) {
@@ -485,6 +498,7 @@ public final class CommandPermissions extends CommandDefault implements ITabComp
                 "Parent groups: " + permissionGroup.getGroups(),
                 "Default: " + permissionGroup.isDefaultGroup() + " | SortId: " + permissionGroup.getSortId(),
                 "Prefix: " + permissionGroup.getPrefix().replace("&", "[color]"),
+                "Color: " + permissionGroup.getColor().replace("&", "[color]"),
                 "Suffix: " + permissionGroup.getSuffix().replace("&", "[color]"),
                 "Display: " + permissionGroup.getDisplay().replace("&", "[color]")
         );


### PR DESCRIPTION
- Added property "color" to permission groups
- Added team color support to use into newer mc versions

Fixed white color name in mc version 1.13-1.14 issue
Perhaps prefix now can contain 2 other chars instead of the two player name color codes