### PR TITLE
Restrict some publish operations for foreign ServiceInfoSnapshots

### DIFF
--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -2212,10 +2212,12 @@ public final class Wrapper extends CloudNetDriver {
     }
 
     public void publishServiceInfoUpdate(ServiceInfoSnapshot serviceInfoSnapshot) {
-        this.eventManager.callEvent(new ServiceInfoSnapshotConfigureEvent(serviceInfoSnapshot));
+        if (currentServiceInfoSnapshot.getServiceId().equals(serviceInfoSnapshot.getServiceId())) {
+            this.eventManager.callEvent(new ServiceInfoSnapshotConfigureEvent(serviceInfoSnapshot));
 
-        this.lastServiceInfoSnapShot = this.currentServiceInfoSnapshot;
-        this.currentServiceInfoSnapshot = serviceInfoSnapshot;
+            this.lastServiceInfoSnapShot = this.currentServiceInfoSnapshot;
+            this.currentServiceInfoSnapshot = serviceInfoSnapshot;
+        }
 
         this.networkClient.sendPacket(new PacketClientServiceInfoUpdate(serviceInfoSnapshot));
     }


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes
- [x] bugfix

Fixed little bug which occured when making this method usable for public updates.
Foreign perhaps ServiceInfoSnapshots had been affected operations which where only intendet to local stuff.