### PR TITLE
Fix NullPointerException on every group creation

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagement.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagement.java
@@ -194,11 +194,13 @@ public final class DefaultDatabasePermissionManagement implements IPermissionMan
         Validate.checkNotNull(group);
 
         IPermissionGroup permissionGroup = permissionGroupsMap.remove(group);
-        if (permissionManagementHandler != null) {
-            permissionManagementHandler.handleDeleteGroup(this, permissionGroup);
-        }
+        if (permissionGroup != null) {
+            if (permissionManagementHandler != null) {
+                permissionManagementHandler.handleDeleteGroup(this, permissionGroup);
+            }
 
-        saveGroups();
+            saveGroups();
+        }
     }
 
     @Override


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
There was a NullPointerException (de.dytanic.cloudnet.ext.cloudperms.listener.PermissionsUpdateListener.handle(PermissionsUpdateListener.java:50)) when you execute "perms create group NAME POTENCY" on every service that has the CloudPerms Plugin enabled. This is fixed by this PR.

