### PR TITLE
Now CloudNet takes care about custom properties

### DIFF
--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
@@ -446,6 +446,38 @@ public abstract class CloudNetDriver {
         return createCloudService(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, JsonDocument.newDocument(), port);
     }
 
+    public ITask<ServiceInfoSnapshot> createCloudServiceAsync(
+            String name,
+            String runtime,
+            boolean autoDeleteOnStop,
+            boolean staticService,
+            Collection<ServiceRemoteInclusion> includes,
+            Collection<ServiceTemplate> templates,
+            Collection<ServiceDeployment> deployments,
+            Collection<String> groups,
+            ProcessConfiguration processConfiguration,
+            Integer port
+    ){
+        return createCloudServiceAsync(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, JsonDocument.newDocument(), port);
+    }
+
+    public ITask<Collection<ServiceInfoSnapshot>> createCloudServiceAsync(
+            String nodeUniqueId,
+            int amount,
+            String name,
+            String runtime,
+            boolean autoDeleteOnStop,
+            boolean staticService,
+            Collection<ServiceRemoteInclusion> includes,
+            Collection<ServiceTemplate> templates,
+            Collection<ServiceDeployment> deployments,
+            Collection<String> groups,
+            ProcessConfiguration processConfiguration,
+            Integer port
+    ){
+        return createCloudServiceAsync(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, JsonDocument.newDocument(), port);
+    }
+
     public IServicesRegistry getServicesRegistry() {
         return this.servicesRegistry;
     }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
@@ -84,6 +84,7 @@ public abstract class CloudNetDriver {
             Collection<ServiceDeployment> deployments,
             Collection<String> groups,
             ProcessConfiguration processConfiguration,
+            JsonDocument properties,
             Integer port
     );
 
@@ -99,6 +100,7 @@ public abstract class CloudNetDriver {
             Collection<ServiceDeployment> deployments,
             Collection<String> groups,
             ProcessConfiguration processConfiguration,
+            JsonDocument properties,
             Integer port
     );
 
@@ -256,6 +258,7 @@ public abstract class CloudNetDriver {
             Collection<ServiceDeployment> deployments,
             Collection<String> groups,
             ProcessConfiguration processConfiguration,
+            JsonDocument properties,
             Integer port
     );
 
@@ -271,6 +274,7 @@ public abstract class CloudNetDriver {
             Collection<ServiceDeployment> deployments,
             Collection<String> groups,
             ProcessConfiguration processConfiguration,
+            JsonDocument properties,
             Integer port
     );
 

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
@@ -414,6 +414,38 @@ public abstract class CloudNetDriver {
         return listenableTask;
     }
 
+    public ServiceInfoSnapshot createCloudService(
+            String name,
+            String runtime,
+            boolean autoDeleteOnStop,
+            boolean staticService,
+            Collection<ServiceRemoteInclusion> includes,
+            Collection<ServiceTemplate> templates,
+            Collection<ServiceDeployment> deployments,
+            Collection<String> groups,
+            ProcessConfiguration processConfiguration,
+            Integer port
+    ){
+        return createCloudService(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, JsonDocument.newDocument(), port);
+    }
+
+    public Collection<ServiceInfoSnapshot> createCloudService(
+            String nodeUniqueId,
+            int amount,
+            String name,
+            String runtime,
+            boolean autoDeleteOnStop,
+            boolean staticService,
+            Collection<ServiceRemoteInclusion> includes,
+            Collection<ServiceTemplate> templates,
+            Collection<ServiceDeployment> deployments,
+            Collection<String> groups,
+            ProcessConfiguration processConfiguration,
+            Integer port
+    ){
+        return createCloudService(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, JsonDocument.newDocument(), port);
+    }
+
     public IServicesRegistry getServicesRegistry() {
         return this.servicesRegistry;
     }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
