### PR TITLE
Feature/wrapper group perms

### DIFF
--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/CachedPermissionManagement.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/CachedPermissionManagement.java
@@ -1,0 +1,12 @@
+package de.dytanic.cloudnet.driver.permission;
+
+import java.util.Map;
+import java.util.UUID;
+
+public interface CachedPermissionManagement extends IPermissionManagement {
+
+    Map<UUID, IPermissionUser> getCachedPermissionUsers();
+
+    Map<String, IPermissionGroup> getCachedPermissionGroups();
+
+}

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/DefaultPermissionManagement.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/DefaultPermissionManagement.java
@@ -4,9 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.function.BooleanSupplier;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/DefaultPermissionManagement.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/DefaultPermissionManagement.java
@@ -4,29 +4,33 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public interface DefaultPermissionManagement extends IPermissionManagement {
+public abstract class DefaultPermissionManagement implements IPermissionManagement {
 
-    default IPermissionManagement getChildPermissionManagement() {
+    public IPermissionManagement getChildPermissionManagement() {
         return null;
     }
 
-    default boolean canBeOverwritten() {
+    public boolean canBeOverwritten() {
         return true;
     }
 
     @Deprecated
-    default List<IPermissionUser> getUser(String name) {
+    public List<IPermissionUser> getUser(String name) {
         return this.getUsers(name);
     }
 
     @Deprecated
-    default Collection<IPermissionUser> getUserByGroup(String group) {
+    public Collection<IPermissionUser> getUserByGroup(String group) {
         return this.getUsersByGroup(group);
     }
 
-    default IPermissionGroup getHighestPermissionGroup(@NotNull IPermissionUser permissionUser) {
+    public IPermissionGroup getHighestPermissionGroup(@NotNull IPermissionUser permissionUser) {
         IPermissionGroup permissionGroup = null;
 
         for (IPermissionGroup group : this.getGroups(permissionUser)) {
@@ -43,7 +47,7 @@ public interface DefaultPermissionManagement extends IPermissionManagement {
         return permissionGroup != null ? permissionGroup : this.getDefaultPermissionGroup();
     }
 
-    default boolean testPermissionGroup(@Nullable IPermissionGroup permissionGroup) {
+    public boolean testPermissionGroup(@Nullable IPermissionGroup permissionGroup) {
         if (permissionGroup == null) {
             return false;
         }
@@ -51,7 +55,7 @@ public interface DefaultPermissionManagement extends IPermissionManagement {
         return this.testPermissible(permissionGroup);
     }
 
-    default boolean testPermissionUser(@Nullable IPermissionUser permissionUser) {
+    public boolean testPermissionUser(@Nullable IPermissionUser permissionUser) {
         if (permissionUser == null) {
             return false;
         }
@@ -74,7 +78,7 @@ public interface DefaultPermissionManagement extends IPermissionManagement {
         return result;
     }
 
-    default boolean testPermissible(@Nullable IPermissible permissible) {
+    public boolean testPermissible(@Nullable IPermissible permissible) {
         if (permissible == null) {
             return false;
         }
@@ -118,7 +122,7 @@ public interface DefaultPermissionManagement extends IPermissionManagement {
         return result;
     }
 
-    default Collection<IPermissionGroup> getGroups(@Nullable IPermissionUser permissionUser) {
+    public Collection<IPermissionGroup> getGroups(@Nullable IPermissionUser permissionUser) {
         Collection<IPermissionGroup> permissionGroups = new ArrayList<>();
 
         if (permissionUser == null) {
@@ -140,43 +144,29 @@ public interface DefaultPermissionManagement extends IPermissionManagement {
         return permissionGroups;
     }
 
-    default Collection<IPermissionGroup> getExtendedGroups(@Nullable IPermissionGroup group) {
+    public Collection<IPermissionGroup> getExtendedGroups(@Nullable IPermissionGroup group) {
         return group == null ?
                 Collections.emptyList() :
                 this.getGroups().stream().filter(permissionGroup -> group.getGroups().contains(permissionGroup.getName())).collect(Collectors.toList());
     }
 
     @NotNull
-    default PermissionCheckResult getPermissionResult(@NotNull IPermissionUser permissionUser, @NotNull String permission) {
+    public PermissionCheckResult getPermissionResult(@NotNull IPermissionUser permissionUser, @NotNull String permission) {
         return this.getPermissionResult(permissionUser, new Permission(permission));
     }
 
     @NotNull
-    default PermissionCheckResult getPermissionResult(@NotNull IPermissionUser permissionUser, @NotNull Permission permission) {
-        switch (permissionUser.hasPermission(permission)) {
-            case ALLOWED:
-                return PermissionCheckResult.ALLOWED;
-            case FORBIDDEN:
-                return PermissionCheckResult.FORBIDDEN;
-            default:
-                for (IPermissionGroup permissionGroup : this.getGroups(permissionUser)) {
-                    if (permissionGroup != null) {
-                        PermissionCheckResult result = this.tryExtendedGroups(permissionGroup.getName(), permissionGroup, permission, 0);
-                        if (result == PermissionCheckResult.ALLOWED || result == PermissionCheckResult.FORBIDDEN) {
-                            return result;
-                        }
-                    }
-                }
-                break;
-        }
-
-        IPermissionGroup defaultGroup = this.getDefaultPermissionGroup();
-        return defaultGroup != null ? this.tryExtendedGroups(defaultGroup.getName(), defaultGroup, permission, 0) : PermissionCheckResult.DENIED;
+    public PermissionCheckResult getPermissionResult(@NotNull IPermissionUser permissionUser, @NotNull Permission permission) {
+        return this.getPermissionResult(permissionUser, () -> permissionUser.hasPermission(permission), permissionGroup -> this.tryExtendedGroups(permissionGroup.getName(), permissionGroup, permission, 0));
     }
 
     @NotNull
-    default PermissionCheckResult getPermissionResult(@NotNull IPermissionUser permissionUser, @NotNull String group, @NotNull Permission permission) {
-        switch (permissionUser.hasPermission(group, permission)) {
+    public PermissionCheckResult getPermissionResult(@NotNull IPermissionUser permissionUser, @NotNull String group, @NotNull Permission permission) {
+        return this.getPermissionResult(permissionUser, () -> permissionUser.hasPermission(permission), permissionGroup -> this.tryExtendedGroups(permissionGroup.getName(), permissionGroup, group, permission, 0));
+    }
+
+    public PermissionCheckResult getPermissionResult(IPermissionUser permissionUser, Supplier<PermissionCheckResult> permissionTester, Function<IPermissionGroup, PermissionCheckResult> extendedGroupsTester) {
+        switch (permissionTester.get()) {
             case ALLOWED:
                 return PermissionCheckResult.ALLOWED;
             case FORBIDDEN:
@@ -184,7 +174,7 @@ public interface DefaultPermissionManagement extends IPermissionManagement {
             default:
                 for (IPermissionGroup permissionGroup : this.getGroups(permissionUser)) {
                     if (permissionGroup != null) {
-                        PermissionCheckResult result = this.tryExtendedGroups(permissionGroup.getName(), permissionGroup, group, permission, 0);
+                        PermissionCheckResult result = extendedGroupsTester.apply(permissionGroup);
                         if (result == PermissionCheckResult.ALLOWED || result == PermissionCheckResult.FORBIDDEN) {
                             return result;
                         }
@@ -193,11 +183,11 @@ public interface DefaultPermissionManagement extends IPermissionManagement {
                 break;
         }
 
-        IPermissionGroup defaultGroup = this.getDefaultPermissionGroup();
-        return defaultGroup != null ? this.tryExtendedGroups(defaultGroup.getName(), defaultGroup, group, permission, 0) : PermissionCheckResult.DENIED;
+        IPermissionGroup publicGroup = this.getDefaultPermissionGroup();
+        return publicGroup != null ? extendedGroupsTester.apply(publicGroup) : PermissionCheckResult.DENIED;
     }
 
-    default PermissionCheckResult tryExtendedGroups(@NotNull String firstGroup, @Nullable IPermissionGroup permissionGroup, @NotNull Permission permission, int layer) {
+    public PermissionCheckResult tryExtendedGroups(@NotNull String firstGroup, @Nullable IPermissionGroup permissionGroup, @NotNull Permission permission, int layer) {
         if (permissionGroup == null) {
             return PermissionCheckResult.DENIED;
         }
@@ -225,7 +215,7 @@ public interface DefaultPermissionManagement extends IPermissionManagement {
         return PermissionCheckResult.DENIED;
     }
 
-    default PermissionCheckResult tryExtendedGroups(@NotNull String firstGroup, @Nullable IPermissionGroup permissionGroup, @NotNull String group, @NotNull Permission permission, int layer) {
+    public PermissionCheckResult tryExtendedGroups(@NotNull String firstGroup, @Nullable IPermissionGroup permissionGroup, @NotNull String group, @NotNull Permission permission, int layer) {
         if (permissionGroup == null) {
             return PermissionCheckResult.DENIED;
         }
@@ -253,11 +243,11 @@ public interface DefaultPermissionManagement extends IPermissionManagement {
         return PermissionCheckResult.DENIED;
     }
 
-    default Collection<Permission> getAllPermissions(@NotNull IPermissible permissible) {
+    public Collection<Permission> getAllPermissions(@NotNull IPermissible permissible) {
         return this.getAllPermissions(permissible, null);
     }
 
-    default Collection<Permission> getAllPermissions(@NotNull IPermissible permissible, String group) {
+    public Collection<Permission> getAllPermissions(@NotNull IPermissible permissible, String group) {
         if (permissible == null) {
             return Collections.emptyList();
         }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissionManagement.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissionManagement.java
@@ -24,6 +24,7 @@ public interface IPermissionManagement {
 
     IPermissionUser getFirstUser(String name);
 
+    void init();
 
     boolean reload();
 

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsHelper.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsHelper.java
@@ -1,5 +1,6 @@
 package de.dytanic.cloudnet.ext.cloudperms;
 
+import de.dytanic.cloudnet.driver.permission.CachedPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.driver.permission.PermissionUser;
 
@@ -15,11 +16,11 @@ public class CloudPermissionsHelper {
         throw new UnsupportedOperationException();
     }
 
-    public static void initPermissionUser(CloudPermissionsManagement permissionsManagement, UUID uniqueId, String name, Consumer<String> disconnectHandler) {
+    public static void initPermissionUser(CachedPermissionManagement permissionsManagement, UUID uniqueId, String name, Consumer<String> disconnectHandler) {
         initPermissionUser(permissionsManagement, uniqueId, name, disconnectHandler, true);
     }
 
-    public static void initPermissionUser(CloudPermissionsManagement permissionsManagement, UUID uniqueId, String name, Consumer<String> disconnectHandler, boolean shouldUpdateName) {
+    public static void initPermissionUser(CachedPermissionManagement permissionsManagement, UUID uniqueId, String name, Consumer<String> disconnectHandler, boolean shouldUpdateName) {
         IPermissionUser permissionUser = null;
         try {
             permissionUser = permissionsManagement.getUserAsync(uniqueId).get(3, TimeUnit.SECONDS);

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsManagement.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsManagement.java
@@ -1,30 +1,22 @@
 package de.dytanic.cloudnet.ext.cloudperms;
 
-import de.dytanic.cloudnet.common.concurrent.CompletedTask;
 import de.dytanic.cloudnet.common.concurrent.ITask;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.permission.*;
-import de.dytanic.cloudnet.ext.cloudperms.listener.PermissionsUpdateListener;
-import de.dytanic.cloudnet.wrapper.Wrapper;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
-public class CloudPermissionsManagement extends DefaultPermissionManagement implements DefaultSynchronizedPermissionManagement {
+@Deprecated
+@ApiStatus.ScheduledForRemoval(inVersion = "3.5")
+public class CloudPermissionsManagement implements IPermissionManagement, CachedPermissionManagement {
 
-    private final Map<String, IPermissionGroup> cachedPermissionGroups = new ConcurrentHashMap<>();
-    private final Map<UUID, IPermissionUser> cachedPermissionUsers = new ConcurrentHashMap<>();
+    private final IPermissionManagement wrapped;
 
-    private final IPermissionManagement childPermissionManagement;
-
-    protected CloudPermissionsManagement(@NotNull IPermissionManagement childPermissionManagement) {
-        this.childPermissionManagement = childPermissionManagement;
-        this.init();
-
-        CloudNetDriver.getInstance().setPermissionManagement(this);
+    public CloudPermissionsManagement(IPermissionManagement wrapped) {
+        this.wrapped = wrapped;
     }
 
     /**
@@ -39,17 +31,336 @@ public class CloudPermissionsManagement extends DefaultPermissionManagement impl
         return new CloudPermissionsPermissionManagement(Objects.requireNonNull(CloudNetDriver.getInstance().getPermissionManagement()));
     }
 
-    private void init() {
-        for (IPermissionGroup permissionGroup : this.getChildPermissionManagement().getGroups()) {
-            this.cachedPermissionGroups.put(permissionGroup.getName(), permissionGroup);
-        }
-
-        this.getDriver().getEventManager().registerListener(new PermissionsUpdateListener(this));
+    @Override
+    public IPermissionManagement getChildPermissionManagement() {
+        return wrapped.getChildPermissionManagement();
     }
 
     @Override
     public boolean canBeOverwritten() {
-        return false;
+        return wrapped.canBeOverwritten();
+    }
+
+    @Override
+    @ApiStatus.ScheduledForRemoval(inVersion = "3.5")
+    @Deprecated
+    public List<IPermissionUser> getUser(String name) {
+        return wrapped.getUser(name);
+    }
+
+    @Override
+    public IPermissionUser getFirstUser(String name) {
+        return wrapped.getFirstUser(name);
+    }
+
+    @Override
+    public void init() {
+        this.wrapped.init();
+    }
+
+    @Override
+    public boolean reload() {
+        return wrapped.reload();
+    }
+
+    @Override
+    public IPermissionGroup getHighestPermissionGroup(@NotNull IPermissionUser permissionUser) {
+        return wrapped.getHighestPermissionGroup(permissionUser);
+    }
+
+    @Override
+    public IPermissionGroup getDefaultPermissionGroup() {
+        return wrapped.getDefaultPermissionGroup();
+    }
+
+    @Override
+    public boolean testPermissionGroup(@Nullable IPermissionGroup permissionGroup) {
+        return wrapped.testPermissionGroup(permissionGroup);
+    }
+
+    @Override
+    public boolean testPermissionUser(@Nullable IPermissionUser permissionUser) {
+        return wrapped.testPermissionUser(permissionUser);
+    }
+
+    @Override
+    public boolean testPermissible(@Nullable IPermissible permissible) {
+        return wrapped.testPermissible(permissible);
+    }
+
+    @Override
+    public IPermissionUser addUser(@NotNull String name, @NotNull String password, int potency) {
+        return wrapped.addUser(name, password, potency);
+    }
+
+    @Override
+    public IPermissionGroup addGroup(@NotNull String role, int potency) {
+        return wrapped.addGroup(role, potency);
+    }
+
+    @Override
+    public Collection<IPermissionGroup> getGroups(@Nullable IPermissionUser permissionUser) {
+        return wrapped.getGroups(permissionUser);
+    }
+
+    @Override
+    public Collection<IPermissionGroup> getExtendedGroups(@Nullable IPermissionGroup group) {
+        return wrapped.getExtendedGroups(group);
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull IPermissionUser permissionUser, @NotNull String permission) {
+        return wrapped.hasPermission(permissionUser, permission);
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull IPermissionUser permissionUser, @NotNull Permission permission) {
+        return wrapped.hasPermission(permissionUser, permission);
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull IPermissionUser permissionUser, @NotNull String group, @NotNull Permission permission) {
+        return wrapped.hasPermission(permissionUser, group, permission);
+    }
+
+    @Override
+    public @NotNull PermissionCheckResult getPermissionResult(@NotNull IPermissionUser permissionUser, @NotNull String permission) {
+        return wrapped.getPermissionResult(permissionUser, permission);
+    }
+
+    @Override
+    public @NotNull PermissionCheckResult getPermissionResult(@NotNull IPermissionUser permissionUser, @NotNull Permission permission) {
+        return wrapped.getPermissionResult(permissionUser, permission);
+    }
+
+    @Override
+    public @NotNull PermissionCheckResult getPermissionResult(@NotNull IPermissionUser permissionUser, @NotNull String group, @NotNull Permission permission) {
+        return wrapped.getPermissionResult(permissionUser, group, permission);
+    }
+
+    @Override
+    public Collection<Permission> getAllPermissions(@NotNull IPermissible permissible) {
+        return wrapped.getAllPermissions(permissible);
+    }
+
+    @Override
+    public Collection<Permission> getAllPermissions(@NotNull IPermissible permissible, @Nullable String group) {
+        return wrapped.getAllPermissions(permissible, group);
+    }
+
+    @Override
+    public IPermissionUser addUser(@NotNull IPermissionUser permissionUser) {
+        return wrapped.addUser(permissionUser);
+    }
+
+    @Override
+    public void updateUser(@NotNull IPermissionUser permissionUser) {
+        wrapped.updateUser(permissionUser);
+    }
+
+    @Override
+    public boolean deleteUser(@NotNull String name) {
+        return wrapped.deleteUser(name);
+    }
+
+    @Override
+    public boolean deleteUser(@NotNull IPermissionUser permissionUser) {
+        return wrapped.deleteUser(permissionUser);
+    }
+
+    @Override
+    public boolean containsUser(@NotNull UUID uniqueId) {
+        return wrapped.containsUser(uniqueId);
+    }
+
+    @Override
+    public boolean containsUser(@NotNull String name) {
+        return wrapped.containsUser(name);
+    }
+
+    @Override
+    public @Nullable IPermissionUser getUser(@NotNull UUID uniqueId) {
+        return wrapped.getUser(uniqueId);
+    }
+
+    @Override
+    public @NotNull List<IPermissionUser> getUsers(@NotNull String name) {
+        return wrapped.getUsers(name);
+    }
+
+    @Override
+    public Collection<IPermissionUser> getUsers() {
+        return wrapped.getUsers();
+    }
+
+    @Override
+    public void setUsers(@Nullable Collection<? extends IPermissionUser> users) {
+        wrapped.setUsers(users);
+    }
+
+    @Override
+    public Collection<IPermissionUser> getUsersByGroup(@NotNull String group) {
+        return wrapped.getUsersByGroup(group);
+    }
+
+    @Override
+    public IPermissionGroup addGroup(@NotNull IPermissionGroup permissionGroup) {
+        return wrapped.addGroup(permissionGroup);
+    }
+
+    @Override
+    public void updateGroup(@NotNull IPermissionGroup permissionGroup) {
+        wrapped.updateGroup(permissionGroup);
+    }
+
+    @Override
+    public void deleteGroup(@NotNull String name) {
+        wrapped.deleteGroup(name);
+    }
+
+    @Override
+    public void deleteGroup(@NotNull IPermissionGroup permissionGroup) {
+        wrapped.deleteGroup(permissionGroup);
+    }
+
+    @Override
+    public boolean containsGroup(@NotNull String group) {
+        return wrapped.containsGroup(group);
+    }
+
+    @Override
+    public @Nullable IPermissionGroup getGroup(@NotNull String name) {
+        return wrapped.getGroup(name);
+    }
+
+    @Override
+    public Collection<IPermissionGroup> getGroups() {
+        return wrapped.getGroups();
+    }
+
+    @Override
+    public void setGroups(@Nullable Collection<? extends IPermissionGroup> groups) {
+        wrapped.setGroups(groups);
+    }
+
+    @Override
+    public @NotNull ITask<Collection<IPermissionGroup>> getGroupsAsync(@Nullable IPermissionUser permissionUser) {
+        return wrapped.getGroupsAsync(permissionUser);
+    }
+
+    @Override
+    public @NotNull ITask<IPermissionUser> addUserAsync(@NotNull IPermissionUser permissionUser) {
+        return wrapped.addUserAsync(permissionUser);
+    }
+
+    @Override
+    public @NotNull ITask<IPermissionUser> addUserAsync(@NotNull String name, @NotNull String password, int potency) {
+        return wrapped.addUserAsync(name, password, potency);
+    }
+
+    @Override
+    public @NotNull ITask<Void> updateUserAsync(@NotNull IPermissionUser permissionUser) {
+        return wrapped.updateUserAsync(permissionUser);
+    }
+
+    @Override
+    public @NotNull ITask<Boolean> deleteUserAsync(@NotNull String name) {
+        return wrapped.deleteUserAsync(name);
+    }
+
+    @Override
+    public @NotNull ITask<Boolean> deleteUserAsync(@NotNull IPermissionUser permissionUser) {
+        return wrapped.deleteUserAsync(permissionUser);
+    }
+
+    @Override
+    public @NotNull ITask<Boolean> containsUserAsync(@NotNull UUID uniqueId) {
+        return wrapped.containsUserAsync(uniqueId);
+    }
+
+    @Override
+    public @NotNull ITask<Boolean> containsUserAsync(@NotNull String name) {
+        return wrapped.containsUserAsync(name);
+    }
+
+    @Override
+    public @NotNull ITask<IPermissionUser> getUserAsync(@NotNull UUID uniqueId) {
+        return wrapped.getUserAsync(uniqueId);
+    }
+
+    @Override
+    public @NotNull ITask<List<IPermissionUser>> getUsersAsync(@NotNull String name) {
+        return wrapped.getUsersAsync(name);
+    }
+
+    @Override
+    public @NotNull ITask<IPermissionUser> getFirstUserAsync(String name) {
+        return wrapped.getFirstUserAsync(name);
+    }
+
+    @Override
+    public @NotNull ITask<Collection<IPermissionUser>> getUsersAsync() {
+        return wrapped.getUsersAsync();
+    }
+
+    @Override
+    public @NotNull ITask<Void> setUsersAsync(@NotNull Collection<? extends IPermissionUser> users) {
+        return wrapped.setUsersAsync(users);
+    }
+
+    @Override
+    public @NotNull ITask<Collection<IPermissionUser>> getUsersByGroupAsync(@NotNull String group) {
+        return wrapped.getUsersByGroupAsync(group);
+    }
+
+    @Override
+    public @NotNull ITask<IPermissionGroup> addGroupAsync(@NotNull IPermissionGroup permissionGroup) {
+        return wrapped.addGroupAsync(permissionGroup);
+    }
+
+    @Override
+    public @NotNull ITask<IPermissionGroup> addGroupAsync(@NotNull String role, int potency) {
+        return wrapped.addGroupAsync(role, potency);
+    }
+
+    @Override
+    public @NotNull ITask<Void> updateGroupAsync(@NotNull IPermissionGroup permissionGroup) {
+        return wrapped.updateGroupAsync(permissionGroup);
+    }
+
+    @Override
+    public @NotNull ITask<Void> deleteGroupAsync(@NotNull String name) {
+        return wrapped.deleteGroupAsync(name);
+    }
+
+    @Override
+    public @NotNull ITask<Void> deleteGroupAsync(@NotNull IPermissionGroup permissionGroup) {
+        return wrapped.deleteGroupAsync(permissionGroup);
+    }
+
+    @Override
+    public @NotNull ITask<Boolean> containsGroupAsync(@NotNull String group) {
+        return wrapped.containsGroupAsync(group);
+    }
+
+    @Override
+    public @NotNull ITask<IPermissionGroup> getGroupAsync(@NotNull String name) {
+        return wrapped.getGroupAsync(name);
+    }
+
+    @Override
+    public ITask<IPermissionGroup> getDefaultPermissionGroupAsync() {
+        return wrapped.getDefaultPermissionGroupAsync();
+    }
+
+    @Override
+    public @NotNull ITask<Collection<IPermissionGroup>> getGroupsAsync() {
+        return wrapped.getGroupsAsync();
+    }
+
+    @Override
+    public @NotNull ITask<Void> setGroupsAsync(@Nullable Collection<? extends IPermissionGroup> groups) {
+        return wrapped.setGroupsAsync(groups);
     }
 
     /**
@@ -71,172 +382,12 @@ public class CloudPermissionsManagement extends DefaultPermissionManagement impl
     }
 
     @Override
-    public @NotNull IPermissionManagement getChildPermissionManagement() {
-        return this.childPermissionManagement;
-    }
-
-    @Override
-    public @NotNull ITask<IPermissionUser> addUserAsync(@NotNull IPermissionUser permissionUser) {
-        return this.childPermissionManagement.addUserAsync(permissionUser);
-    }
-
-    @Override
-    public @NotNull ITask<IPermissionUser> addUserAsync(@NotNull String name, @NotNull String password, int potency) {
-        return this.childPermissionManagement.addUserAsync(name, password, potency);
-    }
-
-    @Override
-    public @NotNull ITask<Void> updateUserAsync(@NotNull IPermissionUser permissionUser) {
-        return this.childPermissionManagement.updateUserAsync(permissionUser);
-    }
-
-    @Override
-    public @NotNull ITask<Boolean> deleteUserAsync(@NotNull String name) {
-        return this.childPermissionManagement.deleteUserAsync(name);
-    }
-
-    @Override
-    public @NotNull ITask<Boolean> deleteUserAsync(@NotNull IPermissionUser permissionUser) {
-        return this.childPermissionManagement.deleteUserAsync(permissionUser);
-    }
-
-    @Override
-    public @NotNull ITask<Boolean> containsUserAsync(@NotNull String name) {
-        if (this.cachedPermissionUsers.values().stream().anyMatch(permissionUser -> permissionUser.getName().equals(name))) {
-            return CompletedTask.create(true);
-        }
-        return this.childPermissionManagement.containsUserAsync(name);
-    }
-
-    @Override
-    public @NotNull ITask<Boolean> containsUserAsync(@NotNull UUID uniqueId) {
-        if (this.cachedPermissionUsers.containsKey(uniqueId)) {
-            return CompletedTask.create(true);
-        }
-        return this.childPermissionManagement.containsUserAsync(uniqueId);
-    }
-
-    @Override
-    public @NotNull ITask<IPermissionUser> getUserAsync(@NotNull UUID uniqueId) {
-        if (this.cachedPermissionUsers.containsKey(uniqueId)) {
-            return CompletedTask.create(this.cachedPermissionUsers.get(uniqueId));
-        }
-        return this.childPermissionManagement.getUserAsync(uniqueId);
-    }
-
-    @Override
-    public @NotNull ITask<List<IPermissionUser>> getUsersAsync(@NotNull String name) {
-        return this.childPermissionManagement.getUsersAsync(name);
-    }
-
-    @Override
-    public @NotNull ITask<IPermissionUser> getFirstUserAsync(String name) {
-        return this.childPermissionManagement.getFirstUserAsync(name);
-    }
-
-    @Override
-    public @NotNull ITask<Collection<IPermissionUser>> getUsersAsync() {
-        return this.childPermissionManagement.getUsersAsync();
-    }
-
-    @Override
-    public @NotNull ITask<Void> setUsersAsync(@NotNull Collection<? extends IPermissionUser> users) {
-        return this.childPermissionManagement.setUsersAsync(users);
-    }
-
-    @Override
-    public @NotNull ITask<Collection<IPermissionUser>> getUsersByGroupAsync(@NotNull String group) {
-        return this.childPermissionManagement.getUsersByGroupAsync(group);
-    }
-
-    @Override
-    public @NotNull ITask<IPermissionGroup> addGroupAsync(@NotNull String role, int potency) {
-        return this.childPermissionManagement.addGroupAsync(role, potency);
-    }
-
-    @Override
-    public @NotNull ITask<IPermissionGroup> addGroupAsync(@NotNull IPermissionGroup permissionGroup) {
-        return this.childPermissionManagement.addGroupAsync(permissionGroup);
-    }
-
-    @Override
-    public @NotNull ITask<Void> updateGroupAsync(@NotNull IPermissionGroup permissionGroup) {
-        return this.childPermissionManagement.updateGroupAsync(permissionGroup);
-    }
-
-    @Override
-    public @NotNull ITask<Void> deleteGroupAsync(@NotNull String name) {
-        return this.childPermissionManagement.deleteGroupAsync(name);
-    }
-
-    @Override
-    public @NotNull ITask<Void> deleteGroupAsync(@NotNull IPermissionGroup permissionGroup) {
-        return this.childPermissionManagement.deleteGroupAsync(permissionGroup);
-    }
-
-    @Override
-    public @NotNull ITask<Boolean> containsGroupAsync(@NotNull String group) {
-        return CompletedTask.create(this.cachedPermissionGroups.containsKey(group));
-    }
-
-    @Override
-    public @NotNull ITask<IPermissionGroup> getGroupAsync(@NotNull String name) {
-        return CompletedTask.create(this.cachedPermissionGroups.get(name));
-    }
-
-    @Override
-    public @NotNull ITask<IPermissionGroup> getDefaultPermissionGroupAsync() {
-        return CompletedTask.create(this.cachedPermissionGroups.values().stream()
-                .filter(IPermissionGroup::isDefaultGroup)
-                .findFirst()
-                .orElse(null));
-    }
-
-    @Override
-    public @NotNull ITask<Collection<IPermissionGroup>> getGroupsAsync() {
-        return CompletedTask.create(this.cachedPermissionGroups.values());
-    }
-
-    @Override
-    public Collection<IPermissionGroup> getGroups() {
-        return this.cachedPermissionGroups.values();
-    }
-
-    @Override
-    public @NotNull ITask<Void> setGroupsAsync(@Nullable Collection<? extends IPermissionGroup> groups) {
-        return this.childPermissionManagement.setGroupsAsync(groups);
-    }
-
-    @Override
-    public boolean reload() {
-        this.childPermissionManagement.reload();
-
-        Collection<IPermissionGroup> permissionGroups = this.childPermissionManagement.getGroups();
-
-        this.cachedPermissionGroups.clear();
-
-        for (IPermissionGroup group : permissionGroups) {
-            this.cachedPermissionGroups.put(group.getName(), group);
-        }
-
-        return true;
-    }
-
-    @Override
-    public @NotNull ITask<Collection<IPermissionGroup>> getGroupsAsync(@Nullable IPermissionUser permissionUser) {
-        return this.childPermissionManagement.getGroupsAsync(permissionUser);
-    }
-
-
-    private CloudNetDriver getDriver() {
-        return CloudNetDriver.getInstance();
-    }
-
-    public Map<String, IPermissionGroup> getCachedPermissionGroups() {
-        return this.cachedPermissionGroups;
-    }
-
     public Map<UUID, IPermissionUser> getCachedPermissionUsers() {
-        return this.cachedPermissionUsers;
+        return this.wrapped instanceof CachedPermissionManagement ? ((CachedPermissionManagement) this.wrapped).getCachedPermissionUsers() : null;
+    }
+
+    @Override
+    public Map<String, IPermissionGroup> getCachedPermissionGroups() {
+        return this.wrapped instanceof CachedPermissionManagement ? ((CachedPermissionManagement) this.wrapped).getCachedPermissionGroups() : null;
     }
 }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsManagement.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsManagement.java
@@ -6,13 +6,14 @@ import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.permission.*;
 import de.dytanic.cloudnet.ext.cloudperms.listener.PermissionsUpdateListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class CloudPermissionsManagement implements DefaultPermissionManagement, DefaultSynchronizedPermissionManagement {
+public class CloudPermissionsManagement extends DefaultPermissionManagement implements DefaultSynchronizedPermissionManagement {
 
     private final Map<String, IPermissionGroup> cachedPermissionGroups = new ConcurrentHashMap<>();
     private final Map<UUID, IPermissionUser> cachedPermissionUsers = new ConcurrentHashMap<>();
@@ -51,29 +52,22 @@ public class CloudPermissionsManagement implements DefaultPermissionManagement, 
         return false;
     }
 
+    /**
+     * @deprecated The wrapper itself checks the permissions for every group now
+     */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "3.4")
     public boolean hasPlayerPermission(IPermissionUser permissionUser, String perm) {
-        Permission permission = new Permission(perm, 0);
-
-        for (String group : Wrapper.getInstance().getServiceConfiguration().getGroups()) {
-            if (this.hasPermission(permissionUser, group, permission)) {
-                return true;
-            }
-        }
-
-        return this.hasPermission(permissionUser, permission);
+        return this.hasPermission(permissionUser, perm);
     }
 
+    /**
+     * @deprecated The wrapper itself checks the permissions for every group now
+     */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "3.4")
     public PermissionCheckResult getPlayerPermissionResult(IPermissionUser permissionUser, String perm) {
-        Permission permission = new Permission(perm, 0);
-
-        for (String group : Wrapper.getInstance().getServiceConfiguration().getGroups()) {
-            PermissionCheckResult result = this.getPermissionResult(permissionUser, group, permission);
-            if (result == PermissionCheckResult.ALLOWED || result == PermissionCheckResult.FORBIDDEN) {
-                return result;
-            }
-        }
-
-        return this.getPermissionResult(permissionUser, permission);
+        return this.getPermissionResult(permissionUser, perm);
     }
 
     @Override

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPermissible.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPermissible.java
@@ -1,9 +1,9 @@
 package de.dytanic.cloudnet.ext.cloudperms.bukkit;
 
 import de.dytanic.cloudnet.driver.CloudNetDriver;
+import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.driver.permission.PermissionCheckResult;
-import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
 import de.dytanic.cloudnet.wrapper.Wrapper;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissibleBase;
@@ -20,9 +20,9 @@ import java.util.function.Predicate;
 public final class BukkitCloudNetCloudPermissionsPermissible extends PermissibleBase {
 
     private final Player player;
-    private final CloudPermissionsManagement permissionsManagement;
+    private final IPermissionManagement permissionsManagement;
 
-    public BukkitCloudNetCloudPermissionsPermissible(Player player, CloudPermissionsManagement permissionsManagement) {
+    public BukkitCloudNetCloudPermissionsPermissible(Player player, IPermissionManagement permissionsManagement) {
         super(player);
 
         this.player = player;

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPermissible.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPermissible.java
@@ -91,7 +91,7 @@ public final class BukkitCloudNetCloudPermissionsPermissible extends Permissible
     }
 
     private boolean testDefaultPermission(IPermissionUser permissionUser, String name) {
-        return this.permissionsManagement.getPlayerPermissionResult(permissionUser, name) != PermissionCheckResult.FORBIDDEN;
+        return this.permissionsManagement.getPermissionResult(permissionUser, name) != PermissionCheckResult.FORBIDDEN;
     }
 
     private boolean testParents(String inName, Predicate<Permission> parentAcceptor) {
@@ -129,7 +129,7 @@ public final class BukkitCloudNetCloudPermissionsPermissible extends Permissible
 
     private boolean checkPermission(IPermissionUser permissionUser, String name) {
         return this.getDefaultPermissions().stream().anyMatch(permission -> permission.getName().equalsIgnoreCase(name) && this.testDefaultPermission(permissionUser, name)) ||
-                this.permissionsManagement.hasPlayerPermission(permissionUser, name);
+                this.permissionsManagement.hasPermission(permissionUser, name);
     }
 
     public Player getPlayer() {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/BukkitCloudNetCloudPermissionsPlugin.java
@@ -2,6 +2,7 @@ package de.dytanic.cloudnet.ext.cloudperms.bukkit;
 
 import com.google.common.base.Preconditions;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
+import de.dytanic.cloudnet.driver.permission.CachedPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionGroup;
 import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
@@ -28,7 +29,7 @@ public final class BukkitCloudNetCloudPermissionsPlugin extends JavaPlugin {
         return BukkitCloudNetCloudPermissionsPlugin.instance;
     }
 
-    private CloudPermissionsManagement permissionsManagement;
+    private CachedPermissionManagement permissionsManagement;
 
     @Override
     public void onLoad() {
@@ -63,18 +64,18 @@ public final class BukkitCloudNetCloudPermissionsPlugin extends JavaPlugin {
                                Function<Player, IPermissionGroup> allOtherPlayerPermissionGroupFunction) {
         Preconditions.checkNotNull(player);
 
-        IPermissionUser playerPermissionUser = CloudNetDriver.getInstance().getPermissionManagement().getUser(player.getUniqueId());
+        IPermissionUser playerPermissionUser = this.permissionsManagement.getUser(player.getUniqueId());
         AtomicReference<IPermissionGroup> playerPermissionGroup = new AtomicReference<>(playerIPermissionGroupFunction != null ? playerIPermissionGroupFunction.apply(player) : null);
 
         if (playerPermissionUser != null && playerPermissionGroup.get() == null) {
-            playerPermissionGroup.set(CloudNetDriver.getInstance().getPermissionManagement().getHighestPermissionGroup(playerPermissionUser));
+            playerPermissionGroup.set(this.permissionsManagement.getHighestPermissionGroup(playerPermissionUser));
 
             if (playerPermissionGroup.get() == null) {
-                playerPermissionGroup.set(CloudNetDriver.getInstance().getPermissionManagement().getDefaultPermissionGroup());
+                playerPermissionGroup.set(this.permissionsManagement.getDefaultPermissionGroup());
             }
         }
 
-        int sortIdLength = CloudPermissionsManagement.getInstance().getGroups().stream()
+        int sortIdLength = this.permissionsManagement.getGroups().stream()
                 .map(IPermissionGroup::getSortId)
                 .map(String::valueOf)
                 .mapToInt(String::length)
@@ -90,14 +91,14 @@ public final class BukkitCloudNetCloudPermissionsPlugin extends JavaPlugin {
                 this.addTeamEntry(player, all, playerPermissionGroup.get(), sortIdLength);
             }
 
-            IPermissionUser targetPermissionUser = CloudNetDriver.getInstance().getPermissionManagement().getUser(all.getUniqueId());
+            IPermissionUser targetPermissionUser = this.permissionsManagement.getUser(all.getUniqueId());
             IPermissionGroup targetPermissionGroup = allOtherPlayerPermissionGroupFunction != null ? allOtherPlayerPermissionGroupFunction.apply(all) : null;
 
             if (targetPermissionUser != null && targetPermissionGroup == null) {
-                targetPermissionGroup = CloudNetDriver.getInstance().getPermissionManagement().getHighestPermissionGroup(targetPermissionUser);
+                targetPermissionGroup = this.permissionsManagement.getHighestPermissionGroup(targetPermissionUser);
 
                 if (targetPermissionGroup == null) {
-                    targetPermissionGroup = CloudNetDriver.getInstance().getPermissionManagement().getDefaultPermissionGroup();
+                    targetPermissionGroup = this.permissionsManagement.getDefaultPermissionGroup();
                 }
             }
 
@@ -143,7 +144,7 @@ public final class BukkitCloudNetCloudPermissionsPlugin extends JavaPlugin {
                     ChatColor chatColor = ChatColor.getByChar(color.replaceAll("&", "").replaceAll("§", ""));
                     if (chatColor != null) {
                         permissionGroup.setColor(color);
-                        CloudNetDriver.getInstance().getPermissionManagement().updateGroup(permissionGroup);
+                        this.permissionsManagement.updateGroup(permissionGroup);
                         method.invoke(team, chatColor);
                     }
                 }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/listener/BukkitCloudNetCloudPermissionsPlayerListener.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bukkit/listener/BukkitCloudNetCloudPermissionsPlayerListener.java
@@ -1,7 +1,7 @@
 package de.dytanic.cloudnet.ext.cloudperms.bukkit.listener;
 
+import de.dytanic.cloudnet.driver.permission.CachedPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsHelper;
-import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
 import de.dytanic.cloudnet.ext.cloudperms.bukkit.BukkitCloudNetCloudPermissionsPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -13,9 +13,9 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 public final class BukkitCloudNetCloudPermissionsPlayerListener implements Listener {
 
-    private final CloudPermissionsManagement permissionsManagement;
+    private final CachedPermissionManagement permissionsManagement;
 
-    public BukkitCloudNetCloudPermissionsPlayerListener(CloudPermissionsManagement permissionsManagement) {
+    public BukkitCloudNetCloudPermissionsPlayerListener(CachedPermissionManagement permissionsManagement) {
         this.permissionsManagement = permissionsManagement;
     }
 

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bungee/listener/BungeeCloudNetCloudPermissionsPlayerListener.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bungee/listener/BungeeCloudNetCloudPermissionsPlayerListener.java
@@ -1,8 +1,8 @@
 package de.dytanic.cloudnet.ext.cloudperms.bungee.listener;
 
+import de.dytanic.cloudnet.driver.permission.CachedPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsHelper;
-import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -20,9 +20,9 @@ import java.util.UUID;
 
 public final class BungeeCloudNetCloudPermissionsPlayerListener implements Listener {
 
-    private final CloudPermissionsManagement permissionsManagement;
+    private final CachedPermissionManagement permissionsManagement;
 
-    public BungeeCloudNetCloudPermissionsPlayerListener(CloudPermissionsManagement permissionsManagement) {
+    public BungeeCloudNetCloudPermissionsPlayerListener(CachedPermissionManagement permissionsManagement) {
         this.permissionsManagement = permissionsManagement;
     }
 

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bungee/listener/BungeeCloudNetCloudPermissionsPlayerListener.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/bungee/listener/BungeeCloudNetCloudPermissionsPlayerListener.java
@@ -56,7 +56,7 @@ public final class BungeeCloudNetCloudPermissionsPlayerListener implements Liste
             IPermissionUser permissionUser = this.permissionsManagement.getUser(uniqueId);
 
             if (permissionUser != null) {
-                event.setHasPermission(this.permissionsManagement.hasPlayerPermission(permissionUser, event.getPermission()));
+                event.setHasPermission(this.permissionsManagement.hasPermission(permissionUser, event.getPermission()));
             }
         }
     }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPermissible.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPermissible.java
@@ -4,8 +4,8 @@ import cn.nukkit.Player;
 import cn.nukkit.permission.PermissibleBase;
 import cn.nukkit.permission.Permission;
 import cn.nukkit.permission.PermissionAttachmentInfo;
+import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
-import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
 import de.dytanic.cloudnet.wrapper.Wrapper;
 
 import java.util.HashMap;
@@ -15,9 +15,9 @@ import java.util.stream.Collectors;
 public final class NukkitCloudNetCloudPermissionsPermissible extends PermissibleBase {
 
     private final Player player;
-    private final CloudPermissionsManagement permissionsManagement;
+    private final IPermissionManagement permissionsManagement;
 
-    public NukkitCloudNetCloudPermissionsPermissible(Player player, CloudPermissionsManagement permissionsManagement) {
+    public NukkitCloudNetCloudPermissionsPermissible(Player player, IPermissionManagement permissionsManagement) {
         super(player);
 
         this.player = player;

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPermissible.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPermissible.java
@@ -66,7 +66,7 @@ public final class NukkitCloudNetCloudPermissionsPermissible extends Permissible
         }
 
         IPermissionUser permissionUser = this.permissionsManagement.getUser(this.player.getUniqueId());
-        return permissionUser != null && this.permissionsManagement.hasPlayerPermission(permissionUser, inName);
+        return permissionUser != null && this.permissionsManagement.hasPermission(permissionUser, inName);
     }
 
     public Player getPlayer() {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/NukkitCloudNetCloudPermissionsPlugin.java
@@ -5,6 +5,7 @@ import cn.nukkit.Server;
 import cn.nukkit.plugin.PluginBase;
 import com.google.common.base.Preconditions;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
+import de.dytanic.cloudnet.driver.permission.CachedPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
 import de.dytanic.cloudnet.ext.cloudperms.nukkit.listener.NukkitCloudNetCloudPermissionsPlayerListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
@@ -13,7 +14,7 @@ import java.lang.reflect.Field;
 
 public final class NukkitCloudNetCloudPermissionsPlugin extends PluginBase {
 
-    private CloudPermissionsManagement permissionsManagement;
+    private CachedPermissionManagement permissionsManagement;
 
     @Override
     public void onEnable() {

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/listener/NukkitCloudNetCloudPermissionsPlayerListener.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/nukkit/listener/NukkitCloudNetCloudPermissionsPlayerListener.java
@@ -5,17 +5,17 @@ import cn.nukkit.event.EventHandler;
 import cn.nukkit.event.Listener;
 import cn.nukkit.event.player.PlayerLoginEvent;
 import cn.nukkit.event.player.PlayerQuitEvent;
+import de.dytanic.cloudnet.driver.permission.CachedPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsHelper;
-import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
 import de.dytanic.cloudnet.ext.cloudperms.nukkit.NukkitCloudNetCloudPermissionsPlugin;
 
 public final class NukkitCloudNetCloudPermissionsPlayerListener implements Listener {
 
     private final NukkitCloudNetCloudPermissionsPlugin plugin;
 
-    private final CloudPermissionsManagement permissionsManagement;
+    private final CachedPermissionManagement permissionsManagement;
 
-    public NukkitCloudNetCloudPermissionsPlayerListener(NukkitCloudNetCloudPermissionsPlugin plugin, CloudPermissionsManagement permissionsManagement) {
+    public NukkitCloudNetCloudPermissionsPlayerListener(NukkitCloudNetCloudPermissionsPlugin plugin, CachedPermissionManagement permissionsManagement) {
         this.permissionsManagement = permissionsManagement;
         this.plugin = plugin;
     }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionFunction.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionFunction.java
@@ -2,17 +2,17 @@ package de.dytanic.cloudnet.ext.cloudperms.velocity;
 
 import com.velocitypowered.api.permission.PermissionFunction;
 import com.velocitypowered.api.permission.Tristate;
+import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
-import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
 
 import java.util.UUID;
 
 public final class VelocityCloudNetCloudPermissionsPermissionFunction implements PermissionFunction {
 
     private final UUID uniqueId;
-    private final CloudPermissionsManagement permissionsManagement;
+    private final IPermissionManagement permissionsManagement;
 
-    public VelocityCloudNetCloudPermissionsPermissionFunction(UUID uniqueId, CloudPermissionsManagement permissionsManagement) {
+    public VelocityCloudNetCloudPermissionsPermissionFunction(UUID uniqueId, IPermissionManagement permissionsManagement) {
         this.uniqueId = uniqueId;
         this.permissionsManagement = permissionsManagement;
     }

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionFunction.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionFunction.java
@@ -24,7 +24,7 @@ public final class VelocityCloudNetCloudPermissionsPermissionFunction implements
         }
 
         IPermissionUser permissionUser = this.permissionsManagement.getUser(this.uniqueId);
-        return (permissionUser != null && this.permissionsManagement.hasPlayerPermission(permissionUser, permission)) ?
+        return (permissionUser != null && this.permissionsManagement.hasPermission(permissionUser, permission)) ?
                 Tristate.TRUE : Tristate.FALSE;
     }
 

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionProvider.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionProvider.java
@@ -4,14 +4,14 @@ import com.velocitypowered.api.permission.PermissionFunction;
 import com.velocitypowered.api.permission.PermissionProvider;
 import com.velocitypowered.api.permission.PermissionSubject;
 import com.velocitypowered.api.proxy.Player;
-import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
+import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
 import org.checkerframework.checker.optional.qual.MaybePresent;
 
 public class VelocityCloudNetCloudPermissionsPermissionProvider implements PermissionProvider {
 
-    private final CloudPermissionsManagement permissionsManagement;
+    private final IPermissionManagement permissionsManagement;
 
-    public VelocityCloudNetCloudPermissionsPermissionProvider(CloudPermissionsManagement permissionsManagement) {
+    public VelocityCloudNetCloudPermissionsPermissionProvider(IPermissionManagement permissionsManagement) {
         this.permissionsManagement = permissionsManagement;
     }
 

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
@@ -10,6 +10,7 @@ import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
+import de.dytanic.cloudnet.driver.permission.CachedPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
 import de.dytanic.cloudnet.ext.cloudperms.velocity.listener.VelocityCloudNetCloudPermissionsPlayerListener;
 import de.dytanic.cloudnet.wrapper.Wrapper;
@@ -21,7 +22,7 @@ public final class VelocityCloudNetCloudPermissionsPlugin {
 
     private final ProxyServer proxyServer;
 
-    private CloudPermissionsManagement permissionsManagement;
+    private CachedPermissionManagement permissionsManagement;
 
     private PermissionProvider permissionProvider;
 

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/listener/VelocityCloudNetCloudPermissionsPlayerListener.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/listener/VelocityCloudNetCloudPermissionsPlayerListener.java
@@ -7,17 +7,17 @@ import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.LoginEvent;
 import com.velocitypowered.api.event.permission.PermissionsSetupEvent;
 import com.velocitypowered.api.permission.PermissionProvider;
+import de.dytanic.cloudnet.driver.permission.CachedPermissionManagement;
 import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsHelper;
-import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
 import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
 
 public final class VelocityCloudNetCloudPermissionsPlayerListener {
 
-    private final CloudPermissionsManagement permissionsManagement;
+    private final CachedPermissionManagement permissionsManagement;
 
     private final PermissionProvider permissionProvider;
 
-    public VelocityCloudNetCloudPermissionsPlayerListener(CloudPermissionsManagement permissionsManagement, PermissionProvider permissionProvider) {
+    public VelocityCloudNetCloudPermissionsPlayerListener(CachedPermissionManagement permissionsManagement, PermissionProvider permissionProvider) {
         this.permissionsManagement = permissionsManagement;
         this.permissionProvider = permissionProvider;
     }

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/PermissionCacheListener.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/PermissionCacheListener.java
@@ -1,16 +1,17 @@
-package de.dytanic.cloudnet.ext.cloudperms.listener;
+package de.dytanic.cloudnet.wrapper;
 
 
 import de.dytanic.cloudnet.driver.event.EventListener;
 import de.dytanic.cloudnet.driver.event.events.permission.*;
 import de.dytanic.cloudnet.driver.permission.IPermissionGroup;
-import de.dytanic.cloudnet.ext.cloudperms.CloudPermissionsManagement;
+import org.jetbrains.annotations.ApiStatus;
 
-public final class PermissionsUpdateListener {
+@ApiStatus.Internal
+public final class PermissionCacheListener {
 
-    private final CloudPermissionsManagement permissionsManagement;
+    private final WrapperPermissionManagement permissionsManagement;
 
-    public PermissionsUpdateListener(CloudPermissionsManagement permissionsManagement) {
+    public PermissionCacheListener(WrapperPermissionManagement permissionsManagement) {
         this.permissionsManagement = permissionsManagement;
     }
 /*

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -136,7 +136,7 @@ public final class Wrapper extends CloudNetDriver {
         }
         super.packetQueryProvider = new PacketQueryProvider(this.networkClient);
 
-        super.setPermissionManagement(new WrapperPermissionManagement(super.packetQueryProvider));
+        super.setPermissionManagement(new WrapperPermissionManagement(super.packetQueryProvider, this));
 
         //- Packet client registry
         this.networkClient.getPacketRegistry().addListener(PacketConstants.INTERNAL_EVENTBUS_CHANNEL, new PacketServerServiceInfoPublisherListener());

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -180,6 +180,8 @@ public final class Wrapper extends CloudNetDriver {
 
         this.networkClient.getPacketRegistry().removeListener(PacketConstants.INTERNAL_AUTHORIZATION_CHANNEL);
 
+        this.permissionManagement.init();
+
         if (!listener.isResult()) {
             throw new IllegalStateException("authorization response is: denied");
         }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/CloudNet.java
@@ -255,6 +255,7 @@ public final class CloudNet extends CloudNetDriver {
         }
 
         NodePermissionManagement permissionManagement = new DefaultDatabasePermissionManagement(this::getDatabaseProvider);
+        permissionManagement.init();
         permissionManagement.setPermissionManagementHandler(new DefaultPermissionManagementHandler());
         this.permissionManagement = permissionManagement;
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/permission/ClusterSynchronizedPermissionManagement.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/permission/ClusterSynchronizedPermissionManagement.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import de.dytanic.cloudnet.common.concurrent.CompletableTask;
 import de.dytanic.cloudnet.common.concurrent.ITask;
 import de.dytanic.cloudnet.common.concurrent.NullCompletableTask;
+import de.dytanic.cloudnet.driver.permission.DefaultPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionGroup;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
 import org.jetbrains.annotations.NotNull;
@@ -12,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 
-public abstract class ClusterSynchronizedPermissionManagement implements NodePermissionManagement {
+public abstract class ClusterSynchronizedPermissionManagement extends DefaultPermissionManagement implements NodePermissionManagement {
     @Override
     public @NotNull ITask<IPermissionUser> addUserAsync(@NotNull IPermissionUser permissionUser) {
         Preconditions.checkNotNull(permissionUser);

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagement.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagement.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
 public class DefaultDatabasePermissionManagement extends ClusterSynchronizedPermissionManagement
-        implements DefaultSynchronizedPermissionManagement, DefaultPermissionManagement {
+        implements DefaultSynchronizedPermissionManagement {
 
     private static final String DATABASE_USERS_NAME = "cloudnet_permission_users";
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagement.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagement.java
@@ -30,7 +30,10 @@ public class DefaultDatabasePermissionManagement extends ClusterSynchronizedPerm
 
     public DefaultDatabasePermissionManagement(Callable<AbstractDatabaseProvider> databaseProviderCallable) {
         this.databaseProviderCallable = databaseProviderCallable;
+    }
 
+    @Override
+    public void init() {
         this.file.getParentFile().mkdirs();
         this.loadGroups();
     }

--- a/cloudnet/src/test/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagementTest.java
+++ b/cloudnet/src/test/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagementTest.java
@@ -30,6 +30,7 @@ public class DefaultDatabasePermissionManagementTest {
         System.setProperty("cloudnet.permissions.json.path", "build/group_permissions.json");
 
         IPermissionManagement permissionManagement = new DefaultDatabasePermissionManagement(() -> databaseProvider);
+        permissionManagement.init();
 
         IPermissionUser permissionUser = permissionManagement.addUser(userName, "1234", (byte) 5);
         Assert.assertNotNull(permissionUser);


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Previously the CloudPermissionsManagement#hasPlayerPermission method has checked the permissions of a user with every group on the current service, due to some API changes, this method is no more accessible for users. Now the wrapper itself handles the group permission checks in PermissionManagement#hasPermission.