### PR TITLE
Fix that the permission cloudnet.syncproxy.maintenance did not work

### DIFF
--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bungee/listener/BungeeCloudNetCloudPermissionsPlayerListener.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bungee/listener/BungeeCloudNetCloudPermissionsPlayerListener.java
@@ -11,6 +11,8 @@ import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.UUID;
 
 public final class BungeeCloudNetCloudPermissionsPlayerListener implements Listener {
@@ -24,9 +26,21 @@ public final class BungeeCloudNetCloudPermissionsPlayerListener implements Liste
     public void handle(PermissionCheckEvent event) {
         CommandSender sender = event.getSender();
 
-        if (sender instanceof ProxiedPlayer) {
-            UUID uniqueId = ((ProxiedPlayer) sender).getUniqueId();
+        UUID uniqueId = null;
 
+        if (sender instanceof ProxiedPlayer) {
+            uniqueId = ((ProxiedPlayer) sender).getUniqueId();
+        } else {
+            try {
+                Method method = sender.getClass().getDeclaredMethod("getUniqueId");
+                uniqueId = (UUID) method.invoke(sender);
+            } catch (NoSuchMethodException ignored) {
+            } catch (IllegalAccessException | InvocationTargetException exception) {
+                exception.printStackTrace();
+            }
+        }
+
+        if (uniqueId != null) {
             IPermissionUser permissionUser = CloudPermissionsPermissionManagement.getInstance().getUser(uniqueId);
 
             if (permissionUser != null) {

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/util/LoginPendingConnectionCommandSender.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/util/LoginPendingConnectionCommandSender.java
@@ -101,7 +101,7 @@ public class LoginPendingConnectionCommandSender implements CommandSender {
         return this.pendingConnection;
     }
 
-    public UUID getUniqueId() { //this method is REQUIRED, do NOT DELETE
+    public UUID getUniqueId() {
         return this.uniqueId;
     }
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/util/LoginPendingConnectionCommandSender.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/util/LoginPendingConnectionCommandSender.java
@@ -98,10 +98,10 @@ public class LoginPendingConnectionCommandSender implements CommandSender {
     }
 
     public PendingConnection getPendingConnection() {
-        return pendingConnection;
+        return this.pendingConnection;
     }
 
-    public UUID getUniqueId() {
+    public UUID getUniqueId() { //this method is REQUIRED, do NOT DELETE
         return this.uniqueId;
     }
 }


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
Since the release date of 3.0.0, this permission didn't work, this is fixed with this PR.