### PR TITLE
Server updates

### DIFF
--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -463,7 +463,6 @@ public final class Wrapper extends CloudNetDriver {
     private synchronized void mainloop() throws Exception {
         long value = System.currentTimeMillis();
         long millis = 1000 / TPS;
-        int tps5 = TPS * 5, start1Tick = tps5;
 
         if (this.startApplication()) {
             while (!Thread.currentThread().isInterrupted()) {
@@ -488,12 +487,6 @@ public final class Wrapper extends CloudNetDriver {
                             this.processQueue.poll();
                         }
                     }
-
-                    if (start1Tick++ >= tps5) {
-                        this.publishServiceInfoUpdate();
-                        start1Tick = 0;
-                    }
-
                 } catch (Exception exception) {
                     exception.printStackTrace();
                 }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -98,7 +98,6 @@ public final class Wrapper extends CloudNetDriver {
      * The single task thread of the scheduler of the wrapper application
      */
     private final Thread mainThread = Thread.currentThread();
-    private final Function<Pair<JsonDocument, byte[]>, Void> VOID_FUNCTION = documentPair -> null;
     private IDatabaseProvider databaseProvider = new DefaultWrapperDatabaseProvider();
     /**
      * The ServiceInfoSnapshot instances. The current ServiceInfoSnapshot instance is the last send object snapshot


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
Removed the service info updates every 5 seconds from the wrapper because they are only needed for the signs (to display their cpu usage/thread count)


### related issues/discussions
Fixes #24 
