### PR TITLE
New option for the Smart Module

### DIFF
--- a/cloudnet-modules/cloudnet-smart/build.gradle
+++ b/cloudnet-modules/cloudnet-smart/build.gradle
@@ -9,4 +9,5 @@ jar {
 
 dependencies {
     compileOnly project(':cloudnet')
+    compileOnly project(':cloudnet-modules:cloudnet-bridge')
 }

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetSmartModule.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/CloudNetSmartModule.java
@@ -99,7 +99,7 @@ public final class CloudNetSmartModule extends NodeCloudNetModule {
     }
 
     public ServiceInfoSnapshot getFreeNonStartedService(String taskName) {
-        return CloudNet.getInstance().getCloudServiceManager().getGlobalServiceInfoSnapshots().values().stream()
+        return CloudNet.getInstance().getCloudServiceProvider().getCloudServices().stream()
                 .filter(serviceInfoSnapshot -> serviceInfoSnapshot.getServiceId().getTaskName().equalsIgnoreCase(taskName) &&
                         (serviceInfoSnapshot.getLifeCycle() == ServiceLifeCycle.PREPARED || serviceInfoSnapshot.getLifeCycle() == ServiceLifeCycle.DEFINED))
                 .findFirst()

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudNetTickListener.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudNetTickListener.java
@@ -79,7 +79,7 @@ public final class CloudNetTickListener {
 
         for (ServiceInfoSnapshot serviceInfoSnapshot : onlineServiceInfoSnapshots) {
             SmartServiceTaskConfig smartTask = CloudNetSmartModule.getInstance().getSmartServiceTaskConfig(serviceInfoSnapshot);
-            if (smartTask == null) {
+            if (smartTask == null || !smartTask.isEnabled()) {
                 continue;
             }
             CloudNetServiceSmartProfile cloudServiceProfile = CloudNetSmartModule.getInstance().getProvidedSmartServices().get(serviceInfoSnapshot.getServiceId().getUniqueId());
@@ -95,7 +95,7 @@ public final class CloudNetTickListener {
 
                 int runningServices = (int) runningServiceInfoSnapshots.stream().filter(runningServiceInfoSnapshot -> runningServiceInfoSnapshot.getServiceId().getTaskName().equals(serviceInfoSnapshot.getServiceId().getTaskName())).count();
                 ServiceTask serviceTask = CloudNet.getInstance().getServiceTaskProvider().getServiceTask(serviceInfoSnapshot.getServiceId().getTaskName());
-                if (runningServices <= serviceTask.getMinServiceCount()) {
+                if (serviceTask == null || runningServices <= serviceTask.getMinServiceCount()) {
                     continue;
                 }
 
@@ -121,15 +121,14 @@ public final class CloudNetTickListener {
                     cloudService.getServiceInfoSnapshot().getProperties().contains("Max-Players")) {
                 SmartServiceTaskConfig smartTask = CloudNetSmartModule.getInstance().getSmartServiceTaskConfig(cloudService.getServiceInfoSnapshot());
 
-                if (this.isIngameService(cloudService.getServiceInfoSnapshot())) {
+                if (smartTask == null || !smartTask.isEnabled() || this.isIngameService(cloudService.getServiceInfoSnapshot())) {
                     continue;
                 }
 
-                if (smartTask != null && smartTask.getPercentOfPlayersForANewServiceByInstance() > 0 && !this.newInstanceDelay.contains(cloudService.getServiceId().getUniqueId()) &&
-                        this.getPercentOf(
-                                cloudService.getServiceInfoSnapshot().getProperties().getInt("Online-Count"),
-                                cloudService.getServiceInfoSnapshot().getProperties().getInt("Max-Players")
-                        ) >= smartTask.getPercentOfPlayersForANewServiceByInstance()) {
+                if (smartTask.getPercentOfPlayersForANewServiceByInstance() > 0 && !this.newInstanceDelay.contains(cloudService.getServiceId().getUniqueId()) && this.getPercentOf(
+                        cloudService.getServiceInfoSnapshot().getProperties().getInt("Online-Count"),
+                        cloudService.getServiceInfoSnapshot().getProperties().getInt("Max-Players")
+                ) >= smartTask.getPercentOfPlayersForANewServiceByInstance()) {
                     ServiceInfoSnapshot serviceInfoSnapshot = CloudNetSmartModule.getInstance().getFreeNonStartedService(cloudService.getServiceId().getTaskName());
 
                     ServiceTask serviceTask = CloudNetDriver.getInstance().getServiceTaskProvider().getServiceTask(cloudService.getServiceId().getTaskName());

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudNetTickListener.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudNetTickListener.java
@@ -43,10 +43,7 @@ public final class CloudNetTickListener {
                 .filter(CloudNetSmartModule.getInstance()::hasSmartServiceTaskConfig)
                 .sorted(Comparator.comparingInt(serviceTask -> CloudNetSmartModule.getInstance().getSmartServiceTaskConfig(serviceTask).getPriority()))
                 .forEachOrdered(serviceTask -> {
-                    if (serviceTask.canStartServices() &&
-                            serviceTask.getAssociatedNodes() != null &&
-                            (serviceTask.getAssociatedNodes().contains(CloudNet.getInstance().getConfig().getIdentity().getUniqueId()) ||
-                                    serviceTask.getAssociatedNodes().isEmpty())) {
+                    if (serviceTask.canStartServices() && CloudNet.getInstance().canStartServices(serviceTask)) {
 
                         SmartServiceTaskConfig smartTask = CloudNetSmartModule.getInstance().getSmartServiceTaskConfig(serviceTask);
                         this.autoGeneratePreparedServices(smartTask, serviceTask);

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/util/SmartServiceTaskConfig.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/util/SmartServiceTaskConfig.java
@@ -9,7 +9,6 @@ import lombok.ToString;
 public class SmartServiceTaskConfig implements Comparable<SmartServiceTaskConfig> {
 
     protected boolean enabled = false;
-
     protected int priority = 10;
 
     protected boolean directTemplatesAndInclusionsSetup = true;
@@ -17,16 +16,15 @@ public class SmartServiceTaskConfig implements Comparable<SmartServiceTaskConfig
     protected int preparedServices = 0;
 
     protected boolean dynamicMemoryAllocation = false;
-
     protected int dynamicMemoryAllocationRange = 256;
 
     protected int percentOfPlayersToCheckShouldAutoStopTheServiceInFuture = 0;
-
     protected int autoStopTimeByUnusedServiceInSeconds = 180;
 
     protected int percentOfPlayersForANewServiceByInstance = 100;
-
     protected int forAnewInstanceDelayTimeInSeconds = 300;
+
+    protected int minNonFullServices = 0;
 
     protected TemplateInstaller templateInstaller = TemplateInstaller.INSTALL_ALL;
 
@@ -35,8 +33,8 @@ public class SmartServiceTaskConfig implements Comparable<SmartServiceTaskConfig
     public SmartServiceTaskConfig(
             int priority, boolean directTemplatesAndInclusionsSetup, int preparedServices, boolean dynamicMemoryAllocation,
             int dynamicMemoryAllocationRange, int percentOfPlayersToCheckShouldAutoStopTheServiceInFuture, int autoStopTimeByUnusedServiceInSeconds,
-            boolean switchToPreparedServiceAfterAutoStopTimeByUnusedService, int percentOfPlayersForANewServiceByInstance,
-            int forAnewInstanceDelayTimeInSeconds, TemplateInstaller templateInstaller, int maxServiceCount) {
+            int percentOfPlayersForANewServiceByInstance, int forAnewInstanceDelayTimeInSeconds,
+            int minNonFullServices, TemplateInstaller templateInstaller, int maxServiceCount) {
         this.enabled = false;
         this.priority = priority;
         this.directTemplatesAndInclusionsSetup = directTemplatesAndInclusionsSetup;
@@ -47,6 +45,7 @@ public class SmartServiceTaskConfig implements Comparable<SmartServiceTaskConfig
         this.autoStopTimeByUnusedServiceInSeconds = autoStopTimeByUnusedServiceInSeconds;
         this.percentOfPlayersForANewServiceByInstance = percentOfPlayersForANewServiceByInstance;
         this.forAnewInstanceDelayTimeInSeconds = forAnewInstanceDelayTimeInSeconds;
+        this.minNonFullServices = minNonFullServices;
         this.templateInstaller = templateInstaller;
         this.maxServiceCount = maxServiceCount;
     }
@@ -137,6 +136,14 @@ public class SmartServiceTaskConfig implements Comparable<SmartServiceTaskConfig
 
     public void setForAnewInstanceDelayTimeInSeconds(int forAnewInstanceDelayTimeInSeconds) {
         this.forAnewInstanceDelayTimeInSeconds = forAnewInstanceDelayTimeInSeconds;
+    }
+
+    public int getMinNonFullServices() {
+        return this.minNonFullServices;
+    }
+
+    public void setMinNonFullServices(int minNonFullServices) {
+        this.minNonFullServices = minNonFullServices;
     }
 
     public TemplateInstaller getTemplateInstaller() {


### PR DESCRIPTION
- [ ] breaking changes
- [x] no breaking changes

### changes made to the repository
Adds a new option that keeps X services running with a configurable max percentage of online players per service and fixes that the enabled option was ignored in the smart module.