### PR TITLE
Discard packets from inactive connections

### DIFF
--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyPacketDecoder.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyPacketDecoder.java
@@ -20,6 +20,13 @@ final class NettyPacketDecoder extends ByteToMessageDecoder {
             return;
         }
 
+        // This weired null check is needed for the 'NettyPacketEncoderDecoderTest' which uses 'null'
+        // as 'ChannelHandlerContext' for testing reasons
+        if (ctx != null && !ctx.channel().isActive()) {
+            byteBuf.skipBytes(byteBuf.readableBytes());
+            return;
+        }
+
         try {
             ProtocolBuffer in = ProtocolBuffer.wrap(byteBuf);
 

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyPacketLengthDeserializer.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/network/netty/NettyPacketLengthDeserializer.java
@@ -15,6 +15,11 @@ public final class NettyPacketLengthDeserializer extends ByteToMessageDecoder {
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+        if (!ctx.channel().isActive()) {
+            in.skipBytes(in.readableBytes());
+            return;
+        }
+
         in.markReaderIndex();
         byte[] lengthBytes = new byte[5];
 


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

The basic problem is that CloudNet will still decode packets even if the channel they were sent from has been disconnected. Assuming Netty uses an initial recvbuf size of 1,024 bytes, we can stack 512 correctly framed but invalid packets (one byte for length, the other byte for packet ID). If we now send 512 packets over different connections that immediately disconnect the channel, netty will continue to try to decode the packets after the channel close - which will result in an error. Another scenario of unneeded but decoded packets is when a service sends a packet to the node but then disconnects. The channel is inactive, the service deleted but the packets sent are still decoded - which is useless and (if we believe [Aleksey Shipilёv](https://shipilev.net/blog/2014/exceptional-performance/)) very performance intensive (if it causes console errors).

So we skip reading packets from channels that are inactive to reduce the heap load of the unnecessary packets.

### Documentation of test results:

All tests passed successfully (as well as compiling and joining = triggering a service update)

### Related issues/discussions:

https://github.com/netty/netty/issues/10417
