### PR TITLE
Default Setup, ServiceInfoSnapshot-OnlineCount and SmartModule AutoStop Hotfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ defaultTasks 'clean', 'build', 'test', 'jar'
 
 allprojects {
 
-    def major = 3, minor = 2, patch = 0, versionType = "SNAPSHOT"
+    def major = 3, minor = 2, patch = 0, versionType = "RELEASE"
 
     group 'de.dytanic.cloudnet'
     version "$major.$minor.$patch-$versionType"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ defaultTasks 'clean', 'build', 'test', 'jar'
 
 allprojects {
 
-    def major = 3, minor = 2, patch = 0, versionType = "RELEASE"
+    def major = 3, minor = 2, patch = 1, versionType = "RELEASE"
 
     group 'de.dytanic.cloudnet'
     version "$major.$minor.$patch-$versionType"

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetBridgePlugin.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetBridgePlugin.java
@@ -35,7 +35,7 @@ public final class BukkitCloudNetBridgePlugin extends JavaPlugin {
 
     private void initListeners() {
         //BukkitAPI
-        Bukkit.getServer().getPluginManager().registerEvents(new BukkitPlayerListener(), this);
+        Bukkit.getServer().getPluginManager().registerEvents(new BukkitPlayerListener(this), this);
 
         //CloudNet
         CloudNetDriver.getInstance().getEventManager().registerListener(new BukkitCloudNetListener());

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/listener/BukkitPlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/listener/BukkitPlayerListener.java
@@ -5,6 +5,7 @@ import de.dytanic.cloudnet.driver.service.ServiceTask;
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
 import de.dytanic.cloudnet.ext.bridge.BridgeConfigurationProvider;
 import de.dytanic.cloudnet.ext.bridge.BridgeHelper;
+import de.dytanic.cloudnet.ext.bridge.bukkit.BukkitCloudNetBridgePlugin;
 import de.dytanic.cloudnet.ext.bridge.bukkit.BukkitCloudNetHelper;
 import de.dytanic.cloudnet.wrapper.Wrapper;
 import org.bukkit.Bukkit;
@@ -19,11 +20,14 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 public final class BukkitPlayerListener implements Listener {
 
+    private final BukkitCloudNetBridgePlugin plugin;
+
     private final BridgeConfiguration bridgeConfiguration;
 
     private final boolean onlyProxyProtection;
 
-    public BukkitPlayerListener() {
+    public BukkitPlayerListener(BukkitCloudNetBridgePlugin plugin) {
+        this.plugin = plugin;
         this.bridgeConfiguration = BridgeConfigurationProvider.load();
         this.onlyProxyProtection = !Bukkit.getOnlineMode()
                 && this.bridgeConfiguration != null
@@ -71,7 +75,7 @@ public final class BukkitPlayerListener implements Listener {
         BridgeHelper.sendChannelMessageServerDisconnect(BukkitCloudNetHelper.createNetworkConnectionInfo(event.getPlayer()),
                 BukkitCloudNetHelper.createNetworkPlayerServerInfo(event.getPlayer(), false));
 
-        BridgeHelper.updateServiceInfo();
+        Bukkit.getScheduler().runTask(this.plugin, BridgeHelper::updateServiceInfo);
     }
 
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetBridgePlugin.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetBridgePlugin.java
@@ -65,7 +65,7 @@ public final class BungeeCloudNetBridgePlugin extends Plugin {
 
     private void initListeners() {
         //BungeeCord API
-        ProxyServer.getInstance().getPluginManager().registerListener(this, new BungeePlayerListener());
+        ProxyServer.getInstance().getPluginManager().registerListener(this, new BungeePlayerListener(this));
 
         //CloudNet
         CloudNetDriver.getInstance().getEventManager().registerListener(new BungeeCloudNetListener());

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/listener/BungeePlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/listener/BungeePlayerListener.java
@@ -2,6 +2,7 @@ package de.dytanic.cloudnet.ext.bridge.bungee.listener;
 
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
 import de.dytanic.cloudnet.ext.bridge.BridgeHelper;
+import de.dytanic.cloudnet.ext.bridge.bungee.BungeeCloudNetBridgePlugin;
 import de.dytanic.cloudnet.ext.bridge.bungee.BungeeCloudNetHelper;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
 import net.md_5.bungee.api.ProxyServer;
@@ -11,7 +12,15 @@ import net.md_5.bungee.api.event.*;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 
+import java.util.concurrent.TimeUnit;
+
 public final class BungeePlayerListener implements Listener {
+
+    private BungeeCloudNetBridgePlugin plugin;
+
+    public BungeePlayerListener(BungeeCloudNetBridgePlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler
     public void handle(LoginEvent event) {
@@ -77,6 +86,6 @@ public final class BungeePlayerListener implements Listener {
     public void handle(PlayerDisconnectEvent event) {
         BridgeHelper.sendChannelMessageProxyDisconnect(BungeeCloudNetHelper.createNetworkConnectionInfo(event.getPlayer().getPendingConnection()));
 
-        BridgeHelper.updateServiceInfo();
+        ProxyServer.getInstance().getScheduler().schedule(this.plugin, BridgeHelper::updateServiceInfo, 50, TimeUnit.MILLISECONDS);
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/listener/NukkitPlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/listener/NukkitPlayerListener.java
@@ -8,6 +8,7 @@ import cn.nukkit.event.Listener;
 import cn.nukkit.event.player.PlayerJoinEvent;
 import cn.nukkit.event.player.PlayerLoginEvent;
 import cn.nukkit.event.player.PlayerQuitEvent;
+import cn.nukkit.scheduler.Task;
 import de.dytanic.cloudnet.common.collection.Iterables;
 import de.dytanic.cloudnet.driver.service.ServiceTask;
 import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
@@ -70,7 +71,12 @@ public final class NukkitPlayerListener implements Listener {
         BridgeHelper.sendChannelMessageServerDisconnect(NukkitCloudNetHelper.createNetworkConnectionInfo(event.getPlayer()),
                 NukkitCloudNetHelper.createNetworkPlayerServerInfo(event.getPlayer(), false));
 
-        BridgeHelper.updateServiceInfo();
+        event.getPlayer().getServer().getScheduler().scheduleDelayedTask(new Task() {
+            @Override
+            public void onRun(int currentTick) {
+                BridgeHelper.updateServiceInfo();
+            }
+        }, 1);
     }
 
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/SpongeCloudNetBridgePlugin.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/SpongeCloudNetBridgePlugin.java
@@ -39,7 +39,7 @@ public final class SpongeCloudNetBridgePlugin {
 
     private void initListeners() {
         //Sponge API
-        Sponge.getEventManager().registerListeners(this, new SpongePlayerListener());
+        Sponge.getEventManager().registerListeners(this, new SpongePlayerListener(this));
 
         //CloudNet
         CloudNetDriver.getInstance().getEventManager().registerListener(new SpongeCloudNetListener());

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/listener/SpongePlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/sponge/listener/SpongePlayerListener.java
@@ -1,11 +1,20 @@
 package de.dytanic.cloudnet.ext.bridge.sponge.listener;
 
 import de.dytanic.cloudnet.ext.bridge.BridgeHelper;
+import de.dytanic.cloudnet.ext.bridge.sponge.SpongeCloudNetBridgePlugin;
 import de.dytanic.cloudnet.ext.bridge.sponge.SpongeCloudNetHelper;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
+import org.spongepowered.api.scheduler.SpongeExecutorService;
 
 public final class SpongePlayerListener {
+
+    private SpongeExecutorService executorService;
+
+    public SpongePlayerListener(SpongeCloudNetBridgePlugin plugin) {
+        this.executorService = Sponge.getGame().getScheduler().createSyncExecutor(plugin);
+    }
 
     @Listener
     public void handle(ClientConnectionEvent.Join event) {
@@ -13,7 +22,7 @@ public final class SpongePlayerListener {
                 SpongeCloudNetHelper.createNetworkPlayerServerInfo(event.getTargetEntity(), false)
         );
 
-        BridgeHelper.updateServiceInfo();
+        this.executorService.execute(BridgeHelper::updateServiceInfo);
     }
 
     @Listener
@@ -21,6 +30,6 @@ public final class SpongePlayerListener {
         BridgeHelper.sendChannelMessageServerDisconnect(SpongeCloudNetHelper.createNetworkConnectionInfo(event.getTargetEntity()),
                 SpongeCloudNetHelper.createNetworkPlayerServerInfo(event.getTargetEntity(), false));
 
-        BridgeHelper.updateServiceInfo();
+        this.executorService.execute(BridgeHelper::updateServiceInfo);
     }
 }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetBridgePlugin.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetBridgePlugin.java
@@ -53,7 +53,7 @@ public final class VelocityCloudNetBridgePlugin {
 
     private void initListeners() {
         //Velocity API
-        this.proxyServer.getEventManager().register(this, new VelocityPlayerListener());
+        this.proxyServer.getEventManager().register(this, new VelocityPlayerListener(this));
 
         //CloudNet
         CloudNetDriver.getInstance().getEventManager().registerListener(new VelocityCloudNetListener());

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
@@ -10,10 +10,19 @@ import com.velocitypowered.api.event.player.ServerPreConnectEvent;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
 import de.dytanic.cloudnet.ext.bridge.BridgeHelper;
 import de.dytanic.cloudnet.ext.bridge.player.NetworkServiceInfo;
+import de.dytanic.cloudnet.ext.bridge.velocity.VelocityCloudNetBridgePlugin;
 import de.dytanic.cloudnet.ext.bridge.velocity.VelocityCloudNetHelper;
 import net.kyori.text.TextComponent;
 
+import java.util.concurrent.TimeUnit;
+
 public final class VelocityPlayerListener {
+
+    private VelocityCloudNetBridgePlugin plugin;
+
+    public VelocityPlayerListener(VelocityCloudNetBridgePlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @Subscribe
     public void handle(LoginEvent event) {
@@ -24,7 +33,8 @@ public final class VelocityPlayerListener {
     public void handle(PostLoginEvent event) {
         BridgeHelper.sendChannelMessageProxyLoginSuccess(VelocityCloudNetHelper.createNetworkConnectionInfo(event.getPlayer()));
 
-        VelocityCloudNetHelper.updateServiceInfo();
+        VelocityCloudNetHelper.getProxyServer().getScheduler().buildTask(this.plugin, VelocityCloudNetHelper::updateServiceInfo)
+                .delay(50, TimeUnit.MILLISECONDS).schedule();
     }
 
     @Subscribe
@@ -82,6 +92,7 @@ public final class VelocityPlayerListener {
     public void handle(DisconnectEvent event) {
         BridgeHelper.sendChannelMessageProxyDisconnect(VelocityCloudNetHelper.createNetworkConnectionInfo(event.getPlayer()));
 
-        VelocityCloudNetHelper.updateServiceInfo();
+        VelocityCloudNetHelper.getProxyServer().getScheduler().buildTask(this.plugin, VelocityCloudNetHelper::updateServiceInfo)
+                .delay(50, TimeUnit.MILLISECONDS).schedule();
     }
 }

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudNetTickListener.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudNetTickListener.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 public final class CloudNetTickListener {
 
@@ -67,12 +68,16 @@ public final class CloudNetTickListener {
     }
 
     private void handleAutoStop() {
-        Collection<ServiceInfoSnapshot> serviceInfoSnapshots = Iterables.filter(CloudNetDriver.getInstance().getCloudServiceProvider().getCloudServices(), cloudService -> CloudNetSmartModule.getInstance().getProvidedSmartServices().containsKey(cloudService.getServiceId().getUniqueId()) &&
-                cloudService.getLifeCycle() == ServiceLifeCycle.RUNNING &&
-                cloudService.getProperties().contains("Online-Count") &&
-                cloudService.getProperties().contains("Max-Players"));
+        Collection<ServiceInfoSnapshot> runningServiceInfoSnapshots = CloudNetDriver.getInstance().getCloudServiceProvider().getCloudServices()
+                .stream()
+                .filter(serviceInfoSnapshot -> serviceInfoSnapshot.getLifeCycle() == ServiceLifeCycle.RUNNING)
+                .collect(Collectors.toList());
+        Collection<ServiceInfoSnapshot> onlineServiceInfoSnapshots = runningServiceInfoSnapshots.stream()
+                .filter(serviceInfoSnapshot -> serviceInfoSnapshot.getProperties().contains("Online-Count"))
+                .filter(serviceInfoSnapshot -> serviceInfoSnapshot.getProperties().contains("Max-Players"))
+                .collect(Collectors.toList());
 
-        for (ServiceInfoSnapshot serviceInfoSnapshot : serviceInfoSnapshots) {
+        for (ServiceInfoSnapshot serviceInfoSnapshot : onlineServiceInfoSnapshots) {
             SmartServiceTaskConfig smartTask = CloudNetSmartModule.getInstance().getSmartServiceTaskConfig(serviceInfoSnapshot);
             if (smartTask == null) {
                 continue;
@@ -88,9 +93,9 @@ public final class CloudNetTickListener {
                             serviceInfoSnapshot.getProperties().getInt("Max-Players")
                     ) <= smartTask.getPercentOfPlayersToCheckShouldAutoStopTheServiceInFuture()) {
 
-                int onlineServices = CloudNet.getInstance().getCloudServiceProvider().getServicesCountByTask(serviceInfoSnapshot.getServiceId().getTaskName());
+                int runningServices = (int) runningServiceInfoSnapshots.stream().filter(runningServiceInfoSnapshot -> runningServiceInfoSnapshot.getServiceId().getTaskName().equals(serviceInfoSnapshot.getServiceId().getTaskName())).count();
                 ServiceTask serviceTask = CloudNet.getInstance().getServiceTaskProvider().getServiceTask(serviceInfoSnapshot.getServiceId().getTaskName());
-                if (onlineServices <= serviceTask.getMinServiceCount()) {
+                if (runningServices <= serviceTask.getMinServiceCount()) {
                     continue;
                 }
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/DefaultInstallation.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/DefaultInstallation.java
@@ -198,7 +198,7 @@ public class DefaultInstallation {
                 if (animation.hasResult("internalHost")) {
                     HostAndPort defaultHost = (HostAndPort) animation.getResult("internalHost");
 
-                    this.cloudNet.getConfig().setDefaultHostAddress(defaultHost.getHost());
+                    this.cloudNet.getConfig().setHostAddress(defaultHost.getHost());
                     this.cloudNet.getConfig().setIdentity(new NetworkClusterNode(
                             animation.hasResult("nodeId") ? (String) animation.getResult("nodeId") : "Node-" + UUID.randomUUID().toString().split("-")[0],
                             new HostAndPort[]{defaultHost}

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/conf/IConfiguration.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/conf/IConfiguration.java
@@ -18,6 +18,8 @@ public interface IConfiguration {
 
     String getHostAddress();
 
+    void setHostAddress(String hostAddress);
+
     NetworkClusterNode getIdentity();
 
     void setIdentity(NetworkClusterNode identity);

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/conf/JsonConfiguration.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/conf/JsonConfiguration.java
@@ -26,7 +26,7 @@ public final class JsonConfiguration implements IConfiguration {
     }.getType(),
             CLUSTER = new TypeToken<NetworkCluster>() {
             }.getType(),
-            COLLECTION_STRING = new TypeToken<Collection<String>>() {
+            SET_STRING = new TypeToken<Set<String>>() {
             }.getType(),
             HOST_AND_PORT_COLLECTION = new TypeToken<Collection<HostAndPort>>() {
             }.getType();
@@ -105,7 +105,7 @@ public final class JsonConfiguration implements IConfiguration {
             addresses.addAll(Arrays.asList(System.getenv("CLOUDNET_DEFAULT_IP_WHITELIST").split(",")));
         }
 
-        this.ipWhitelist = this.document.get("ipWhitelist", COLLECTION_STRING, addresses);
+        this.ipWhitelist = this.document.get("ipWhitelist", SET_STRING, addresses);
 
         this.clusterConfig = this.document.get("cluster", CLUSTER, new NetworkCluster(
                 System.getenv("CLOUDNET_CLUSTER_ID") != null ?
@@ -301,6 +301,11 @@ public final class JsonConfiguration implements IConfiguration {
 
         this.httpListeners = httpListeners;
         this.save();
+    }
+
+    @Override
+    public void setHostAddress(String hostAddress) {
+        this.hostAddress = hostAddress;
     }
 
     public ConfigurationOptionSSL getClientSslConfig() {

--- a/cloudnet/src/main/resources/lang/german.properties
+++ b/cloudnet/src/main/resources/lang/german.properties
@@ -20,7 +20,7 @@ cloudnet-http-server-bind=Versuche den HTTP Server auf die Adresse "%address%" z
 cloudnet-load-task=Aufgabe aus %path% wird geladen...
 cloudnet-load-task-failed=Aufgabe aus %path% konnte nicht geladen werden
 cloudnet-load-task-success=Aufgabe %name% aus %path% wurde erfolgreich geladen
-cloudnet-cluster-h2-warning=CloudNet läuft um Cluster, aber h2 wird als Datenbank verwendet! Dies führt möglicherweise zu großen Synchronisationsproblemen. Nutze eine zentrale Datenbank, zu der sich alle Nodes verbinden können.
+cloudnet-cluster-h2-warning=CloudNet läuft im Cluster, aber h2 wird als Datenbank verwendet! Dies führt möglicherweise zu großen Synchronisationsproblemen. Nutze eine zentrale Datenbank, zu der sich alle Nodes verbinden können.
 #
 # Node ModuleProviderHandler receivedMessages
 #


### PR DESCRIPTION
- Fixed the issue that the online count was wrong when a player disconnects from a server
- Fixed an issue that the smart module checked for all services (prepared, starting, ...) for the auto stop, which caused problems when using the preparedServices entry in the smart config
- Fixed wrong hostAddress on first node setup