### PR TITLE
Added IJsonDocPropertyable#getProperties method

### DIFF
--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/BasicJsonDocPropertyable.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/BasicJsonDocPropertyable.java
@@ -6,13 +6,13 @@ public class BasicJsonDocPropertyable implements IJsonDocPropertyable {
 
     @Override
     public <E> IJsonDocPropertyable setProperty(JsonDocProperty<E> docProperty, E val) {
-        properties.setProperty(docProperty, val);
+        this.properties.setProperty(docProperty, val);
         return this;
     }
 
     @Override
     public <E> E getProperty(JsonDocProperty<E> docProperty) {
-        return properties.getProperty(docProperty);
+        return this.properties.getProperty(docProperty);
     }
 
     @Override
@@ -23,9 +23,10 @@ public class BasicJsonDocPropertyable implements IJsonDocPropertyable {
 
     @Override
     public <E> boolean hasProperty(JsonDocProperty<E> docProperty) {
-        return docProperty.tester.test(properties);
+        return docProperty.tester.test(this.properties);
     }
 
+    @Override
     public JsonDocument getProperties() {
         return this.properties;
     }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/IJsonDocPropertyable.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/IJsonDocPropertyable.java
@@ -13,4 +13,6 @@ public interface IJsonDocPropertyable {
 
     <E> boolean hasProperty(JsonDocProperty<E> docProperty);
 
+    JsonDocument getProperties();
+
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocument.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocument.java
@@ -815,6 +815,11 @@ public class JsonDocument implements IDocument<JsonDocument> {
         return docProperty.tester.test(this);
     }
 
+    @Override
+    public JsonDocument getProperties() {
+        return this;
+    }
+
     public JsonObject toJsonObject() {
         return jsonObject;
     }


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
With this method users can easily get the properties of an object without creating a JsonDocProperty which would be useless for just a string for example.
I think the JsonDocProperty class would be useful to make objects serializable, but on the other side gson already has a serializer for that. So, why do we need that class?