### PR TITLE
Update start.sh

### DIFF
--- a/.template/start.sh
+++ b/.template/start.sh
@@ -1,1 +1,1 @@
-screen -S CloudNet java -XX:+UseG1GC -XX:MaxGCPauseMillis=50 -XX:MaxPermSize=256M -XX:+UnlockExperimentalVMOptions -XX:+UseCompressedOops -XX:-UseAdaptiveSizePolicy -XX:CompileThreshold=100 -Dfile.encoding=UTF-8 -Xmx456M -Xms256m -jar launcher.jar
+screen -RS CloudNet java -XX:+UseG1GC -XX:MaxGCPauseMillis=50 -XX:MaxPermSize=256M -XX:+UnlockExperimentalVMOptions -XX:+UseCompressedOops -XX:-UseAdaptiveSizePolicy -XX:CompileThreshold=100 -Dfile.encoding=UTF-8 -Xmx456M -Xms256m -jar launcher.jar


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
Added that an excisting screen named "CloudNet" will be accessed instead of newly created.
This will prevent issue of users who want to access the console and start a new instance instead (other users who need this will probably know how to "escape" it)
