### PR TITLE
Ignore ingame services for the auto-stop of the Smart Module

### DIFF
--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudServiceListener.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudServiceListener.java
@@ -1,7 +1,6 @@
 package de.dytanic.cloudnet.ext.smart.listener;
 
 import de.dytanic.cloudnet.CloudNet;
-import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.event.EventListener;
 import de.dytanic.cloudnet.driver.service.ServiceTask;
 import de.dytanic.cloudnet.event.service.CloudServiceCreateEvent;

--- a/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudServiceListener.java
+++ b/cloudnet-modules/cloudnet-smart/src/main/java/de/dytanic/cloudnet/ext/smart/listener/CloudServiceListener.java
@@ -1,11 +1,13 @@
 package de.dytanic.cloudnet.ext.smart.listener;
 
 import de.dytanic.cloudnet.CloudNet;
+import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.event.EventListener;
 import de.dytanic.cloudnet.driver.service.ServiceTask;
 import de.dytanic.cloudnet.event.service.CloudServiceCreateEvent;
 import de.dytanic.cloudnet.event.service.CloudServicePostDeleteEvent;
 import de.dytanic.cloudnet.event.service.CloudServicePostPrepareEvent;
+import de.dytanic.cloudnet.ext.bridge.BridgeServiceProperty;
 import de.dytanic.cloudnet.ext.smart.CloudNetServiceSmartProfile;
 import de.dytanic.cloudnet.ext.smart.CloudNetSmartModule;
 import de.dytanic.cloudnet.ext.smart.util.SmartServiceTaskConfig;
@@ -23,7 +25,8 @@ public final class CloudServiceListener {
         if (serviceTask != null && CloudNetSmartModule.getInstance().hasSmartServiceTaskConfig(serviceTask)) {
             SmartServiceTaskConfig smartTask = CloudNetSmartModule.getInstance().getSmartServiceTaskConfig(serviceTask);
             if (smartTask.getMaxServiceCount() > 0 &&
-                    CloudNet.getInstance().getCloudServiceProvider().getCloudServices(serviceTask.getName()).size() >= smartTask.getMaxServiceCount()) {
+                    CloudNet.getInstance().getCloudServiceProvider().getCloudServices(serviceTask.getName())
+                            .stream().filter(serviceInfoSnapshot -> !serviceInfoSnapshot.getProperty(BridgeServiceProperty.IS_IN_GAME).orElse(false)).count() >= smartTask.getMaxServiceCount()) {
                 event.setCancelled(true);
                 return;
             }


### PR DESCRIPTION

This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Ignore ingame services for the auto-stop of the Smart Module

### Documentation of test results:

No tests have been done so far.


### Related issues/discussions:

https://github.com/CloudNetService/CloudNet-v3/projects/2#card-39204647
