### PR TITLE
Updated Gson Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ allprojects {
         //Dependencies
         dependencyLombokVersion = '1.18.6'
         dependencyH2Version = '1.4.197'
-        dependencyGsonVersion = '2.8.2'
+        dependencyGsonVersion = '2.8.5'
         dependencyNettyVersion = '4.1.36.Final'
         dependencyJLine2Version = '2.14.6'
         dependencyJAnsiVersion = '1.17.1'

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ allprojects {
         //Dependencies
         dependencyLombokVersion = '1.18.6'
         dependencyH2Version = '1.4.197'
-        dependencyGsonVersion = '2.8.5'
+        dependencyGsonVersion = '2.8.0'
         dependencyNettyVersion = '4.1.36.Final'
         dependencyJLine2Version = '2.14.6'
         dependencyJAnsiVersion = '1.17.1'

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocument.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocument.java
@@ -839,6 +839,6 @@ public class JsonDocument implements IDocument<JsonDocument> {
 
     @Override
     public Iterator<String> iterator() {
-        return this.jsonObject.keySet().iterator();
+        return this.jsonObject.entrySet().stream().map(Map.Entry::getKey).iterator();
     }
 }


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

Changed Gson version to newer one.
Done this to prevent warning of illegal reflective access to some constructor by gson.
Tested, seems to work. Fortunately the old version and new version of gson are not so much different.