### PR TITLE
Changed dependency handling into wrapper

### DIFF
--- a/cloudnet-common/build.gradle
+++ b/cloudnet-common/build.gradle
@@ -1,5 +1,5 @@
 jar {
-    archiveName = cloudnetCommonFile
+    archiveFileName.set(cloudnetCommonFile)
 }
 
 dependencies {

--- a/cloudnet-driver/build.gradle
+++ b/cloudnet-driver/build.gradle
@@ -1,6 +1,6 @@
 jar {
 
-    archiveName = cloudnetDriverOutFileName
+    archiveFileName.set(cloudnetDriverOutFileName)
 
     from {
 

--- a/cloudnet-modules/cloudnet-syncproxy/build.gradle
+++ b/cloudnet-modules/cloudnet-syncproxy/build.gradle
@@ -1,5 +1,5 @@
 jar {
-    archiveName = cloudnetModuleSyncProxyFileName
+    archiveFileName.set(cloudnetModuleSyncProxyFileName)
 }
 
 dependencies {

--- a/cloudnet-wrapper-jvm/build.gradle
+++ b/cloudnet-wrapper-jvm/build.gradle
@@ -1,15 +1,33 @@
-jar {
-
-    archiveName cloudnetWrapperFile
-
-    manifest {
-        attributes 'Main-Class': 'de.dytanic.cloudnet.wrapper.Main'
-        attributes 'Premain-Class': 'de.dytanic.cloudnet.wrapper.runtime.RuntimeAgent'
-        attributes 'Implementation-Version': version + "-" + getCurrentCommitHash()
-        attributes 'Implementation-Title': cloudNetCodeName
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
     }
 }
 
+apply plugin: 'com.github.johnrengelman.shadow'
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'de.dytanic.cloudnet.wrapper.Main'
+        attributes 'Premain-Class': 'de.dytanic.cloudnet.wrapper.runtime.RuntimeAgent'
+        attributes 'Implementation-Version': archiveVersion.get() + "-" + getCurrentCommitHash()
+        attributes 'Implementation-Title': cloudNetCodeName
+    }
+
+    dependsOn shadowJar
+}
+
 dependencies {
-    compileOnly project(':cloudnet-driver')
+    compile project(':cloudnet-driver')
+}
+
+shadowJar {
+    archiveFileName.set(cloudnetWrapperFile)
+    archiveClassifier.set(null)
+    archiveVersion.set(null)
+    relocate 'io.netty', 'de.dytanic.cloudnet.wrapper.relocate.netty'
+    relocate 'com.google.gson', 'de.dytanic.cloudnet.wrapper.relocate.gson'
 }

--- a/cloudnet/build.gradle
+++ b/cloudnet/build.gradle
@@ -4,11 +4,11 @@ jar {
 
     manifest {
         attributes 'Main-Class': 'de.dytanic.cloudnet.Main'
-        attributes 'Implementation-Version': version + "-" + getCurrentCommitHash()
+        attributes 'Implementation-Version': archiveVersion.get() + "-" + getCurrentCommitHash()
         attributes 'Implementation-Title': cloudNetCodeName
     }
 
-    archiveName = cloudnetRunnableOutFileName
+    archiveFileName.set(cloudnetRunnableOutFileName)
 
     manifest = jar.manifest
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/JVMCloudService.java
@@ -634,8 +634,7 @@ final class JVMCloudService implements ICloudService {
         commandArguments.addAll(Arrays.asList(
                 "-Xmx" + this.serviceConfiguration.getProcessConfig().getMaxHeapMemorySize() + "M",
                 "-javaagent:" + wrapperFile.getAbsolutePath(),
-                "-cp", System.getProperty("cloudnet.launcher.driver.dependencies") +
-                        File.pathSeparator + wrapperFile.getAbsolutePath() +
+                "-cp", wrapperFile.getAbsolutePath() +
                         File.pathSeparator + String.join(File.pathSeparator, availableJarFiles)
         ));
 


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

Changed:
- Updated deprecated field settings in gradle file to conventional usuage
- Added shadow plugin to create shadowed jar files for wrapper
- Added shadow relocate functions to build config for inserting needed dependencies into wrapper jar file
- Removed Collection of all usable wrapper dependencies from classpath
- Added liberty to use our own dependency versions without relations to server software one's

Related Issues:
- Fixed 1.8 netty join problem
- Fixed compatibility issues that where caused by affection dependencies into classpath
- Fixed gson version issue (github): https://github.com/CloudNetService/CloudNet-v3/issues/1
- Fixed gson channelMessage issue (discord): https://discordapp.com/channels/325362837184577536/536594898321670154/581604794263928852
- Opened door to use this Pull Request with new gson Version: https://github.com/CloudNetService/CloudNet-v3/pull/103

Note: By this change the wrapper jar will grow to 4 MB, so also the launcher.jar file size will be affected. But this must be done, because dytanics solution with loading all dependencies into classpath will cause much more incompatability issues than it already does. If we really want to still keep the launcher size little, maybe downloading the wrapper jar from external server repo will be another solution. But the wrapper file has to be such big!