### PR TITLE
Fix proxy fallback priority sorting

### DIFF
--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
@@ -21,7 +21,7 @@ public class ProxyFallback implements Comparable<ProxyFallback> {
 
     @Override
     public int compareTo(ProxyFallback o) {
-        return priority + o.priority;
+        return Integer.compare(o.priority, this.priority);
     }
 
     public String getTask() {


### PR DESCRIPTION
- [ ] breaking changes
- [ ] no breaking changes

The priority of the fallbacks configured by users might change, if the have multiple fallbacks configured. Before this PR the sorting was just like the config, now it is sorted by the priority. But this shouldn't be too much of a breaking change