### PR TITLE
Print console on the screen command with INFO level

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandScreen.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandScreen.java
@@ -46,7 +46,7 @@ public final class CommandScreen extends CommandDefault implements ITabCompleter
 
                         if (enabled) {
                             for (String input : cloudService.getServiceConsoleLogCache().getCachedLogMessages()) {
-                                CloudNetDriver.getInstance().getLogger().log(LogLevel.IMPORTANT, "[" + cloudService.getServiceId().getName() + "] " + input);
+                                CloudNetDriver.getInstance().getLogger().log(LogLevel.INFO, "[" + cloudService.getServiceId().getName() + "] " + input);
                             }
 
                             sender.sendMessage(LanguageManager.getMessage("command-screen-enable-for-service")


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
Prints the cached console on executing the screen command with the INFO level instead of the IMPORTANT level just like when there is new input when the screen is enabled.