### PR TITLE
Fix console prompt in the log messages

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine2Console.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine2Console.java
@@ -1,6 +1,7 @@
 package de.dytanic.cloudnet.console;
 
 import jline.console.ConsoleReader;
+import org.fusesource.jansi.Ansi;
 import org.fusesource.jansi.AnsiConsole;
 
 public final class JLine2Console implements IConsole {
@@ -51,7 +52,7 @@ public final class JLine2Console implements IConsole {
         text = ConsoleColor.toColouredString('&', text);
 
         try {
-            this.consoleReader.print(ConsoleReader.RESET_LINE + text + ConsoleColor.DEFAULT);
+            this.consoleReader.print(Ansi.ansi().eraseLine(Ansi.Erase.ALL).toString() + ConsoleReader.RESET_LINE + text + ConsoleColor.DEFAULT);
             this.consoleReader.flush();
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -73,7 +74,7 @@ public final class JLine2Console implements IConsole {
         }
 
         try {
-            this.consoleReader.print(ConsoleReader.RESET_LINE + text + ConsoleColor.DEFAULT);
+            this.consoleReader.print(Ansi.ansi().eraseLine(Ansi.Erase.ALL).toString() + ConsoleReader.RESET_LINE + text + ConsoleColor.DEFAULT);
             this.consoleReader.drawLine();
             this.consoleReader.flush();
         } catch (Exception exception) {


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
This fixes that the command prompt is contained in every console message with a length less than the length of the prompt.
This image shows the messages before this commit
![image](https://user-images.githubusercontent.com/37866812/65832678-4c6b9900-e2c7-11e9-9926-848a37dc1c6f.png)  
and this image
![image](https://user-images.githubusercontent.com/37866812/65832687-5ab9b500-e2c7-11e9-9bf4-00dc4292c671.png) the messages after this commit

