### PR TITLE
Remove all automatic cluster synchronizations, add "cluster push all" command

### DIFF
--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/ClusterSynchronizedPermissionManagement.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/ClusterSynchronizedPermissionManagement.java
@@ -67,7 +67,9 @@ public interface ClusterSynchronizedPermissionManagement extends IPermissionMana
     }
 
     default void deleteGroup(String group) {
-        this.deleteGroup(this.getGroup(group));
+        if (this.containsGroup(group)) {
+            this.deleteGroup(this.getGroup(group));
+        }
     }
 
     default void deleteGroup(IPermissionGroup group) {

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTemplate.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTemplate.java
@@ -52,15 +52,19 @@ public class ServiceTemplate implements INameable {
 
     public static ServiceTemplate parse(String template) {
         String[] base = template.split(":");
+
         if (base.length > 2) {
             return null;
         }
+
         String path = base.length == 2 ? base[1] : base[0];
         String storage = base.length == 2 ? base[0] : "local";
         String[] splitPath = path.split("/");
+
         if (splitPath.length != 2) {
             return null;
         }
+
         return new ServiceTemplate(splitPath[0], splitPath[1], storage);
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -962,7 +962,8 @@ public final class CloudNet extends CloudNetDriver {
                 new DefaultDatabasePermissionManagement(this::getDatabaseProvider));
 
         this.servicesRegistry.registerService(AbstractDatabaseProvider.class, "h2",
-                new H2DatabaseProvider(System.getProperty("cloudnet.database.h2.path", "local/database/h2"), taskScheduler));
+                new H2DatabaseProvider(System.getProperty("cloudnet.database.h2.path", "local/database/h2"),
+                        !CloudNet.getInstance().getConfig().getClusterConfig().getNodes().isEmpty(), this.taskScheduler));
     }
 
     private void runConsole() {

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandCluster.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandCluster.java
@@ -38,6 +38,7 @@ public final class CommandCluster extends CommandDefault implements ITabComplete
                     "cluster shutdown",
                     "cluster add <nodeId> <host> <port>",
                     "cluster nodes | id=<id>",
+                    "cluster push all",
                     "cluster push local-templates",
                     "cluster push tasks",
                     "cluster push groups",
@@ -48,39 +49,31 @@ public final class CommandCluster extends CommandDefault implements ITabComplete
 
         if (args[0].toLowerCase().contains("push")) {
             if (args.length == 2) {
+                if (args[1].equalsIgnoreCase("all")) {
+                    this.pushTasks(sender);
+                    this.pushGroups(sender);
+                    this.pushPermissions(sender);
+                    this.pushLocalTemplates(sender);
+                    return;
+                }
+
                 if (args[1].equalsIgnoreCase("local-templates")) {
-                    ITemplateStorage storage = CloudNetDriver.getInstance().getServicesRegistry().getService(ITemplateStorage.class, LocalTemplateStorage.LOCAL_TEMPLATE_STORAGE);
-
-                    byte[] bytes;
-                    for (ServiceTemplate serviceTemplate : storage.getTemplates()) {
-                        bytes = storage.toZipByteArray(serviceTemplate);
-                        if (bytes != null) {
-                            getCloudNet().deployTemplateInCluster(serviceTemplate, bytes);
-                        }
-
-                        sender.sendMessage(
-                                LanguageManager.getMessage("command-cluster-push-templates-from-local-success")
-                                        .replace("%template%", serviceTemplate.getStorage() + ":" + serviceTemplate.getTemplatePath())
-                        );
-                    }
+                    this.pushLocalTemplates(sender);
                     return;
                 }
 
                 if (args[1].equalsIgnoreCase("local-perms")) {
-                    getCloudNet().publishPermissionGroupUpdates(getCloudNet().getPermissionManagement().getGroups(), NetworkUpdateType.SET);
-
-                    sender.sendMessage(LanguageManager.getMessage("command-cluster-push-permissions-success"));
+                    this.pushPermissions(sender);
+                    return;
                 }
 
                 if (args[1].equalsIgnoreCase("tasks")) {
-                    getCloudNet().updateServiceTasksInCluster(getCloudNet().getServiceTaskProvider().getPermanentServiceTasks(), NetworkUpdateType.SET);
-                    sender.sendMessage(LanguageManager.getMessage("command-cluster-push-tasks-success"));
+                    this.pushTasks(sender);
                     return;
                 }
 
                 if (args[1].equalsIgnoreCase("groups")) {
-                    getCloudNet().updateGroupConfigurationsInCluster(getCloudNet().getGroupConfigurationProvider().getGroupConfigurations(), NetworkUpdateType.SET);
-                    sender.sendMessage(LanguageManager.getMessage("command-cluster-push-groups-success"));
+                    this.pushGroups(sender);
                     return;
                 }
             }
@@ -121,6 +114,39 @@ public final class CommandCluster extends CommandDefault implements ITabComplete
 
             sender.sendMessage(LanguageManager.getMessage("command-cluster-create-node-success"));
         }
+    }
+
+    private void pushLocalTemplates(ICommandSender sender) {
+        ITemplateStorage storage = CloudNetDriver.getInstance().getServicesRegistry().getService(ITemplateStorage.class, LocalTemplateStorage.LOCAL_TEMPLATE_STORAGE);
+
+        byte[] bytes;
+        for (ServiceTemplate serviceTemplate : storage.getTemplates()) {
+            bytes = storage.toZipByteArray(serviceTemplate);
+            if (bytes != null) {
+                getCloudNet().deployTemplateInCluster(serviceTemplate, bytes);
+            }
+
+            sender.sendMessage(
+                    LanguageManager.getMessage("command-cluster-push-templates-from-local-success")
+                            .replace("%template%", serviceTemplate.getStorage() + ":" + serviceTemplate.getTemplatePath())
+            );
+        }
+    }
+
+    private void pushPermissions(ICommandSender sender) {
+        getCloudNet().publishPermissionGroupUpdates(getCloudNet().getPermissionManagement().getGroups(), NetworkUpdateType.SET);
+
+        sender.sendMessage(LanguageManager.getMessage("command-cluster-push-permissions-success"));
+    }
+
+    private void pushTasks(ICommandSender sender) {
+        getCloudNet().updateServiceTasksInCluster(getCloudNet().getServiceTaskProvider().getPermanentServiceTasks(), NetworkUpdateType.SET);
+        sender.sendMessage(LanguageManager.getMessage("command-cluster-push-tasks-success"));
+    }
+
+    private void pushGroups(ICommandSender sender) {
+        getCloudNet().updateGroupConfigurationsInCluster(getCloudNet().getGroupConfigurationProvider().getGroupConfigurations(), NetworkUpdateType.SET);
+        sender.sendMessage(LanguageManager.getMessage("command-cluster-push-groups-success"));
     }
 
     private void displayNode(ICommandSender sender, IClusterNodeServer node) {
@@ -183,6 +209,7 @@ public final class CommandCluster extends CommandDefault implements ITabComplete
                 args.length == 2 ?
                         args[0].equalsIgnoreCase("push") ?
                                 Arrays.asList(
+                                        "all",
                                         "local-templates",
                                         "tasks",
                                         "groups",

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandCopy.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandCopy.java
@@ -3,12 +3,13 @@ package de.dytanic.cloudnet.command.commands;
 import de.dytanic.cloudnet.command.ICommandSender;
 import de.dytanic.cloudnet.common.Properties;
 import de.dytanic.cloudnet.common.language.LanguageManager;
+import de.dytanic.cloudnet.driver.provider.service.SpecificCloudServiceProvider;
 import de.dytanic.cloudnet.driver.service.ServiceDeployment;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
 import de.dytanic.cloudnet.driver.service.ServiceTemplate;
-import de.dytanic.cloudnet.service.ICloudService;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,43 +29,36 @@ public class CommandCopy extends CommandDefault {
         ServiceInfoSnapshot serviceInfoSnapshot = super.getCloudNet().getCloudServiceByNameOrUniqueId(args[0]);
 
         if (serviceInfoSnapshot != null) {
+            SpecificCloudServiceProvider cloudServiceProvider = super.getCloudNet().getCloudServiceProvider(serviceInfoSnapshot);
+            ServiceTemplate targetTemplate;
 
-            ICloudService cloudService = super.getCloudNet().getCloudServiceManager().getCloudService(serviceInfoSnapshot.getServiceId().getUniqueId());
-
-            if (cloudService != null) {
-
-                ServiceTemplate targetTemplate;
-
-                if (properties.containsKey("template")) {
-                    targetTemplate = ServiceTemplate.parse(properties.get("template"));
-                } else {
-                    targetTemplate = cloudService.getTemplates()
-                            .stream()
-                            .filter(serviceTemplate -> serviceTemplate.getPrefix().equalsIgnoreCase(cloudService.getServiceId().getTaskName())
-                                    && serviceTemplate.getName().equalsIgnoreCase("default"))
-                            .findFirst().orElse(null);
-                }
-
-                if (targetTemplate == null) {
-                    sender.sendMessage(LanguageManager.getMessage("command-copy-service-no-default-template").replace("%name%", cloudService.getServiceId().getName()));
-                    return;
-                }
-
-                List<ServiceDeployment> oldDeployments = new ArrayList<>(cloudService.getDeployments());
-                cloudService.getDeployments().clear();
-
-                cloudService.getDeployments().add(new ServiceDeployment(targetTemplate, Collections.emptyList()));
-                cloudService.deployResources();
-                cloudService.getDeployments().clear();
-
-                cloudService.getDeployments().addAll(oldDeployments);
-
-                sender.sendMessage(
-                        LanguageManager.getMessage("command-copy-success")
-                                .replace("%name%", cloudService.getServiceId().getName())
-                                .replace("%template%", targetTemplate.getStorage() + ":" + targetTemplate.getPrefix() + "/" + targetTemplate.getName())
-                );
+            if (properties.containsKey("template")) {
+                targetTemplate = ServiceTemplate.parse(properties.get("template"));
+            } else {
+                targetTemplate = Arrays.stream(serviceInfoSnapshot.getConfiguration().getTemplates())
+                        .filter(serviceTemplate -> serviceTemplate.getPrefix().equalsIgnoreCase(serviceInfoSnapshot.getServiceId().getTaskName())
+                                && serviceTemplate.getName().equalsIgnoreCase("default"))
+                        .findFirst().orElse(null);
             }
+
+            if (targetTemplate == null) {
+                sender.sendMessage(LanguageManager.getMessage("command-copy-service-no-default-template").replace("%name%", serviceInfoSnapshot.getServiceId().getName()));
+                return;
+            }
+
+            List<ServiceDeployment> oldDeployments = new ArrayList<>(Arrays.asList(serviceInfoSnapshot.getConfiguration().getDeployments()));
+
+            cloudServiceProvider.addServiceDeployment(new ServiceDeployment(targetTemplate, Collections.emptyList()));
+            cloudServiceProvider.deployResources(true);
+
+            oldDeployments.forEach(cloudServiceProvider::addServiceDeployment);
+
+            sender.sendMessage(
+                    LanguageManager.getMessage("command-copy-success")
+                            .replace("%name%", serviceInfoSnapshot.getServiceId().getName())
+                            .replace("%template%", targetTemplate.getStorage() + ":" + targetTemplate.getPrefix() + "/" + targetTemplate.getName())
+            );
+
         }
     }
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandCopy.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandCopy.java
@@ -22,7 +22,7 @@ public class CommandCopy extends CommandDefault {
     @Override
     public void execute(ICommandSender sender, String command, String[] args, String commandLine, Properties properties) {
         if (args.length == 0) {
-            sender.sendMessage("cp <local service uniqueId | name> | template=storage:prefix/name");
+            sender.sendMessage("cp <local service uniqueId | name> [excludes: spigot.jar;logs;plugins] | template=storage:prefix/name");
             return;
         }
 
@@ -48,7 +48,9 @@ public class CommandCopy extends CommandDefault {
 
             List<ServiceDeployment> oldDeployments = new ArrayList<>(Arrays.asList(serviceInfoSnapshot.getConfiguration().getDeployments()));
 
-            cloudServiceProvider.addServiceDeployment(new ServiceDeployment(targetTemplate, Collections.emptyList()));
+            List<String> excludes = args.length == 2 ? Arrays.asList(args[1].split(";")) : Collections.emptyList();
+
+            cloudServiceProvider.addServiceDeployment(new ServiceDeployment(targetTemplate, excludes));
             cloudServiceProvider.deployResources(true);
 
             oldDeployments.forEach(cloudServiceProvider::addServiceDeployment);

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/network/ClusterUtils.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/network/ClusterUtils.java
@@ -4,11 +4,14 @@ import de.dytanic.cloudnet.CloudNet;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
 import de.dytanic.cloudnet.driver.permission.DefaultJsonFilePermissionManagement;
+import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.driver.service.ServiceTemplate;
 import de.dytanic.cloudnet.network.packet.*;
 import de.dytanic.cloudnet.permission.DefaultDatabasePermissionManagement;
 import de.dytanic.cloudnet.template.ITemplateStorage;
 import de.dytanic.cloudnet.template.LocalTemplateStorage;
+
+import java.util.Collection;
 
 public class ClusterUtils {
 
@@ -23,30 +26,12 @@ public class ClusterUtils {
     public static void sendSetupInformationPackets(INetworkChannel channel, boolean secondNodeConnection) {
         channel.sendPacket(new PacketServerSetGlobalServiceInfoList(CloudNet.getInstance().getCloudServiceManager().getGlobalServiceInfoSnapshots().values()));
         if (!secondNodeConnection) {
-            channel.sendPacket(new PacketServerSetGroupConfigurationList(CloudNet.getInstance().getGroupConfigurationProvider().getGroupConfigurations(), NetworkUpdateType.ADD));
-            channel.sendPacket(new PacketServerSetServiceTaskList(CloudNet.getInstance().getServiceTaskProvider().getPermanentServiceTasks(), NetworkUpdateType.ADD));
+            CloudNet.getInstance().publishH2DatabaseDataToCluster(channel);
 
             if (CloudNet.getInstance().getPermissionManagement() instanceof DefaultJsonFilePermissionManagement) {
-                channel.sendPacket(new PacketServerSetPermissionData(
-                        CloudNet.getInstance().getPermissionManagement().getUsers(),
-                        CloudNet.getInstance().getPermissionManagement().getGroups(),
-                        NetworkUpdateType.ADD
-                ));
+                Collection<IPermissionUser> users = CloudNet.getInstance().getPermissionManagement().getUsers();
+                channel.sendPacket(new PacketServerSetPermissionData(users, NetworkUpdateType.ADD));
             }
-
-            if (CloudNet.getInstance().getPermissionManagement() instanceof DefaultDatabasePermissionManagement) {
-                channel.sendPacket(new PacketServerSetPermissionData(CloudNet.getInstance().getPermissionManagement().getGroups(), NetworkUpdateType.ADD, true));
-            }
-
-            ITemplateStorage templateStorage = CloudNetDriver.getInstance().getServicesRegistry().getService(ITemplateStorage.class, LocalTemplateStorage.LOCAL_TEMPLATE_STORAGE);
-
-            byte[] bytes;
-            for (ServiceTemplate serviceTemplate : templateStorage.getTemplates()) {
-                bytes = templateStorage.toZipByteArray(serviceTemplate);
-                channel.sendPacket(new PacketServerDeployLocalTemplate(serviceTemplate, bytes, false));
-            }
-
-            CloudNet.getInstance().publishH2DatabaseDataToCluster(channel);
         }
     }
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/network/listener/PacketServerSetPermissionDataListener.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/network/listener/PacketServerSetPermissionDataListener.java
@@ -17,7 +17,8 @@ public final class PacketServerSetPermissionDataListener implements IPacketListe
 
     @Override
     public void handle(INetworkChannel channel, IPacket packet) {
-        if (packet.getHeader().contains("permissionGroups") && packet.getHeader().contains("set_json_database")) {
+        if ((packet.getHeader().contains("permissionGroups") || packet.getHeader().contains("permissionUsers")) &&
+                packet.getHeader().contains("set_json_database")) {
             if (CloudNet.getInstance().getPermissionManagement() instanceof ClusterSynchronizedPermissionManagement) {
                 List<PermissionUser> permissionUsers = packet.getHeader().get("permissionUsers", new TypeToken<List<PermissionUser>>() {
                 }.getType());

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
@@ -222,11 +222,7 @@ public final class DefaultCloudServiceManager implements ICloudServiceManager {
     public void removeGroupConfigurationWithoutClusterSync(String name) {
         Validate.checkNotNull(name);
 
-        for (GroupConfiguration group : this.config.getGroups()) {
-            if (group.getName().equalsIgnoreCase(name)) {
-                this.config.getGroups().remove(group);
-            }
-        }
+        this.config.getGroups().removeIf(group -> group.getName().equalsIgnoreCase(name));
 
         this.config.save();
     }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
@@ -487,8 +487,6 @@ public final class DefaultCloudServiceManager implements ICloudServiceManager {
     @Override
     public void reload() {
         this.config.load();
-        CloudNet.getInstance().updateGroupConfigurationsInCluster(this.getGroupConfigurations(), NetworkUpdateType.SET);
-        CloudNet.getInstance().updateServiceTasksInCluster(this.getServiceTasks(), NetworkUpdateType.SET);
     }
 
     @Override

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/DefaultCloudServiceManager.java
@@ -213,9 +213,10 @@ public final class DefaultCloudServiceManager implements ICloudServiceManager {
     public void removeGroupConfiguration(String name) {
         Validate.checkNotNull(name);
 
-        GroupConfiguration groupConfiguration = this.getGroupConfiguration(name);
-        Validate.checkNotNull(groupConfiguration);
-        this.removeGroupConfiguration(groupConfiguration);
+        if (this.isGroupConfigurationPresent(name)) {
+            GroupConfiguration groupConfiguration = this.getGroupConfiguration(name);
+            this.removeGroupConfiguration(groupConfiguration);
+        }
     }
 
     @Override

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/ITemplateStorage.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/ITemplateStorage.java
@@ -80,6 +80,11 @@ public interface ITemplateStorage extends AutoCloseable, INameable {
 
     Collection<ServiceTemplate> getTemplates();
 
+    default boolean shouldSyncInCluster() {
+        return false;
+    }
+
     @Override
     void close() throws IOException;
+
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/LocalTemplateStorage.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/LocalTemplateStorage.java
@@ -303,6 +303,11 @@ public final class LocalTemplateStorage implements ITemplateStorage {
     }
 
     @Override
+    public boolean shouldSyncInCluster() {
+        return true;
+    }
+
+    @Override
     public void close() {
     }
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/TemplateStorageUtil.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/TemplateStorageUtil.java
@@ -118,7 +118,7 @@ public final class TemplateStorageUtil {
                         }
                     }
 
-                    try (OutputStream outputStream =storage.newOutputStream(serviceTemplate, "spigot.yml");
+                    try (OutputStream outputStream = storage.newOutputStream(serviceTemplate, "spigot.yml");
                          InputStream inputStream = CloudNet.class.getClassLoader().getResourceAsStream("files/nms/spigot.yml")) {
                         if (inputStream != null) {
                             FileUtils.copy(inputStream, outputStream, buffer);
@@ -144,7 +144,9 @@ public final class TemplateStorageUtil {
                 break;
             }
 
-            CloudNet.getInstance().deployTemplateInCluster(serviceTemplate, storage.toZipByteArray(serviceTemplate));
+            if (storage.shouldSyncInCluster()) {
+                CloudNet.getInstance().deployTemplateInCluster(serviceTemplate, storage.toZipByteArray(serviceTemplate));
+            }
             return true;
         } else {
             return false;

--- a/cloudnet/src/main/resources/lang/english.properties
+++ b/cloudnet/src/main/resources/lang/english.properties
@@ -20,6 +20,7 @@ cloudnet-http-server-bind=Attempting to bind the HTTP server to the address "%ad
 cloudnet-load-task=Loading task from %path%...
 cloudnet-load-task-failed=Failed to load task from %path%
 cloudnet-load-task-success=Successfully loaded task %name% from %path%
+cloudnet-cluster-h2-warning=CloudNet runs in a cluster, but h2 is being used as the database! This might cause big synchronization problems. Please consider switching to a central database, where all nodes can connect to.
 #
 # Node ModuleProviderHandler receivedMessages
 #

--- a/cloudnet/src/main/resources/lang/german.properties
+++ b/cloudnet/src/main/resources/lang/german.properties
@@ -20,6 +20,7 @@ cloudnet-http-server-bind=Versuche den HTTP Server auf die Adresse "%address%" z
 cloudnet-load-task=Aufgabe aus %path% wird geladen...
 cloudnet-load-task-failed=Aufgabe aus %path% konnte nicht geladen werden
 cloudnet-load-task-success=Aufgabe %name% aus %path% wurde erfolgreich geladen
+cloudnet-cluster-h2-warning=CloudNet läuft um Cluster, aber h2 wird als Datenbank verwendet! Dies führt möglicherweise zu großen Synchronisationsproblemen. Nutze eine zentrale Datenbank, zu der sich alle Nodes verbinden können.
 #
 # Node ModuleProviderHandler receivedMessages
 #

--- a/cloudnet/src/test/java/de/dytanic/cloudnet/database/h2/H2DatabaseProviderTest.java
+++ b/cloudnet/src/test/java/de/dytanic/cloudnet/database/h2/H2DatabaseProviderTest.java
@@ -19,7 +19,7 @@ public final class H2DatabaseProviderTest implements IDatabaseHandler {
 
     @Test
     public void testDatabaseProvider() throws Exception {
-        AbstractDatabaseProvider databaseProvider = new H2DatabaseProvider("build/h2database");
+        AbstractDatabaseProvider databaseProvider = new H2DatabaseProvider("build/h2database", false);
         Assert.assertTrue(databaseProvider.init());
 
         databaseProvider.setDatabaseHandler(this);

--- a/cloudnet/src/test/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagementTest.java
+++ b/cloudnet/src/test/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagementTest.java
@@ -16,7 +16,7 @@ public class DefaultDatabasePermissionManagementTest {
     @Test
     public void testFilePermissionManager() throws Exception {
         String groupName = "Test", userName = "Tester", permission = "test.permission", groupPermission = "role.permission";
-        AbstractDatabaseProvider databaseProvider = new H2DatabaseProvider("build/h2database");
+        AbstractDatabaseProvider databaseProvider = new H2DatabaseProvider("build/h2database", false);
         Assert.assertTrue(databaseProvider.init());
 
         System.setProperty("cloudnet.permissions.json.path", "build/group_permissions.json");


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

Removed all automatic synchronizations to the cluster (tasks, groups, templates, permission groups) because they just caused issues:
if a task is changed on one node and then another node connects, changes may get overwritten
  (the same for templates, permission groups and groups)

Now, only the H2 database and the Permission Users (if they are saved in the json file instead of the database) are automatically synchronized on a node connection.
The "clu push ..." command and creating/deleting/modifying tasks, groups, etc. using their specific command still syncs everything.

It also adds the "cluster push all" command to push everything to the cluster.