### PR TITLE
Option to disable removal of deployments

### DIFF
--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
@@ -292,7 +292,7 @@ public abstract class CloudNetDriver {
 
     public abstract void includeWaitingServiceInclusions(UUID uniqueId);
 
-    public abstract void deployResources(UUID uniqueId);
+    public abstract void deployResources(UUID uniqueId, Boolean removeDeployments);
 
     public abstract ITask<Collection<UUID>> getServicesAsUniqueIdAsync();
 
@@ -476,6 +476,10 @@ public abstract class CloudNetDriver {
             Integer port
     ) {
         return createCloudServiceAsync(nodeUniqueId, amount, name, runtime, autoDeleteOnStop, staticService, includes, templates, deployments, groups, processConfiguration, JsonDocument.newDocument(), port);
+    }
+
+    public void deployResources(UUID uniqueId) {
+        this.deployResources(uniqueId, true);
     }
 
     public IServicesRegistry getServicesRegistry() {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/CloudNetDriver.java
@@ -292,7 +292,7 @@ public abstract class CloudNetDriver {
 
     public abstract void includeWaitingServiceInclusions(UUID uniqueId);
 
-    public abstract void deployResources(UUID uniqueId, Boolean removeDeployments);
+    public abstract void deployResources(UUID uniqueId, boolean removeDeployments);
 
     public abstract ITask<Collection<UUID>> getServicesAsUniqueIdAsync();
 

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -1549,11 +1549,12 @@ public final class Wrapper extends CloudNetDriver {
      * @see CloudNetDriver
      */
     @Override
-    public void deployResources(UUID uniqueId) {
+    public void deployResources(UUID uniqueId, Boolean removeDeployments) {
         Validate.checkNotNull(uniqueId);
 
         sendCallablePacketWithAsDriverSyncAPIWithNetworkConnector(
-                new JsonDocument(PacketConstants.SYNC_PACKET_ID_PROPERTY, "deploy_resources_from_service").append("uniqueId", uniqueId), null,
+                new JsonDocument(PacketConstants.SYNC_PACKET_ID_PROPERTY, "deploy_resources_from_service")
+                        .append("uniqueId", uniqueId).append("removeDeployments", removeDeployments), null,
                 VOID_FUNCTION);
     }
 

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -1549,7 +1549,7 @@ public final class Wrapper extends CloudNetDriver {
      * @see CloudNetDriver
      */
     @Override
-    public void deployResources(UUID uniqueId, Boolean removeDeployments) {
+    public void deployResources(UUID uniqueId, boolean removeDeployments) {
         Validate.checkNotNull(uniqueId);
 
         sendCallablePacketWithAsDriverSyncAPIWithNetworkConnector(

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -1177,7 +1177,7 @@ public final class CloudNet extends CloudNetDriver {
     }
 
     @Override
-    public void deployResources(UUID uniqueId) {
+    public void deployResources(UUID uniqueId, Boolean removeDeployments) {
         Validate.checkNotNull(uniqueId);
 
         if (!getCloudServiceManager().getGlobalServiceInfoSnapshots().containsKey(uniqueId))
@@ -1186,7 +1186,7 @@ public final class CloudNet extends CloudNetDriver {
         ICloudService cloudService = getCloudServiceManager().getCloudService(uniqueId);
 
         if (cloudService != null) {
-            cloudService.deployResources();
+            cloudService.deployResources(removeDeployments);
             return;
         }
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -1177,7 +1177,7 @@ public final class CloudNet extends CloudNetDriver {
     }
 
     @Override
-    public void deployResources(UUID uniqueId, Boolean removeDeployments) {
+    public void deployResources(UUID uniqueId, boolean removeDeployments) {
         Validate.checkNotNull(uniqueId);
 
         if (!getCloudServiceManager().getGlobalServiceInfoSnapshots().containsKey(uniqueId))

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServer.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServer.java
@@ -435,14 +435,14 @@ public final class DefaultClusterNodeServer implements IClusterNodeServer {
     }
 
     @Override
-    public void deployResources(UUID uniqueId) {
+    public void deployResources(UUID uniqueId, Boolean removeDeployments) {
         Validate.checkNotNull(uniqueId);
 
         if (this.channel != null)
             try {
                 CloudNetDriver.getInstance().sendCallablePacketWithAsDriverSyncAPI(this.channel,
                         new JsonDocument(PacketConstants.SYNC_PACKET_ID_PROPERTY, "deploy_resources_from_service")
-                                .append("uniqueId", uniqueId)
+                                .append("uniqueId", uniqueId).append("removeDeployments", removeDeployments)
                         , new byte[0],
                         (Function<Pair<JsonDocument, byte[]>, Void>) documentPair -> null).get(5, TimeUnit.SECONDS);
             } catch (InterruptedException | ExecutionException | TimeoutException e) {

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServer.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/DefaultClusterNodeServer.java
@@ -435,7 +435,7 @@ public final class DefaultClusterNodeServer implements IClusterNodeServer {
     }
 
     @Override
-    public void deployResources(UUID uniqueId, Boolean removeDeployments) {
+    public void deployResources(UUID uniqueId, boolean removeDeployments) {
         Validate.checkNotNull(uniqueId);
 
         if (this.channel != null)

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/IClusterNodeServer.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/IClusterNodeServer.java
@@ -102,7 +102,7 @@ public interface IClusterNodeServer extends AutoCloseable {
 
     void includeWaitingServiceTemplates(UUID uniqueId);
 
-    void deployResources(UUID uniqueId, Boolean removeDeployments);
+    void deployResources(UUID uniqueId, boolean removeDeployments);
 
     default void deployResources(UUID uniqueId) {
         deployResources(uniqueId, true);

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/IClusterNodeServer.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/cluster/IClusterNodeServer.java
@@ -102,7 +102,11 @@ public interface IClusterNodeServer extends AutoCloseable {
 
     void includeWaitingServiceTemplates(UUID uniqueId);
 
-    void deployResources(UUID uniqueId);
+    void deployResources(UUID uniqueId, Boolean removeDeployments);
+
+    default void deployResources(UUID uniqueId) {
+        deployResources(uniqueId, true);
+    }
 
     Collection<Integer> getReservedTaskIds(String task);
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/network/listener/PacketClientSyncAPIPacketListener.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/network/listener/PacketClientSyncAPIPacketListener.java
@@ -288,7 +288,9 @@ public final class PacketClientSyncAPIPacketListener implements IPacketListener 
                 }
                 break;
                 case "deploy_resources_from_service": {
-                    getCloudNet().deployResources(packet.getHeader().get("uniqueId", UUID.class));
+                    getCloudNet().deployResources(
+                            packet.getHeader().get("uniqueId", UUID.class),
+                            packet.getHeader().getBoolean("removeDeployments"));
                     this.sendEmptyResponse(channel, packet.getUniqueId());
                 }
                 break;

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudService.java
@@ -70,6 +70,9 @@ public interface ICloudService {
 
     void includeTemplates();
 
-    void deployResources();
+    void deployResources(Boolean removeDeployments);
 
+    default void deployResources() {
+        deployResources(true);
+    }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudService.java
@@ -70,7 +70,7 @@ public interface ICloudService {
 
     void includeTemplates();
 
-    void deployResources(Boolean removeDeployments);
+    void deployResources(boolean removeDeployments);
 
     default void deployResources() {
         deployResources(true);

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
@@ -502,7 +502,7 @@ final class JVMCloudService implements ICloudService {
     }
 
     @Override
-    public void deployResources() {
+    public void deployResources(Boolean removeDeployments) {
         for (ServiceDeployment deployment : this.deployments)
             if (deployment != null)
                 if (deployment.getTemplate() != null && deployment.getTemplate().getStorage() != null && deployment.getTemplate().getPrefix() != null &&
@@ -532,7 +532,7 @@ final class JVMCloudService implements ICloudService {
                             deployment.getTemplate()
                     );
 
-                    this.deployments.remove(deployment);
+                    if (removeDeployments) this.deployments.remove(deployment);
 
                     if (storage instanceof LocalTemplateStorage)
                         CloudNet.getInstance().deployTemplateInCluster(deployment.getTemplate(), storage.toZipByteArray(deployment.getTemplate()));

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
@@ -502,7 +502,7 @@ final class JVMCloudService implements ICloudService {
     }
 
     @Override
-    public void deployResources(Boolean removeDeployments) {
+    public void deployResources(boolean removeDeployments) {
         for (ServiceDeployment deployment : this.deployments)
             if (deployment != null)
                 if (deployment.getTemplate() != null && deployment.getTemplate().getStorage() != null && deployment.getTemplate().getPrefix() != null &&
@@ -532,7 +532,9 @@ final class JVMCloudService implements ICloudService {
                             deployment.getTemplate()
                     );
 
-                    if (removeDeployments) this.deployments.remove(deployment);
+                    if (removeDeployments) {
+                        this.deployments.remove(deployment);
+                    }
 
                     if (storage instanceof LocalTemplateStorage)
                         CloudNet.getInstance().deployTemplateInCluster(deployment.getTemplate(), storage.toZipByteArray(deployment.getTemplate()));


### PR DESCRIPTION
Since CloudNet clears the deployments into the service after deploying its ressources, in some cases it would be helpful having the ability to disable this.

An example usecase: Sometimes services have to be copied during runtime without stopping them, for example to copy data securely to prefent data loosing in crash cases.

Added overloaded methods for fully api-support 