### PR TITLE
Fix unregistered listeners/commands/... of runtimeModules

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -265,8 +265,6 @@ public final class CloudNet extends CloudNetDriver {
 
         this.unloadAll();
 
-        this.registerDefaultCommands();
-        this.registerDefaultServices();
         this.enableModules();
 
         this.logger.info(LanguageManager.getMessage("reload-end-message"));
@@ -1871,41 +1869,38 @@ public final class CloudNet extends CloudNetDriver {
 
     private void unloadAll() {
         this.unloadModules();
-
-        this.commandMap.unregisterCommands();
-        this.eventManager.unregisterAll();
-        this.servicesRegistry.unregisterAll();
-        this.httpServer.clearHandlers();
     }
 
     private void unloadModules() {
         for (IModuleWrapper moduleWrapper : this.moduleProvider.getModules()) {
             if (!moduleWrapper.getModuleConfiguration().isRuntimeModule()) {
-                //unregister packet listeners
-                this.unregisterPacketListenersByClassLoader(moduleWrapper.getClassLoader());
-
-                moduleWrapper.unloadModule();
-                this.logger.info(LanguageManager.getMessage("cloudnet-unload-module")
-                        .replace("%module_group%", moduleWrapper.getModuleConfiguration().getGroup())
-                        .replace("%module_name%", moduleWrapper.getModuleConfiguration().getName())
-                        .replace("%module_version%", moduleWrapper.getModuleConfiguration().getVersion())
-                        .replace("%module_author%", moduleWrapper.getModuleConfiguration().getAuthor()));
+                this.unloadModule(moduleWrapper);
             }
         }
     }
 
     private void unloadAllModules0() {
         for (IModuleWrapper moduleWrapper : this.moduleProvider.getModules()) {
-            //unregister packet listeners
-            this.unregisterPacketListenersByClassLoader(moduleWrapper.getClassLoader());
-
-            moduleWrapper.unloadModule();
-            this.logger.info(LanguageManager.getMessage("cloudnet-unload-module")
-                    .replace("%module_group%", moduleWrapper.getModuleConfiguration().getGroup())
-                    .replace("%module_name%", moduleWrapper.getModuleConfiguration().getName())
-                    .replace("%module_version%", moduleWrapper.getModuleConfiguration().getVersion())
-                    .replace("%module_author%", moduleWrapper.getModuleConfiguration().getAuthor()));
+            this.unloadModule(moduleWrapper);
         }
+    }
+
+    private void unloadModule(IModuleWrapper moduleWrapper) {
+        //unregister packet listeners
+        this.unregisterPacketListenersByClassLoader(moduleWrapper.getClassLoader());
+        this.eventManager.unregisterListeners(moduleWrapper.getClassLoader());
+        this.commandMap.unregisterCommands(moduleWrapper.getClassLoader());
+        this.servicesRegistry.unregisterAll(moduleWrapper.getClassLoader());
+        this.httpServer.removeHandler(moduleWrapper.getClassLoader());
+        this.getNetworkClient().getPacketRegistry().removeListeners(moduleWrapper.getClassLoader());
+        this.getNetworkServer().getPacketRegistry().removeListeners(moduleWrapper.getClassLoader());
+
+        moduleWrapper.unloadModule();
+        this.logger.info(LanguageManager.getMessage("cloudnet-unload-module")
+                .replace("%module_group%", moduleWrapper.getModuleConfiguration().getGroup())
+                .replace("%module_name%", moduleWrapper.getModuleConfiguration().getName())
+                .replace("%module_version%", moduleWrapper.getModuleConfiguration().getVersion())
+                .replace("%module_author%", moduleWrapper.getModuleConfiguration().getAuthor()));
     }
 
     private void initDefaultConfigDefaultHostAddress() throws Exception {

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -1886,7 +1886,6 @@ public final class CloudNet extends CloudNetDriver {
     }
 
     private void unloadModule(IModuleWrapper moduleWrapper) {
-        //unregister packet listeners
         this.unregisterPacketListenersByClassLoader(moduleWrapper.getClassLoader());
         this.eventManager.unregisterListeners(moduleWrapper.getClassLoader());
         this.commandMap.unregisterCommands(moduleWrapper.getClassLoader());


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
All listeners, commands, services and http listeners were unregistered by all modules on reloading the Cloud, the modules that shouldn't be reloaded, too.

