### PR TITLE
Neutralization auf authors to CloudNetService

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@
 
 Linux / OSX
 ```
-git clone https://github.com/Dytanic/CloudNet-3.X.git
-cd CloudNet-3.X
+git clone https://github.com/CloudNetService/CloudNet-v3.git
+cd CloudNet-v3
 ./gradlew
 ```
 
 Windows
 ```
-git clone https://github.com/Dytanic/CloudNet-3.X.git
-cd CloudNet-3.X
+git clone https://github.com/CloudNetService/CloudNet-v3.git
+cd CloudNet-v3
 gradlew.bat
 ```
 

--- a/cloudnet-examples/src/main/resources/module.json
+++ b/cloudnet-examples/src/main/resources/module.json
@@ -2,10 +2,10 @@
   "group": "de.dytanic.cloudnet.modules.test",
   "name": "CloudNet-TestModule",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "main": "de.dytanic.cloudnet.examples.ExampleModule",
   "description": "The example module, which you can see a example of the api from CloudNet",
-  "website": "https://dytanic.de",
+  "website": "https://cloudnetservice.eu",
   "properties": {
     "test_property_for_runtime": "foo bar"
   },

--- a/cloudnet-modules/cloudnet-bridge/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-bridge/src/main/resources/module.json
@@ -2,7 +2,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-Bridge",
   "version": "1.1",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "Node extension for the CloudNet runtime, which optimize some features",
   "main": "de.dytanic.cloudnet.ext.bridge.node.CloudNetBridgeModule"

--- a/cloudnet-modules/cloudnet-bridge/src/main/resources/plugin.bukkit.yml
+++ b/cloudnet-modules/cloudnet-bridge/src/main/resources/plugin.bukkit.yml
@@ -1,6 +1,6 @@
 name: CloudNet-Bridge
 version: 1.0
-author: Dytanic
+author: CloudNetService
 description: Bukkit extension for the CloudNet runtime, which optimize some features
 
 main: de.dytanic.cloudnet.ext.bridge.bukkit.BukkitCloudNetBridgePlugin

--- a/cloudnet-modules/cloudnet-bridge/src/main/resources/plugin.bungee.yml
+++ b/cloudnet-modules/cloudnet-bridge/src/main/resources/plugin.bungee.yml
@@ -1,6 +1,6 @@
 name: CloudNet-Bridge
 version: 1.0
-author: Dytanic
+author: CloudNetService
 description: BungeeCord extension for the CloudNet runtime, which optimize some features
 
 main: de.dytanic.cloudnet.ext.bridge.bungee.BungeeCloudNetBridgePlugin

--- a/cloudnet-modules/cloudnet-bridge/src/main/resources/plugin.nukkit.yml
+++ b/cloudnet-modules/cloudnet-bridge/src/main/resources/plugin.nukkit.yml
@@ -1,7 +1,7 @@
 name: CloudNet-Bridge
 version: 1.0
 api: ["1.0.5"]
-author: Dytanic
+author: CloudNetService
 website: https://cloudnetservice.eu
 description: Nukkit extension for the CloudNet runtime, which optimize some features
 

--- a/cloudnet-modules/cloudnet-cloudflare/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-cloudflare/src/main/resources/module.json
@@ -3,7 +3,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-CloudFlare",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "Node extension for the https://cloudflare.com REST-API",
   "main": "de.dytanic.cloudnet.ext.cloudflare.CloudNetCloudflareModule"

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/resources/module.json
@@ -2,7 +2,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-CloudPerms",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "Node extension for the CloudNet node runtime, which include a player permission system",
   "main": "de.dytanic.cloudnet.ext.cloudperms.node.CloudNetCloudPermissionsModule"

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/resources/plugin.bukkit.yml
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/resources/plugin.bukkit.yml
@@ -1,6 +1,6 @@
 name: CloudNet-CloudPerms
 version: 1.0
-author: Dytanic
+author: CloudNetService
 description: Bukkit extension which implement the permission management system from CloudNet into Bukkit for players
 
 main: de.dytanic.cloudnet.ext.cloudperms.bukkit.BukkitCloudNetCloudPermissionsPlugin

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/resources/plugin.bungee.yml
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/resources/plugin.bungee.yml
@@ -1,6 +1,6 @@
 name: CloudNet-CloudPerms
 version: 1.0
-author: Dytanic
+author: CloudNetService
 description: BungeeCord extension which implement the permission management system from CloudNet into BungeeCord for players
 
 main: de.dytanic.cloudnet.ext.cloudperms.bungee.BungeeCloudNetCloudPermissionsPlugin

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/resources/plugin.nukkit.yml
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/resources/plugin.nukkit.yml
@@ -1,7 +1,7 @@
 name: CloudNet-CloudPerms
 version: 1.0
 api: ["1.0.5"]
-author: Dytanic
+author: CloudNetService
 description: Nukkit extension which implement the permission management system from CloudNet into Nukkit for players
 
 main: de.dytanic.cloudnet.ext.cloudperms.nukkit.NukkitCloudNetCloudPermissionsPlugin

