### PR TITLE
Bump gson from 2.8.2 to 2.8.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ allprojects {
         //Dependencies
         dependencyLombokVersion = '1.18.6'
         dependencyH2Version = '1.4.197'
-        dependencyGsonVersion = '2.8.2'
+        dependencyGsonVersion = '2.8.6'
         dependencyNettyVersion = '4.1.36.Final'
         dependencyJLine2Version = '2.14.6'
         dependencyJAnsiVersion = '1.17.1'

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocument.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocument.java
@@ -20,7 +20,6 @@ import java.util.*;
  */
 public class JsonDocument implements IDocument<JsonDocument> {
 
-    protected static final JsonParser PARSER = new JsonParser();
     public static Gson GSON = new GsonBuilder()
             .serializeNulls()
             .disableHtmlEscaping()
@@ -325,7 +324,7 @@ public class JsonDocument implements IDocument<JsonDocument> {
 
     @Override
     public JsonDocument append(Reader reader) {
-        return append(PARSER.parse(reader).getAsJsonObject());
+        return append(JsonParser.parseReader(reader).getAsJsonObject());
     }
 
     @Override
@@ -771,7 +770,7 @@ public class JsonDocument implements IDocument<JsonDocument> {
     @Override
     public JsonDocument read(Reader reader) {
         try (BufferedReader bufferedReader = new BufferedReader(reader)) {
-            return this.append(PARSER.parse(bufferedReader).getAsJsonObject());
+            return this.append(JsonParser.parseReader(bufferedReader).getAsJsonObject());
         } catch (Exception ex) {
             ex.getStackTrace();
         }
@@ -780,13 +779,13 @@ public class JsonDocument implements IDocument<JsonDocument> {
 
     @Override
     public IReadable read(byte[] bytes) {
-        this.append(PARSER.parse(new String(bytes, StandardCharsets.UTF_8)).getAsJsonObject());
+        this.append(JsonParser.parseString(new String(bytes, StandardCharsets.UTF_8)).getAsJsonObject());
         return this;
     }
 
     public JsonDocument read(String input) {
         try {
-            this.append(PARSER.parse(new BufferedReader(new StringReader(input))).getAsJsonObject());
+            this.append(JsonParser.parseReader(new BufferedReader(new StringReader(input))).getAsJsonObject());
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModuleWrapper.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/module/DefaultModuleWrapper.java
@@ -74,7 +74,7 @@ public class DefaultModuleWrapper implements IModuleWrapper {
             }
 
             try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
-                JsonObject jsonObject = new JsonParser().parse(reader).getAsJsonObject();
+                JsonObject jsonObject = JsonParser.parseReader(reader).getAsJsonObject();
 
                 moduleConfigurationSource = new JsonDocument(jsonObject);
                 moduleConfiguration = GSON.fromJson(jsonObject, MODULE_CONFIGURATION_TYPE);


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
Bump gson from 2.8.2 to 2.8.6 and replace the old methods which are now deprecated with the new ones
