### PR TITLE
Ignore interrupt warning on server stop

### DIFF
--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -2265,10 +2265,7 @@ public final class Wrapper extends CloudNetDriver {
                     if (diff < millis) {
                         try {
                             Thread.sleep(millis - diff);
-                        } catch (InterruptedException ignored) {
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
+                        } catch (InterruptedException ignored) { }
                     }
 
                     value = System.currentTimeMillis();

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -2265,8 +2265,9 @@ public final class Wrapper extends CloudNetDriver {
                     if (diff < millis) {
                         try {
                             Thread.sleep(millis - diff);
-                        } catch (Exception exception) {
-                            exception.printStackTrace();
+                        } catch (InterruptedException ignored) {
+                        } catch (Exception e) {
+                            e.printStackTrace();
                         }
                     }
 

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -2238,7 +2238,7 @@ public final class Wrapper extends CloudNetDriver {
 
 
     /**
-     * Removes all PacketListeners from all channels of the Network Connctor from a
+     * Removes all PacketListeners from all channels of the Network Connector from a
      * specific ClassLoader. It is recommended to do this with the disables of your own plugin
      *
      * @param classLoader the ClassLoader from which the IPacketListener implementations derive.


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

Changes: 
- made the case of InterruptException ignored to prevent printing it
- since the thread have to be interrupted, this warning is the normal behaviour
- corrected little type fault :D