### PR TITLE
Fixed wrong class path for velocity syncproxy plugin

### DIFF
--- a/cloudnet-modules/cloudnet-syncproxy/src/main/resources/velocity-plugin.json
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/resources/velocity-plugin.json
@@ -7,5 +7,5 @@
   "authors": [
     "CloudNetService"
   ],
-  "main": "de.dytanic.cloudnet.ext.cloudperms.velocity.VelocityCloudNetCloudPermissionsPlugin"
+  "main": "de.dytanic.cloudnet.ext.syncproxy.velocity.VelocityCloudNetSyncProxyPlugin"
 }


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
This fixes that the syncproxy plugin has never been loaded because of a wrong class defined in the velocity-plugin.json file