### PR TITLE
Add a method to force update ServiceInfoSnapshots on other services

### DIFF
--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/provider/service/SpecificCloudServiceProvider.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/provider/service/SpecificCloudServiceProvider.java
@@ -22,6 +22,16 @@ public interface SpecificCloudServiceProvider {
     ServiceInfoSnapshot getServiceInfoSnapshot();
 
     /**
+     * Forces this service to update its {@link ServiceInfoSnapshot}, instead of {@link #getServiceInfoSnapshot()}, this method
+     * always returns the current snapshot with the current e.g. CPU and memory usage.
+     *
+     * @return the current info or {@code null} if the service is not connected
+     * @throws IllegalArgumentException if no uniqueId/name/serviceInfo was given on creating this provider
+     */
+    @Nullable
+    ServiceInfoSnapshot forceUpdateServiceInfo();
+
+    /**
      * Adds a service template to this service. This template won't be copied directly after adding it but when the service is prepared.
      *
      * @param serviceTemplate the template to be added to the list of templates of this service
@@ -137,6 +147,16 @@ public interface SpecificCloudServiceProvider {
      */
     @NotNull
     ITask<ServiceInfoSnapshot> getServiceInfoSnapshotAsync();
+
+    /**
+     * Forces this service to update its {@link ServiceInfoSnapshot}, instead of {@link #getServiceInfoSnapshot()}, this method
+     * always returns the current snapshot with the current e.g. CPU and memory usage.
+     *
+     * @return the current info or {@code null} if the service is not connected
+     * @throws IllegalArgumentException if no uniqueId/name/serviceInfo was given on creating this provider
+     */
+    @NotNull
+    ITask<ServiceInfoSnapshot> forceUpdateServiceInfoAsync();
 
     /**
      * Adds a service template to this service. This template won't be copied directly after adding it but when the service is prepared

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/Wrapper.java
@@ -44,6 +44,7 @@ import de.dytanic.cloudnet.wrapper.provider.WrapperServiceTaskProvider;
 import de.dytanic.cloudnet.wrapper.provider.service.WrapperCloudServiceFactory;
 import de.dytanic.cloudnet.wrapper.provider.service.WrapperGeneralCloudServiceProvider;
 import de.dytanic.cloudnet.wrapper.provider.service.WrapperSpecificCloudServiceProvider;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -145,6 +146,8 @@ public final class Wrapper extends CloudNetDriver {
         this.networkClient.getPacketRegistry().addListener(PacketConstants.INTERNAL_CLUSTER_CHANNEL, new PacketServerClusterNodeInfoUpdateListener());
 
         this.networkClient.getPacketRegistry().addListener(PacketConstants.INTERNAL_DEBUGGING_CHANNEL, new PacketServerSetGlobalLogLevelListener());
+
+        this.networkClient.getPacketRegistry().addListener(PacketConstants.INTERNAL_CALLABLE_CHANNEL, new PacketClientWrapperSyncListener());
         //-
 
         this.moduleProvider.setModuleDirectory(new File(".wrapper/modules"));
@@ -423,6 +426,20 @@ public final class Wrapper extends CloudNetDriver {
         );
     }
 
+    @ApiStatus.Internal
+    public ServiceInfoSnapshot configureServiceInfoSnapshot() {
+        ServiceInfoSnapshot serviceInfoSnapshot = this.createServiceInfoSnapshot();
+        this.configureServiceInfoSnapshot(serviceInfoSnapshot);
+        return serviceInfoSnapshot;
+    }
+
+    private void configureServiceInfoSnapshot(ServiceInfoSnapshot serviceInfoSnapshot) {
+        this.eventManager.callEvent(new ServiceInfoSnapshotConfigureEvent(serviceInfoSnapshot));
+
+        this.lastServiceInfoSnapShot = this.currentServiceInfoSnapshot;
+        this.currentServiceInfoSnapshot = serviceInfoSnapshot;
+    }
+
     /**
      * This method should be used to send the current ServiceInfoSnapshot and all subscribers on the network and to update their information.
      * It calls the ServiceInfoSnapshotConfigureEvent before send the update to the node.
@@ -435,10 +452,7 @@ public final class Wrapper extends CloudNetDriver {
 
     public synchronized void publishServiceInfoUpdate(@NotNull ServiceInfoSnapshot serviceInfoSnapshot) {
         if (this.currentServiceInfoSnapshot.getServiceId().equals(serviceInfoSnapshot.getServiceId())) {
-            this.eventManager.callEvent(new ServiceInfoSnapshotConfigureEvent(serviceInfoSnapshot));
-
-            this.lastServiceInfoSnapShot = this.currentServiceInfoSnapshot;
-            this.currentServiceInfoSnapshot = serviceInfoSnapshot;
+            this.configureServiceInfoSnapshot(serviceInfoSnapshot);
         }
 
         this.networkClient.sendPacket(new PacketClientServiceInfoUpdate(serviceInfoSnapshot));

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/network/listener/PacketClientWrapperSyncListener.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/network/listener/PacketClientWrapperSyncListener.java
@@ -1,0 +1,35 @@
+package de.dytanic.cloudnet.wrapper.network.listener;
+
+import de.dytanic.cloudnet.common.document.gson.JsonDocument;
+import de.dytanic.cloudnet.driver.network.INetworkChannel;
+import de.dytanic.cloudnet.driver.network.def.PacketConstants;
+import de.dytanic.cloudnet.driver.network.protocol.IPacket;
+import de.dytanic.cloudnet.driver.network.protocol.IPacketListener;
+import de.dytanic.cloudnet.driver.network.protocol.Packet;
+import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
+import de.dytanic.cloudnet.wrapper.Wrapper;
+
+import java.util.UUID;
+
+public class PacketClientWrapperSyncListener implements IPacketListener {
+    @Override
+    public void handle(INetworkChannel channel, IPacket packet) throws Exception {
+        if (packet.getHeader().contains(PacketConstants.SYNC_PACKET_ID_PROPERTY) && packet.getHeader().contains(PacketConstants.SYNC_PACKET_CHANNEL_PROPERTY) &&
+                packet.getHeader().getString(PacketConstants.SYNC_PACKET_CHANNEL_PROPERTY).equals("internal_wrapper_channel")) {
+            String id = packet.getHeader().getString(PacketConstants.SYNC_PACKET_ID_PROPERTY);
+            if ("update_service_info".equals(id)) {
+                ServiceInfoSnapshot serviceInfoSnapshot = Wrapper.getInstance().configureServiceInfoSnapshot();
+                this.sendResponse(channel, packet.getUniqueId(), JsonDocument.newDocument(serviceInfoSnapshot));
+            }
+        }
+    }
+
+    private void sendResponse(INetworkChannel channel, UUID uniqueId, JsonDocument header) {
+        this.sendResponse(channel, uniqueId, header, null);
+    }
+
+    private void sendResponse(INetworkChannel channel, UUID uniqueId, JsonDocument header, byte[] body) {
+        channel.sendPacket(new Packet(PacketConstants.INTERNAL_CALLABLE_CHANNEL, uniqueId, header, body));
+    }
+
+}

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/provider/service/WrapperSpecificCloudServiceProvider.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/provider/service/WrapperSpecificCloudServiceProvider.java
@@ -58,6 +58,11 @@ public class WrapperSpecificCloudServiceProvider implements SpecificCloudService
     }
 
     @Override
+    public @Nullable ServiceInfoSnapshot forceUpdateServiceInfo() {
+        return this.forceUpdateServiceInfoAsync().get(5, TimeUnit.SECONDS, null);
+    }
+
+    @Override
     @NotNull
     public ITask<ServiceInfoSnapshot> getServiceInfoSnapshotAsync() {
         if (this.serviceInfoSnapshot != null) {
@@ -70,6 +75,15 @@ public class WrapperSpecificCloudServiceProvider implements SpecificCloudService
             return this.wrapper.getCloudServiceProvider().getCloudServiceByNameAsync(this.name);
         }
         throw new IllegalArgumentException("Cannot get ServiceInfoSnapshot without uniqueId or name");
+    }
+
+    @Override
+    public @NotNull ITask<ServiceInfoSnapshot> forceUpdateServiceInfoAsync() {
+        return this.wrapper.getPacketQueryProvider().sendCallablePacketWithAsDriverSyncAPIWithNetworkConnector(
+                this.createDocumentWithUniqueIdAndName().append(PacketConstants.SYNC_PACKET_ID_PROPERTY, "force_update_service"),
+                null,
+                documentPair -> documentPair.getFirst().toInstanceOf(ServiceInfoSnapshot.class)
+        );
     }
 
     @Override

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/network/listener/PacketClientSyncAPIPacketListener.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/network/listener/PacketClientSyncAPIPacketListener.java
@@ -27,6 +27,11 @@ public final class PacketClientSyncAPIPacketListener implements IPacketListener 
         if (packet.getHeader().contains(PacketConstants.SYNC_PACKET_ID_PROPERTY) && packet.getHeader().contains(PacketConstants.SYNC_PACKET_CHANNEL_PROPERTY) &&
                 packet.getHeader().getString(PacketConstants.SYNC_PACKET_CHANNEL_PROPERTY).equals("cloudnet_driver_sync_api")) {
             switch (packet.getHeader().getString(PacketConstants.SYNC_PACKET_ID_PROPERTY)) {
+                case "force_update_service": {
+                    ServiceInfoSnapshot serviceInfoSnapshot = this.getCloudServiceProvider(packet.getHeader()).forceUpdateServiceInfo();
+                    this.sendResponse(channel, packet.getUniqueId(), JsonDocument.newDocument(serviceInfoSnapshot));
+                    break;
+                }
                 case "set_service_life_cycle":
                     this.getCloudServiceProvider(packet.getHeader()).setCloudServiceLifeCycle(packet.getHeader().get("lifeCycle", ServiceLifeCycle.class));
                     this.sendEmptyResponse(channel, packet.getUniqueId());

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudService.java
@@ -1,6 +1,9 @@
 package de.dytanic.cloudnet.service;
 
 import de.dytanic.cloudnet.CloudNet;
+import de.dytanic.cloudnet.common.concurrent.CompletedTask;
+import de.dytanic.cloudnet.common.concurrent.ITask;
+import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.event.events.service.CloudServiceInfoUpdateEvent;
 import de.dytanic.cloudnet.driver.network.INetworkChannel;
@@ -58,6 +61,23 @@ public interface ICloudService {
 
     @NotNull
     ServiceInfoSnapshot getLastServiceInfoSnapshot();
+
+    default ITask<ServiceInfoSnapshot> forceUpdateServiceInfoSnapshotAsync() {
+        if (this.getNetworkChannel() == null) {
+            return CompletedTask.create(null);
+        }
+
+        return CloudNetDriver.getInstance().getPacketQueryProvider().sendCallablePacket(
+                this.getNetworkChannel(),
+                "internal_wrapper_channel", "update_service_info",
+                JsonDocument.newDocument(),
+                document -> document.toInstanceOf(ServiceInfoSnapshot.class)
+        ).onComplete(serviceInfoSnapshot -> {
+            if (serviceInfoSnapshot != null) {
+                this.updateServiceInfoSnapshot(serviceInfoSnapshot);
+            }
+        });
+    }
 
     @Nullable
     Process getProcess();


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Adds the method `CloudServiceProvider#forceUpdateServiceInfo`.

### Related issues/discussions:

https://github.com/CloudNetService/CloudNet-v3/projects/2#card-38790243