--- a/cloudnet-modules/cloudnet-database-mysql/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-database-mysql/src/main/resources/module.json
@@ -3,7 +3,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-Database-MySQL",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "CloudNet extension, which includes the database support for MySQL and MariaDB database to store",
   "main": "de.dytanic.cloudnet.ext.database.mysql.CloudNetMySQLDatabaseModule",

--- a/cloudnet-modules/cloudnet-report/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-report/src/main/resources/module.json
@@ -2,7 +2,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-Report",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "Node extension for develop modules and reporting bugs",
   "main": "de.dytanic.cloudnet.ext.report.CloudNetReportModule"

--- a/cloudnet-modules/cloudnet-rest/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-rest/src/main/resources/module.json
@@ -2,7 +2,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-REST",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "Node extension for the CloudNet runtime, which includes the default HTTP REST API for CloudNet",
   "main": "de.dytanic.cloudnet.ext.rest.CloudNetRestModule"

--- a/cloudnet-modules/cloudnet-signs/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-signs/src/main/resources/module.json
@@ -2,7 +2,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-Signs",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "CloudNet extension, which implement the signs system for minecraft server Bukkit and Sponge",
   "main": "de.dytanic.cloudnet.ext.signs.node.CloudNetSignsModule",

--- a/cloudnet-modules/cloudnet-signs/src/main/resources/plugin.bukkit.yml
+++ b/cloudnet-modules/cloudnet-signs/src/main/resources/plugin.bukkit.yml
@@ -1,6 +1,6 @@
 name: CloudNet-Signs
 version: 1.0
-author: Dytanic
+author: CloudNetService
 website: https://cloudnetservice.eu
 description: Bukkit extension for the CloudNet runtime, which optimize some features
 

--- a/cloudnet-modules/cloudnet-smart/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-smart/src/main/resources/module.json
@@ -3,7 +3,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-Smart",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "CloudNet extension, which implement smart network handling and automatic services providing",
   "main": "de.dytanic.cloudnet.ext.smart.CloudNetSmartModule",

--- a/cloudnet-modules/cloudnet-storage-ftp/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-storage-ftp/src/main/resources/module.json
@@ -3,7 +3,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-Storage-FTP",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "CloudNet extension, which includes the ftp storage system",
   "main": "de.dytanic.cloudnet.ext.storage.ftp.CloudNetStorageFTPModule",

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/resources/module.json
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/resources/module.json
@@ -2,7 +2,7 @@
   "group": "de.dytanic.cloudnet.modules",
   "name": "CloudNet-SyncProxy",
   "version": "1.0",
-  "author": "Dytanic",
+  "author": "CloudNetService",
   "website": "https://cloudnetservice.eu",
   "description": "CloudNet extension, which implement the multi Proxy server synchronization bridge technology and some small features",
   "main": "de.dytanic.cloudnet.ext.syncproxy.node.CloudNetSyncProxyModule"

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/resources/plugin.bungee.yml
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/resources/plugin.bungee.yml
@@ -1,6 +1,6 @@
 name: CloudNet-SyncProxy
 version: 1.0
-author: Dytanic
+author: CloudNetService
 description: CloudNet extension, which implement the multi proxy synchronization bridge technology and some small features
 
 main: de.dytanic.cloudnet.ext.syncproxy.bungee.BungeeCloudNetSyncProxyPlugin

--- a/cloudnet-plugins/cloudnet-bridge-test/src/main/resources/plugin.yml
+++ b/cloudnet-plugins/cloudnet-bridge-test/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: CloudNet-Bridge-Test
 version: 1.0
-author: Dytanic
+author: CloudNetService
 
 main: de.dytanic.cloudnet.ext.bridge.test.CloudNetBridgeTestPlugin
 

--- a/cloudnet-plugins/cloudnet-chat/src/main/resources/plugin.yml
+++ b/cloudnet-plugins/cloudnet-chat/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: CloudNet-Chat
 version: '1.0'
-author: Derrop
+author: CloudNetService
 
 main: eu.cloudnetservice.cloudnet.ext.bridge.chat.CloudNetChatPlugin

--- a/cloudnet-plugins/cloudnet-simplenametags/src/main/resources/plugin.yml
+++ b/cloudnet-plugins/cloudnet-simplenametags/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: CloudNet-SimpleNameTags
-author: Dytanic
+author: CloudNetService
 version: 1.0
 
 main: de.dytanic.cloudnet.ext.simplenametags.CloudNetSimpleNameTagsPlugin


### PR DESCRIPTION
Considering futuristic changes and development on this system gets done by the CloudNetServiceTeam, neutralizing authors makes sence.
Main Effect which animated me for the changes: When Plugin gets enabled, now CloudNetService gets stated.
Whole Neutralization of CloudNet's authors is not finished with this PR, this is just a start with some nice effects. 