### PR TITLE
Automatic creation of entries in the Bridge and SyncProxy configs

### DIFF
--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/node/CloudNetBridgeModule.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/node/CloudNetBridgeModule.java
@@ -11,13 +11,11 @@ import de.dytanic.cloudnet.ext.bridge.ProxyFallbackConfiguration;
 import de.dytanic.cloudnet.ext.bridge.node.command.CommandPlayers;
 import de.dytanic.cloudnet.ext.bridge.node.command.CommandReloadBridge;
 import de.dytanic.cloudnet.ext.bridge.node.http.V1BridgeConfigurationHttpHandler;
-import de.dytanic.cloudnet.ext.bridge.node.listener.IncludePluginListener;
-import de.dytanic.cloudnet.ext.bridge.node.listener.NetworkListenerRegisterListener;
-import de.dytanic.cloudnet.ext.bridge.node.listener.NodeCustomChannelMessageListener;
-import de.dytanic.cloudnet.ext.bridge.node.listener.PlayerManagerListener;
+import de.dytanic.cloudnet.ext.bridge.node.listener.*;
 import de.dytanic.cloudnet.ext.bridge.node.player.NodePlayerManager;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,15 +50,9 @@ public final class CloudNetBridgeModule extends NodeCloudNetModule {
         this.bridgeConfiguration = getConfig().get("config", BridgeConfiguration.TYPE, new BridgeConfiguration(
                 "&7Cloud &8| &b",
                 true,
-                Iterables.newArrayList(),
-                Iterables.newArrayList(),
-                Collections.singletonList(
-                        new ProxyFallbackConfiguration(
-                                "Proxy",
-                                "Lobby",
-                                Collections.singletonList(new ProxyFallback("Lobby", null, 1))
-                        )
-                ),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
                 DEFAULT_MESSAGES,
                 true
         ));
@@ -77,6 +69,14 @@ public final class CloudNetBridgeModule extends NodeCloudNetModule {
 
         getConfig().append("config", this.bridgeConfiguration);
         saveConfig();
+    }
+
+    public ProxyFallbackConfiguration createDefaultFallbackConfiguration(String targetGroup) {
+        return new ProxyFallbackConfiguration(
+                targetGroup,
+                "Lobby",
+                Collections.singletonList(new ProxyFallback("Lobby", null, 1))
+        );
     }
 
     public void writeConfiguration(BridgeConfiguration bridgeConfiguration) {
@@ -105,7 +105,7 @@ public final class CloudNetBridgeModule extends NodeCloudNetModule {
 
     @ModuleTask(order = 8, event = ModuleLifeCycle.STARTED)
     public void initListeners() {
-        registerListeners(new NetworkListenerRegisterListener(), new IncludePluginListener(), new NodeCustomChannelMessageListener());
+        registerListeners(new NetworkListenerRegisterListener(), new IncludePluginListener(), new NodeCustomChannelMessageListener(), new BridgeDefaultConfigurationListener());
     }
 
     public BridgeConfiguration getBridgeConfiguration() {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/node/listener/BridgeDefaultConfigurationListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/node/listener/BridgeDefaultConfigurationListener.java
@@ -1,0 +1,30 @@
+package de.dytanic.cloudnet.ext.bridge.node.listener;
+
+import de.dytanic.cloudnet.driver.event.EventListener;
+import de.dytanic.cloudnet.driver.service.ServiceTask;
+import de.dytanic.cloudnet.event.service.task.ServiceTaskAddEvent;
+import de.dytanic.cloudnet.ext.bridge.BridgeConfiguration;
+import de.dytanic.cloudnet.ext.bridge.node.CloudNetBridgeModule;
+
+public class BridgeDefaultConfigurationListener {
+
+    @EventListener
+    public void handleTaskAdd(ServiceTaskAddEvent event) {
+        ServiceTask task = event.getTask();
+
+        if (!task.getProcessConfiguration().getEnvironment().isMinecraftJavaProxy() &&
+                !task.getProcessConfiguration().getEnvironment().isMinecraftBedrockProxy()) {
+            return;
+        }
+
+        BridgeConfiguration configuration = CloudNetBridgeModule.getInstance().getBridgeConfiguration();
+        if (configuration.getBungeeFallbackConfigurations().stream()
+                .noneMatch(proxyFallbackConfiguration -> proxyFallbackConfiguration.getTargetGroup().equals(task.getName()))) {
+            configuration.getBungeeFallbackConfigurations().add(
+                    CloudNetBridgeModule.getInstance().createDefaultFallbackConfiguration(task.getName())
+            );
+            CloudNetBridgeModule.getInstance().writeConfiguration(configuration);
+        }
+    }
+
+}

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetSmartModule.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetSmartModule.java
@@ -57,13 +57,15 @@ public final class CloudNetSmartModule extends NodeCloudNetModule {
 
         for (ServiceTask task : this.getCloudNet().getServiceTaskProvider().getPermanentServiceTasks()) {
             SmartServiceTaskConfig config = task.getProperties().get(SMART_CONFIG_ENTRY, SmartServiceTaskConfig.class);
-            task.getProperties().append(
-                    SMART_CONFIG_ENTRY,
-                    oldSmartTasks.containsKey(task.getName()) ?
-                            oldSmartTasks.get(task.getName()) :
-                            config != null ? config : new SmartServiceTaskConfig()
-            );
-            this.getCloudNet().getCloudServiceManager().updatePermanentServiceTask(task);
+            if (config == null) {
+                task.getProperties().append(
+                        SMART_CONFIG_ENTRY,
+                        oldSmartTasks.containsKey(task.getName()) ?
+                                oldSmartTasks.get(task.getName()) :
+                                new SmartServiceTaskConfig()
+                );
+                this.getCloudNet().getCloudServiceManager().updatePermanentServiceTask(task);
+            }
         }
     }
 

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyConfigurationWriterAndReader.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/SyncProxyConfigurationWriterAndReader.java
@@ -6,6 +6,7 @@ import de.dytanic.cloudnet.common.collection.Pair;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,53 +38,8 @@ public final class SyncProxyConfigurationWriterAndReader {
         JsonDocument document = JsonDocument.newDocument(file);
         if (document == null || !document.contains("config")) {
             write(new SyncProxyConfiguration(
-                    Collections.singletonList(
-                            new SyncProxyProxyLoginConfiguration(
-                                    "Proxy",
-                                    false,
-                                    100,
-                                    Collections.singletonList("Dytanic"),
-                                    Collections.singletonList(new SyncProxyMotd(
-                                            "&b&lCloud&f&lNet &6Eruption &8■ &7next &bgeneration &7cloud system",
-                                            "&7Sponsored by &8» &bEU-Hosting.ch &8▎ &8» &c%proxy%",
-                                            false,
-                                            1,
-                                            new String[]{
-                                                    " ",
-                                                    "&b&lCloud&f&lNet &8× &7your &bfree &7cloudsystem",
-                                                    "&7Sponsored by &8» &bEU-Hosting.ch",
-                                                    "&7Discord &8» &fdiscord.gg/UNQ4wET",
-                                                    " "
-                                            },
-                                            null
-                                    )),
-                                    Collections.singletonList(new SyncProxyMotd(
-                                            "&b&lCloud&f&lNet &6Eruption &8■ &7next &bgeneration &7cloud system",
-                                            "      &bMaintenance &8» &7We are still in &bmaintenance",
-                                            false,
-                                            1,
-                                            new String[]{
-                                                    " ",
-                                                    "&b&lCloud&f&lNet &8× &7your &bfree &7cloudsystem",
-                                                    "&7Discord &8» &fdiscord.gg/UNQ4wET",
-                                                    " "
-                                            },
-                                            "&8➜ &bMaintenance &8&l【&c✘&8&l】"
-                                    ))
-                            )
-                    ),
-                    Collections.singletonList(
-                            new SyncProxyTabListConfiguration(
-                                    "Proxy",
-                                    Collections.singletonList(
-                                            new SyncProxyTabList(
-                                                    " \n&b&lCloud&f&lNet &6Eruption &8■ &7next &bgeneration &7network &8➜ &f%online_players%&8/&f%max_players%&f\n &8► &7Current server &8● &b%server% &8◄ \n ",
-                                                    " \n &7Sponsored by &8» &fEU-Hosting.ch &8▎ &7Discord &8» &fdiscord.gg/UNQ4wET \n &7powered by &8» &b&b&lCloud&f&lNet \n "
-                                            )
-                                    ),
-                                    1
-                            )
-                    ),
+                    new ArrayList<>(),
+                    new ArrayList<>(),
                     DEFAULT_MESSAGES,
                     true
             ), file);
@@ -108,4 +64,54 @@ public final class SyncProxyConfigurationWriterAndReader {
         }
         return configuration;
     }
+
+    public static SyncProxyTabListConfiguration createDefaultTabListConfiguration(String targetGroup) {
+        return new SyncProxyTabListConfiguration(
+                targetGroup,
+                Collections.singletonList(
+                        new SyncProxyTabList(
+                                " \n&b&lCloud&f&lNet &6Eruption &8■ &7next &bgeneration &7network &8➜ &f%online_players%&8/&f%max_players%&f\n &8► &7Current server &8● &b%server% &8◄ \n ",
+                                " \n &7Sponsored by &8» &fEU-Hosting.ch &8▎ &7Discord &8» &fdiscord.gg/UNQ4wET \n &7powered by &8» &b&b&lCloud&f&lNet \n "
+                        )
+                ),
+                1
+        );
+    }
+
+    public static SyncProxyProxyLoginConfiguration createDefaultLoginConfiguration(String targetGroup) {
+        return new SyncProxyProxyLoginConfiguration(
+                targetGroup,
+                false,
+                100,
+                new ArrayList<>(),
+                Collections.singletonList(new SyncProxyMotd(
+                        "&b&lCloud&f&lNet &6Eruption &8■ &7next &bgeneration &7cloud system",
+                        "&7Sponsored by &8» &bEU-Hosting.ch &8▎ &8» &c%proxy%",
+                        false,
+                        1,
+                        new String[]{
+                                " ",
+                                "&b&lCloud&f&lNet &8× &7your &bfree &7cloudsystem",
+                                "&7Sponsored by &8» &bEU-Hosting.ch",
+                                "&7Discord &8» &fdiscord.gg/UNQ4wET",
+                                " "
+                        },
+                        null
+                )),
+                Collections.singletonList(new SyncProxyMotd(
+                        "&b&lCloud&f&lNet &6Eruption &8■ &7next &bgeneration &7cloud system",
+                        "      &bMaintenance &8» &7We are still in &bmaintenance",
+                        false,
+                        1,
+                        new String[]{
+                                " ",
+                                "&b&lCloud&f&lNet &8× &7your &bfree &7cloudsystem",
+                                "&7Discord &8» &fdiscord.gg/UNQ4wET",
+                                " "
+                        },
+                        "&8➜ &bMaintenance &8&l【&c✘&8&l】"
+                ))
+        );
+    }
+
 }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/node/CloudNetSyncProxyModule.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/node/CloudNetSyncProxyModule.java
@@ -8,6 +8,7 @@ import de.dytanic.cloudnet.ext.syncproxy.node.command.CommandSyncProxy;
 import de.dytanic.cloudnet.ext.syncproxy.node.http.V1SyncProxyConfigurationHttpHandler;
 import de.dytanic.cloudnet.ext.syncproxy.node.listener.IncludePluginListener;
 import de.dytanic.cloudnet.ext.syncproxy.node.listener.SyncProxyConfigUpdateListener;
+import de.dytanic.cloudnet.ext.syncproxy.node.listener.SyncProxyDefaultConfigurationListener;
 import de.dytanic.cloudnet.module.NodeCloudNetModule;
 
 import java.io.File;
@@ -36,7 +37,7 @@ public final class CloudNetSyncProxyModule extends NodeCloudNetModule {
 
     @ModuleTask(order = 64, event = ModuleLifeCycle.STARTED)
     public void initListeners() {
-        registerListeners(new IncludePluginListener(), new SyncProxyConfigUpdateListener());
+        registerListeners(new IncludePluginListener(), new SyncProxyConfigUpdateListener(), new SyncProxyDefaultConfigurationListener());
     }
 
     @ModuleTask(order = 60, event = ModuleLifeCycle.STARTED)

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/node/listener/SyncProxyDefaultConfigurationListener.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/node/listener/SyncProxyDefaultConfigurationListener.java
@@ -1,0 +1,42 @@
+package de.dytanic.cloudnet.ext.syncproxy.node.listener;
+
+import de.dytanic.cloudnet.driver.event.EventListener;
+import de.dytanic.cloudnet.driver.service.ServiceTask;
+import de.dytanic.cloudnet.event.service.task.ServiceTaskAddEvent;
+import de.dytanic.cloudnet.ext.syncproxy.SyncProxyConfiguration;
+import de.dytanic.cloudnet.ext.syncproxy.SyncProxyConfigurationWriterAndReader;
+import de.dytanic.cloudnet.ext.syncproxy.node.CloudNetSyncProxyModule;
+
+public class SyncProxyDefaultConfigurationListener {
+
+    @EventListener
+    public void handleTaskAdd(ServiceTaskAddEvent event) {
+        ServiceTask task = event.getTask();
+
+        if (!task.getProcessConfiguration().getEnvironment().isMinecraftJavaProxy() &&
+                !task.getProcessConfiguration().getEnvironment().isMinecraftBedrockProxy()) {
+            return;
+        }
+
+        SyncProxyConfiguration configuration = CloudNetSyncProxyModule.getInstance().getSyncProxyConfiguration();
+        boolean modified = false;
+
+        if (configuration.getLoginConfigurations().stream()
+                .noneMatch(loginConfiguration -> loginConfiguration.getTargetGroup().equals(task.getName()))) {
+            configuration.getLoginConfigurations().add(SyncProxyConfigurationWriterAndReader.createDefaultLoginConfiguration(task.getName()));
+            modified = true;
+        }
+
+        if (configuration.getTabListConfigurations().stream()
+                .noneMatch(tabListConfiguration -> tabListConfiguration.getTargetGroup().equals(task.getName()))) {
+            configuration.getTabListConfigurations().add(SyncProxyConfigurationWriterAndReader.createDefaultTabListConfiguration(task.getName()));
+            modified = true;
+        }
+
+        if (modified) {
+            SyncProxyConfigurationWriterAndReader.write(configuration, CloudNetSyncProxyModule.getInstance().getConfigurationFile());
+        }
+
+    }
+
+}


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
The Smart module doesn't update the tasks on every load anymore, but only when there are changes in the config made by the module.
The Bridge and SyncProxy modules create default entries in their configurations after a task has been created.