### PR TITLE
Add missing getInstance method

### DIFF
--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsPermissionManagement.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsPermissionManagement.java
@@ -6,4 +6,9 @@ package de.dytanic.cloudnet.ext.cloudperms;
  */
 @Deprecated
 public class CloudPermissionsPermissionManagement extends CloudPermissionsManagement {
+  
+    public static CloudPermissionsManagement getInstance() {
+        return CloudPermissionsManagement.getInstance();
+    }
+  
 }


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
Fixes NoSuchMethodErrors for users still using the old CloudPermissionsPermissionManagement class