### PR TITLE
Synchronized the modification of the scoreboard to follow bukkits behaviours

### DIFF
--- a/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/CloudNetSimpleNameTagsPlugin.java
+++ b/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/CloudNetSimpleNameTagsPlugin.java
@@ -10,7 +10,7 @@ public final class CloudNetSimpleNameTagsPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        Listener listener = new CloudNetSimpleNameTagsListener();
+        Listener listener = new CloudNetSimpleNameTagsListener(this);
 
         getServer().getPluginManager().registerEvents(listener, this);
         CloudNetDriver.getInstance().getEventManager().registerListener(listener);

--- a/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
+++ b/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
@@ -6,6 +6,7 @@ import de.dytanic.cloudnet.driver.event.events.permission.PermissionUpdateUserEv
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.bukkit.BukkitCloudNetCloudPermissionsPlugin;
+import de.dytanic.cloudnet.ext.simplenametags.CloudNetSimpleNameTagsPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -16,10 +17,15 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import java.util.Optional;
 
 public final class CloudNetSimpleNameTagsListener implements Listener {
+    private final CloudNetSimpleNameTagsPlugin plugin;
+
+    public CloudNetSimpleNameTagsListener(CloudNetSimpleNameTagsPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void handle(PlayerJoinEvent event) {
-        Bukkit.getScheduler().runTask(Bukkit.getPluginManager().getPlugin("CloudNet-SimpleNameTags"), () -> BukkitCloudNetCloudPermissionsPlugin.getInstance().updateNameTags(event.getPlayer()));
+        Bukkit.getScheduler().runTask(plugin, () -> BukkitCloudNetCloudPermissionsPlugin.getInstance().updateNameTags(event.getPlayer()));
     }
 
     @EventListener

--- a/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
+++ b/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
@@ -6,20 +6,20 @@ import de.dytanic.cloudnet.driver.event.events.permission.PermissionUpdateUserEv
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.bukkit.BukkitCloudNetCloudPermissionsPlugin;
-import de.dytanic.cloudnet.ext.simplenametags.CloudNetSimpleNameTagsPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Optional;
 
 public final class CloudNetSimpleNameTagsListener implements Listener {
-    private final CloudNetSimpleNameTagsPlugin plugin;
+    private final JavaPlugin plugin;
 
-    public CloudNetSimpleNameTagsListener(CloudNetSimpleNameTagsPlugin plugin) {
+    public CloudNetSimpleNameTagsListener(JavaPlugin plugin) {
         this.plugin = plugin;
     }
 

--- a/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
+++ b/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
@@ -9,6 +9,7 @@ import de.dytanic.cloudnet.ext.cloudperms.bukkit.BukkitCloudNetCloudPermissionsP
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
@@ -16,9 +17,9 @@ import java.util.Optional;
 
 public final class CloudNetSimpleNameTagsListener implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     public void handle(PlayerJoinEvent event) {
-        Bukkit.getScheduler().runTaskLaterAsynchronously(Bukkit.getPluginManager().getPlugin("CloudNet-SimpleNameTags"), () -> BukkitCloudNetCloudPermissionsPlugin.getInstance().updateNameTags(event.getPlayer()), 4L);
+        Bukkit.getScheduler().runTask(Bukkit.getPluginManager().getPlugin("CloudNet-SimpleNameTags"), () -> BukkitCloudNetCloudPermissionsPlugin.getInstance().updateNameTags(event.getPlayer()));
     }
 
     @EventListener

--- a/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
+++ b/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 public final class CloudNetSimpleNameTagsListener implements Listener {
 
-    @EventHandler(priority = EventPriority.HIGH)
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void handle(PlayerJoinEvent event) {
         Bukkit.getScheduler().runTask(Bukkit.getPluginManager().getPlugin("CloudNet-SimpleNameTags"), () -> BukkitCloudNetCloudPermissionsPlugin.getInstance().updateNameTags(event.getPlayer()));
     }

--- a/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
+++ b/cloudnet-plugins/cloudnet-simplenametags/src/main/java/de/dytanic/cloudnet/ext/simplenametags/listener/CloudNetSimpleNameTagsListener.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 public final class CloudNetSimpleNameTagsListener implements Listener {
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.HIGH)
     public void handle(PlayerJoinEvent event) {
         Bukkit.getScheduler().runTask(Bukkit.getPluginManager().getPlugin("CloudNet-SimpleNameTags"), () -> BukkitCloudNetCloudPermissionsPlugin.getInstance().updateNameTags(event.getPlayer()));
     }


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

Changes: 
- Synchronized call of the scoreboard update to prevent asynchronous issues
- Used event priority instead of run delay