@@ -1,6 +1,7 @@
 package de.dytanic.cloudnet.driver.service;
 
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
+import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -26,7 +27,7 @@ public final class ServiceConfiguration extends BasicJsonDocPropertyable {
 
     private int port;
 
-    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, int port) {
+    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, JsonDocument properties, int port) {
         this.serviceId = serviceId;
         this.runtime = runtime;
         this.autoDeleteOnStop = autoDeleteOnStop;
@@ -36,6 +37,7 @@ public final class ServiceConfiguration extends BasicJsonDocPropertyable {
         this.templates = templates;
         this.deployments = deployments;
         this.processConfig = processConfig;
+        this.properties = properties;
         this.port = port;
     }
 

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
@@ -27,6 +27,10 @@ public final class ServiceConfiguration extends BasicJsonDocPropertyable {
 
     private int port;
 
+    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, int port){
+        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, processConfig, JsonDocument.newDocument(), port);
+    }
+
     public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, JsonDocument properties, int port) {
         this.serviceId = serviceId;
         this.runtime = runtime;

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceInfoSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceInfoSnapshot.java
@@ -30,6 +30,10 @@ public class ServiceInfoSnapshot extends BasicJsonDocPropertyable {
 
     protected ServiceConfiguration configuration;
 
+    public ServiceInfoSnapshot(long creationTime, ServiceId serviceId, HostAndPort address, boolean connected, ServiceLifeCycle lifeCycle, ProcessSnapshot processSnapshot, ServiceConfiguration configuration) {
+        this(creationTime, serviceId, address, connected, lifeCycle, processSnapshot, JsonDocument.newDocument(), configuration);
+    }
+
     public ServiceInfoSnapshot(long creationTime, ServiceId serviceId, HostAndPort address, boolean connected, ServiceLifeCycle lifeCycle, ProcessSnapshot processSnapshot, JsonDocument properties, ServiceConfiguration configuration) {
         this.creationTime = creationTime;
         this.serviceId = serviceId;

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceInfoSnapshot.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceInfoSnapshot.java
@@ -2,6 +2,7 @@ package de.dytanic.cloudnet.driver.service;
 
 import com.google.gson.reflect.TypeToken;
 import de.dytanic.cloudnet.common.document.gson.BasicJsonDocPropertyable;
+import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.network.HostAndPort;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -29,13 +30,14 @@ public class ServiceInfoSnapshot extends BasicJsonDocPropertyable {
 
     protected ServiceConfiguration configuration;
 
-    public ServiceInfoSnapshot(long creationTime, ServiceId serviceId, HostAndPort address, boolean connected, ServiceLifeCycle lifeCycle, ProcessSnapshot processSnapshot, ServiceConfiguration configuration) {
+    public ServiceInfoSnapshot(long creationTime, ServiceId serviceId, HostAndPort address, boolean connected, ServiceLifeCycle lifeCycle, ProcessSnapshot processSnapshot, JsonDocument properties, ServiceConfiguration configuration) {
         this.creationTime = creationTime;
         this.serviceId = serviceId;
         this.address = address;
         this.connected = connected;
         this.lifeCycle = lifeCycle;
         this.processSnapshot = processSnapshot;
+        this.properties = properties;
         this.configuration = configuration;
     }
 

--- a/cloudnet-examples/src/main/java/de/dytanic/cloudnet/examples/driver/ExampleCreateCloudService.java
+++ b/cloudnet-examples/src/main/java/de/dytanic/cloudnet/examples/driver/ExampleCreateCloudService.java
@@ -3,6 +3,7 @@ package de.dytanic.cloudnet.examples.driver;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.common.concurrent.ITask;
 import de.dytanic.cloudnet.common.concurrent.ITaskListener;
+import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.network.cluster.NetworkClusterNode;
 import de.dytanic.cloudnet.driver.service.*;
@@ -95,6 +96,7 @@ public final class ExampleCreateCloudService {
                         356,
                         new ArrayList<>()
                 ),
+                JsonDocument.newDocument().append("votes", "10"), //define useful properties to call up later
                 null //automatic defined port or the start port
         );
 
@@ -127,6 +129,7 @@ public final class ExampleCreateCloudService {
                                 356,
                                 Collections.EMPTY_LIST
                         ),
+                        JsonDocument.newDocument().append("votes", "10"), //define useful properties to call up later
                         null //automatic defined port or the start port
                 )) {
                     DRIVER.startCloudService(serviceInfoSnapshot); //start the services

--- a/cloudnet-examples/src/main/java/de/dytanic/cloudnet/examples/driver/ExampleIncludeTemplate.java
+++ b/cloudnet-examples/src/main/java/de/dytanic/cloudnet/examples/driver/ExampleIncludeTemplate.java
@@ -1,6 +1,7 @@
 package de.dytanic.cloudnet.examples.driver;
 
 import de.dytanic.cloudnet.common.collection.Iterables;
+import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.service.ProcessConfiguration;
 import de.dytanic.cloudnet.driver.service.ServiceEnvironmentType;
@@ -39,6 +40,7 @@ public final class ExampleIncludeTemplate {
                         256,
                         Iterables.newArrayList()
                 ),
+                JsonDocument.newDocument().append("UUID", playerUniqueId), //define useful properties to call up later
                 null
         );
 

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -290,7 +290,7 @@ public final class Wrapper extends CloudNetDriver {
      */
     @Override
     public ServiceInfoSnapshot createCloudService(String name, String runtime, boolean autoDeleteOnStop, boolean staticService, Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates,
-                                                  Collection<ServiceDeployment> deployments, Collection<String> groups, ProcessConfiguration processConfiguration, Integer port) {
+                                                  Collection<ServiceDeployment> deployments, Collection<String> groups, ProcessConfiguration processConfiguration, JsonDocument properties, Integer port) {
         Validate.checkNotNull(name);
         Validate.checkNotNull(includes);
         Validate.checkNotNull(templates);
@@ -299,7 +299,7 @@ public final class Wrapper extends CloudNetDriver {
         Validate.checkNotNull(processConfiguration);
 
         try {
-            return this.createCloudServiceAsync(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, port).get(5, TimeUnit.SECONDS);
+            return this.createCloudServiceAsync(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, properties, port).get(5, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
         }
@@ -315,7 +315,7 @@ public final class Wrapper extends CloudNetDriver {
     @Override
     public Collection<ServiceInfoSnapshot> createCloudService(String nodeUniqueId, int amount, String name, String runtime, boolean autoDeleteOnStop, boolean staticService, Collection<ServiceRemoteInclusion> includes,
                                                               Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments, Collection<String> groups,
-                                                              ProcessConfiguration processConfiguration, Integer port) {
+                                                              ProcessConfiguration processConfiguration, JsonDocument properties, Integer port) {
         Validate.checkNotNull(nodeUniqueId);
         Validate.checkNotNull(name);
         Validate.checkNotNull(includes);
@@ -325,7 +325,7 @@ public final class Wrapper extends CloudNetDriver {
         Validate.checkNotNull(processConfiguration);
 
         try {
-            return this.createCloudServiceAsync(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, port).get(5, TimeUnit.SECONDS);
+            return this.createCloudServiceAsync(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, properties, port).get(5, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
         }
@@ -1355,7 +1355,7 @@ public final class Wrapper extends CloudNetDriver {
     @Override
     public ITask<ServiceInfoSnapshot> createCloudServiceAsync(String name, String runtime, boolean autoDeleteOnStop, boolean staticService, Collection<ServiceRemoteInclusion> includes,
                                                               Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
-                                                              Collection<String> groups, ProcessConfiguration processConfiguration, Integer port) {
+                                                              Collection<String> groups, ProcessConfiguration processConfiguration, JsonDocument properties, Integer port) {
         Validate.checkNotNull(name);
         Validate.checkNotNull(includes);
         Validate.checkNotNull(templates);
@@ -1374,6 +1374,7 @@ public final class Wrapper extends CloudNetDriver {
                         .append("deployments", deployments)
                         .append("groups", groups)
                         .append("processConfiguration", processConfiguration)
+                        .append("properties", properties)
                         .append("port", port),
                 null,
                 documentPair -> documentPair.getFirst().get("serviceInfoSnapshot", new TypeToken<ServiceInfoSnapshot>() {
@@ -1389,7 +1390,7 @@ public final class Wrapper extends CloudNetDriver {
     @Override
     public ITask<Collection<ServiceInfoSnapshot>> createCloudServiceAsync(String nodeUniqueId, int amount, String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
                                                                           Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
-                                                                          Collection<String> groups, ProcessConfiguration processConfiguration, Integer port) {
+                                                                          Collection<String> groups, ProcessConfiguration processConfiguration, JsonDocument properties, Integer port) {
         Validate.checkNotNull(nodeUniqueId);
         Validate.checkNotNull(name);
         Validate.checkNotNull(includes);
@@ -1411,6 +1412,7 @@ public final class Wrapper extends CloudNetDriver {
                         .append("deployments", deployments)
                         .append("groups", groups)
                         .append("processConfiguration", processConfiguration)
+                        .append("properties", properties)
                         .append("port", port),
                 null,
                 documentPair -> documentPair.getFirst().get("serviceInfoSnapshots", new TypeToken<Collection<ServiceInfoSnapshot>>() {
@@ -2161,6 +2163,7 @@ public final class Wrapper extends CloudNetDriver {
                         Iterables.map(Thread.getAllStackTraces().keySet(), thread -> new ThreadSnapshot(thread.getId(), thread.getName(), thread.getState(), thread.isDaemon(), thread.getPriority())),
                         CPUUsageResolver.getProcessCPUUsage()
                 ),
+                this.currentServiceInfoSnapshot.getProperties(),
                 this.getServiceConfiguration()
         );
     }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -2172,8 +2172,10 @@ public final class Wrapper extends CloudNetDriver {
      * @see ServiceInfoSnapshotConfigureEvent
      */
     public void publishServiceInfoUpdate() {
-        ServiceInfoSnapshot serviceInfoSnapshot = this.createServiceInfoSnapshot();
+        publishServiceInfoUpdate(this.createServiceInfoSnapshot());
+    }
 
+    public void publishServiceInfoUpdate(ServiceInfoSnapshot serviceInfoSnapshot) {
         this.eventManager.callEvent(new ServiceInfoSnapshotConfigureEvent(serviceInfoSnapshot));
 
         this.lastServiceInfoSnapShot = this.currentServiceInfoSnapshot;

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -681,7 +681,8 @@ public final class CloudNet extends CloudNetDriver {
 
     @Override
     public ServiceInfoSnapshot getCloudServiceByName(String name) {
-        return Iterables.first(cloudServiceManager.getCloudServices().values(), cloudService -> cloudService.getServiceId().getName().equalsIgnoreCase(name)).getServiceInfoSnapshot();
+        ICloudService service = Iterables.first(cloudServiceManager.getCloudServices().values(), cloudService -> cloudService.getServiceId().getName().equalsIgnoreCase(name));
+        return service != null ? service.getServiceInfoSnapshot() : null;
     }
 
     @Override

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -407,16 +407,23 @@ public final class CloudNet extends CloudNetDriver {
 
     @Override
     public ServiceInfoSnapshot createCloudService(String name, String runtime, boolean autoDeleteOnStop, boolean staticService, Collection<ServiceRemoteInclusion> includes,
-                                                  Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
-                                                  Collection<String> groups, ProcessConfiguration processConfiguration, Integer port) {
-        ICloudService cloudService = this.cloudServiceManager.runTask(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, port);
+                                                  Collection<ServiceTemplate> templates,
+                                                  Collection<ServiceDeployment> deployments,
+                                                  Collection<String> groups,
+                                                  ProcessConfiguration processConfiguration,
+                                                  JsonDocument properties, Integer port) {
+        ICloudService cloudService = this.cloudServiceManager.runTask(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, properties, port);
         return cloudService != null ? cloudService.getServiceInfoSnapshot() : null;
     }
 
     @Override
     public Collection<ServiceInfoSnapshot> createCloudService(String nodeUniqueId, int amount, String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
-                                                              Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates,
-                                                              Collection<ServiceDeployment> deployments, Collection<String> groups, ProcessConfiguration processConfiguration, Integer port) {
+                                                              Collection<ServiceRemoteInclusion> includes,
+                                                              Collection<ServiceTemplate> templates,
+                                                              Collection<ServiceDeployment> deployments,
+                                                              Collection<String> groups,
+                                                              ProcessConfiguration processConfiguration,
+                                                              JsonDocument properties, Integer port) {
         Validate.checkNotNull(nodeUniqueId);
         Validate.checkNotNull(name);
         Validate.checkNotNull(includes);
@@ -430,7 +437,7 @@ public final class CloudNet extends CloudNetDriver {
 
             for (int i = 0; i < amount; i++) {
                 ICloudService cloudService = this.cloudServiceManager.runTask(
-                        name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, port != null ? port++ : null
+                        name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, properties, port != null ? port++ : null
                 );
 
                 if (cloudService != null) collection.add(cloudService.getServiceInfoSnapshot());
@@ -442,7 +449,7 @@ public final class CloudNet extends CloudNetDriver {
         IClusterNodeServer clusterNodeServer = getClusterNodeServerProvider().getNodeServer(nodeUniqueId);
 
         if (clusterNodeServer != null && clusterNodeServer.isConnected() && clusterNodeServer.getChannel() != null)
-            return clusterNodeServer.createCloudService(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, port);
+            return clusterNodeServer.createCloudService(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, properties, port);
         else
             return null;
     }
@@ -1050,8 +1057,9 @@ public final class CloudNet extends CloudNetDriver {
     @Override
     public ITask<ServiceInfoSnapshot> createCloudServiceAsync(String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
                                                               Collection<ServiceRemoteInclusion> includes,
-                                                              Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
-                                                              Collection<String> groups, ProcessConfiguration processConfiguration, Integer port) {
+                                                              Collection<ServiceTemplate> templates,
+                                                              Collection<ServiceDeployment> deployments,
+                                                              Collection<String> groups, ProcessConfiguration processConfiguration, JsonDocument properties, Integer port) {
         Validate.checkNotNull(name);
         Validate.checkNotNull(includes);
         Validate.checkNotNull(templates);
@@ -1059,14 +1067,16 @@ public final class CloudNet extends CloudNetDriver {
         Validate.checkNotNull(groups);
         Validate.checkNotNull(processConfiguration);
 
-        return scheduleTask(() -> CloudNet.this.createCloudService(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, port));
+        return scheduleTask(() -> CloudNet.this.createCloudService(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, properties, port));
     }
 
     @Override
     public ITask<Collection<ServiceInfoSnapshot>> createCloudServiceAsync(
             String nodeUniqueId, int amount, String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
             Collection<ServiceRemoteInclusion> includes,
-            Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments, Collection<String> groups, ProcessConfiguration processConfiguration, Integer port) {
+            Collection<ServiceTemplate> templates,
+            Collection<ServiceDeployment> deployments,
+            Collection<String> groups, ProcessConfiguration processConfiguration, JsonDocument properties, Integer port) {
         Validate.checkNotNull(nodeUniqueId);
         Validate.checkNotNull(name);
         Validate.checkNotNull(includes);
@@ -1075,7 +1085,7 @@ public final class CloudNet extends CloudNetDriver {
         Validate.checkNotNull(groups);
         Validate.checkNotNull(processConfiguration);
 
-        return scheduleTask(() -> CloudNet.this.createCloudService(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, port));
+        return scheduleTask(() -> CloudNet.this.createCloudService(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, properties, port));
     }
 
     @Override

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServer.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServer.java
@@ -141,8 +141,13 @@ public final class DefaultClusterNodeServer implements IClusterNodeServer {
 
     @Override
     public ServiceInfoSnapshot createCloudService(
-            String name, String runtime, boolean autoDeleteOnStop, boolean staticService, Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates,
-            Collection<ServiceDeployment> deployments, Collection<String> groups, ProcessConfiguration processConfiguration, Integer port) {
+            String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
+            Collection<ServiceRemoteInclusion> includes,
+            Collection<ServiceTemplate> templates,
+            Collection<ServiceDeployment> deployments,
+            Collection<String> groups,
+            ProcessConfiguration processConfiguration,
+            JsonDocument properties,Integer port) {
         Validate.checkNotNull(name);
         Validate.checkNotNull(includes);
         Validate.checkNotNull(templates);
@@ -163,6 +168,7 @@ public final class DefaultClusterNodeServer implements IClusterNodeServer {
                                 .append("deployments", deployments)
                                 .append("groups", groups)
                                 .append("processConfiguration", processConfiguration)
+                                .append("properties", properties)
                                 .append("port", port),
                         new byte[0],
                         (Function<Pair<JsonDocument, byte[]>, ServiceInfoSnapshot>) documentPair -> documentPair.getFirst().get("serviceInfoSnapshot", new TypeToken<ServiceInfoSnapshot>() {
@@ -178,8 +184,12 @@ public final class DefaultClusterNodeServer implements IClusterNodeServer {
     @Override
     public Collection<ServiceInfoSnapshot> createCloudService(
             String nodeUniqueId, int amount, String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
-            Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
-            Collection<String> groups, ProcessConfiguration processConfiguration, Integer port) {
+            Collection<ServiceRemoteInclusion> includes,
+            Collection<ServiceTemplate> templates,
+            Collection<ServiceDeployment> deployments,
+            Collection<String> groups,
+            ProcessConfiguration processConfiguration,
+            JsonDocument properties, Integer port) {
         Validate.checkNotNull(nodeUniqueId);
         Validate.checkNotNull(name);
         Validate.checkNotNull(includes);
@@ -203,6 +213,7 @@ public final class DefaultClusterNodeServer implements IClusterNodeServer {
                                 .append("deployments", deployments)
                                 .append("groups", groups)
                                 .append("processConfiguration", processConfiguration)
+                                .append("properties", properties)
                                 .append("port", port),
                         new byte[0],
                         (Function<Pair<JsonDocument, byte[]>, Collection<ServiceInfoSnapshot>>) documentPair -> documentPair.getFirst().get("serviceInfoSnapshots", new TypeToken<Collection<ServiceInfoSnapshot>>() {

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/IClusterNodeServer.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/IClusterNodeServer.java
@@ -45,7 +45,8 @@ public interface IClusterNodeServer extends AutoCloseable {
 
     ServiceInfoSnapshot createCloudService(ServiceConfiguration serviceConfiguration);
 
-    ServiceInfoSnapshot createCloudService(String name, String runtime, boolean autoDeleteOnStop, boolean staticService, Collection<ServiceRemoteInclusion> includes,
+    ServiceInfoSnapshot createCloudService(String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
+                                           Collection<ServiceRemoteInclusion> includes,
                                            Collection<ServiceTemplate> templates,
                                            Collection<ServiceDeployment> deployments,
                                            Collection<String> groups,
@@ -60,6 +61,24 @@ public interface IClusterNodeServer extends AutoCloseable {
             Collection<String> groups,
             ProcessConfiguration processConfiguration,
             JsonDocument properties, Integer port);
+
+    default ServiceInfoSnapshot createCloudService(String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
+                                                   Collection<ServiceRemoteInclusion> includes,
+                                                   Collection<ServiceTemplate> templates,
+                                                   Collection<ServiceDeployment> deployments,
+                                                   Collection<String> groups,
+                                                   ProcessConfiguration processConfiguration, Integer port){
+        return createCloudService(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, JsonDocument.newDocument(), port);
+    }
+
+    default Collection<ServiceInfoSnapshot> createCloudService(String nodeUniqueId, int amount, String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
+                                                            Collection<ServiceRemoteInclusion> includes,
+                                                            Collection<ServiceTemplate> templates,
+                                                            Collection<ServiceDeployment> deployments,
+                                                            Collection<String> groups,
+                                                            ProcessConfiguration processConfiguration, Integer port){
+        return createCloudService(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, JsonDocument.newDocument(), port);
+    }
 
     ServiceInfoSnapshot sendCommandLineToCloudService(UUID uniqueId, String commandLine);
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/IClusterNodeServer.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/IClusterNodeServer.java
@@ -46,13 +46,20 @@ public interface IClusterNodeServer extends AutoCloseable {
     ServiceInfoSnapshot createCloudService(ServiceConfiguration serviceConfiguration);
 
     ServiceInfoSnapshot createCloudService(String name, String runtime, boolean autoDeleteOnStop, boolean staticService, Collection<ServiceRemoteInclusion> includes,
-                                           Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
-                                           Collection<String> groups, ProcessConfiguration processConfiguration, Integer port);
+                                           Collection<ServiceTemplate> templates,
+                                           Collection<ServiceDeployment> deployments,
+                                           Collection<String> groups,
+                                           ProcessConfiguration processConfiguration,
+                                           JsonDocument properties, Integer port);
 
     Collection<ServiceInfoSnapshot> createCloudService(
             String nodeUniqueId, int amount, String name, String runtime, boolean autoDeleteOnStop, boolean staticService,
-            Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates,
-            Collection<ServiceDeployment> deployments, Collection<String> groups, ProcessConfiguration processConfiguration, Integer port);
+            Collection<ServiceRemoteInclusion> includes,
+            Collection<ServiceTemplate> templates,
+            Collection<ServiceDeployment> deployments,
+            Collection<String> groups,
+            ProcessConfiguration processConfiguration,
+            JsonDocument properties, Integer port);
 
     ServiceInfoSnapshot sendCommandLineToCloudService(UUID uniqueId, String commandLine);
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/network/listener/PacketClientSyncAPIPacketListener.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/network/listener/PacketClientSyncAPIPacketListener.java
@@ -13,6 +13,7 @@ import de.dytanic.cloudnet.driver.permission.PermissionGroup;
 import de.dytanic.cloudnet.driver.permission.PermissionUser;
 import de.dytanic.cloudnet.driver.service.*;
 
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -202,6 +203,8 @@ public final class PacketClientSyncAPIPacketListener implements IPacketListener 
                                     }.getType()),
                                     packet.getHeader().get("processConfiguration", new TypeToken<ProcessConfiguration>() {
                                     }.getType()),
+                                    packet.getHeader().get("properties", new TypeToken<JsonDocument>() {
+                                    }.getType()),
                                     packet.getHeader().getInt("port")
                             ))
                     );
@@ -225,6 +228,8 @@ public final class PacketClientSyncAPIPacketListener implements IPacketListener 
                                     packet.getHeader().get("groups", new TypeToken<Collection<String>>() {
                                     }.getType()),
                                     packet.getHeader().get("processConfiguration", new TypeToken<ProcessConfiguration>() {
+                                    }.getType()),
+                                    packet.getHeader().get("properties", new TypeToken<JsonDocument>() {
                                     }.getType()),
                                     packet.getHeader().getInt("port")
                             ))

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
@@ -5,6 +5,7 @@ import de.dytanic.cloudnet.cluster.IClusterNodeServer;
 import de.dytanic.cloudnet.common.Validate;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.common.collection.Maps;
+import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.network.def.packet.PacketClientServerServiceInfoPublisher;
 import de.dytanic.cloudnet.driver.service.*;
@@ -181,6 +182,7 @@ public final class DefaultCloudServiceManager implements ICloudServiceManager {
                         serviceTask.getProcessConfiguration().getMaxHeapMemorySize(),
                         serviceTask.getProcessConfiguration().getJvmOptions()
                 ),
+                serviceTask.getProperties(),
                 serviceTask.getStartPort()
         );
     }
@@ -229,6 +231,7 @@ public final class DefaultCloudServiceManager implements ICloudServiceManager {
             Collection<ServiceDeployment> deployments,
             Collection<String> groups,
             ProcessConfiguration processConfiguration,
+            JsonDocument properties,
             Integer port
     ) {
 
@@ -257,6 +260,9 @@ public final class DefaultCloudServiceManager implements ICloudServiceManager {
                 includes.addAll(groupConfiguration.getIncludes());
                 templates.addAll(groupConfiguration.getTemplates());
                 deployments.addAll(groupConfiguration.getDeployments());
+                if (properties != null){
+                    properties.append(groupConfiguration.getProperties());
+                }
             }
 
         ServiceConfiguration serviceConfiguration = new ServiceConfiguration(
@@ -275,6 +281,7 @@ public final class DefaultCloudServiceManager implements ICloudServiceManager {
                 templates.toArray(new ServiceTemplate[0]),
                 deployments.toArray(new ServiceDeployment[0]),
                 processConfiguration,
+                properties,
                 port
         );
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudServiceManager.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudServiceManager.java
@@ -76,6 +76,21 @@ public interface ICloudServiceManager {
             Integer port
     );
 
+    default ICloudService runTask(
+            String name,
+            String runtime,
+            boolean autoDeleteOnStop,
+            boolean staticService,
+            Collection<ServiceRemoteInclusion> includes,
+            Collection<ServiceTemplate> templates,
+            Collection<ServiceDeployment> deployments,
+            Collection<String> groups,
+            ProcessConfiguration processConfiguration,
+            Integer port
+    ){
+        return runTask(name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, port);
+    }
+
     void startAllCloudServices();
 
     void stopAllCloudServices();

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudServiceManager.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudServiceManager.java
@@ -1,5 +1,6 @@
 package de.dytanic.cloudnet.service;
 
+import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.service.*;
 
 import java.io.File;
@@ -71,6 +72,7 @@ public interface ICloudServiceManager {
             Collection<ServiceDeployment> deployments,
             Collection<String> groups,
             ProcessConfiguration processConfiguration,
+            JsonDocument properties,
             Integer port
     );
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
@@ -295,6 +295,7 @@ final class JVMCloudService implements ICloudService {
                     this.templates.toArray(new ServiceTemplate[0]),
                     this.deployments.toArray(new ServiceDeployment[0]),
                     this.serviceConfiguration.getProcessConfig(),
+                    this.serviceConfiguration.getProperties(),
                     this.serviceConfiguration.getPort()
             );
 
@@ -385,6 +386,7 @@ final class JVMCloudService implements ICloudService {
                         -1,
                         Collections.emptyList(),
                         -1),
+                this.serviceConfiguration.getProperties(),
                 this.serviceConfiguration
         );
     }


### PR DESCRIPTION
Added ability to define properties when creating ServiceInfoSnapshot and ServiceConfiguration.
Instead of overwrite those, now the Cloud cares about them.

Reached this by adding Properties as parameter to be able to use them on creation and storage of the Snapshot.

Feature could be useful to store easiely custom properties and query them later to do something with them.
This makes it easy to create PrivateServers and other servers which are needing useful information of their parent.

Tested with normal Document values and null values, it is working. 