### PR TITLE
Fixed NullPointerException if the serverinfo of the next filtered fallback isn't present

### DIFF
--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetHelper.java
@@ -75,8 +75,12 @@ public final class BungeeCloudNetHelper {
                         return CompletableFuture.completedFuture(false);
                     }
 
-                    CompletableFuture<Boolean> future = new CompletableFuture<>();
                     ServerInfo serverInfo = ProxyServer.getInstance().getServerInfo(event.getFallbackName());
+                    if (serverInfo == null) {
+                        return CompletableFuture.completedFuture(false);
+                    }
+
+                    CompletableFuture<Boolean> future = new CompletableFuture<>();
                     player.connect(serverInfo, (result, error) -> future.complete(result && error == null));
                     return future;
                 }


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

As reported on the discord of @SuprexDE#3700, an error occurs when filtering a fallback for the player who is not (yet) registered in BungeeCord.

### Documentation of test results:

No runtime tests were performed, but the changes should be so clear that none should be required. If so, I can do that.

### Related issues/discussions:

https://paste.devin.id/oyeqecusay.bash on  Debian 10 (Java 8), CloudNet Hurricane 3.4.0-SNAPSHOT-ba93046
