### PR TITLE
Fixed that unregistered services are still cached after unregister/stop

### DIFF
--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/listener/BungeeCloudNetListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/listener/BungeeCloudNetListener.java
@@ -43,8 +43,8 @@ public final class BungeeCloudNetListener {
     @EventListener
     public void handle(CloudServiceStopEvent event) {
         if (BungeeCloudNetHelper.isServiceEnvironmentTypeProvidedForBungeeCord(event.getServiceInfo())) {
-            String name = event.getServiceInfo().getServiceId().getName();
-            ProxyServer.getInstance().getServers().remove(name);
+            ProxyServer.getInstance().getServers().remove(event.getServiceInfo().getName());
+            BridgeProxyHelper.cacheServiceInfoSnapshot(event.getServiceInfo());
         }
 
         this.bungeeCall(new BungeeCloudServiceStopEvent(event.getServiceInfo()));
@@ -89,7 +89,7 @@ public final class BungeeCloudNetListener {
     @EventListener
     public void handle(CloudServiceUnregisterEvent event) {
         if (BungeeCloudNetHelper.isServiceEnvironmentTypeProvidedForBungeeCord(event.getServiceInfo())) {
-            BridgeProxyHelper.cacheServiceInfoSnapshot(event.getServiceInfo());
+            BridgeProxyHelper.removeCachedServiceInfoSnapshot(event.getServiceInfo());
         }
 
         this.bungeeCall(new BungeeCloudServiceUnregisterEvent(event.getServiceInfo()));

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxy/BridgeProxyHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxy/BridgeProxyHelper.java
@@ -42,6 +42,10 @@ public class BridgeProxyHelper {
         SERVICE_CACHE.put(serviceInfoSnapshot.getName(), serviceInfoSnapshot);
     }
 
+    public static void removeCachedServiceInfoSnapshot(ServiceInfoSnapshot serviceInfoSnapshot) {
+        SERVICE_CACHE.remove(serviceInfoSnapshot.getName());
+    }
+
     public static void handleConnectionFailed(UUID uniqueId, String serviceName) {
         if (PROFILES.containsKey(uniqueId)) {
             PROFILES.get(uniqueId).addKick(serviceName);
@@ -83,7 +87,7 @@ public class BridgeProxyHelper {
 
                 .flatMap(proxyFallback -> getCachedServiceInfoSnapshots(proxyFallback.getTask()).map(serviceInfoSnapshot -> new PlayerFallback(proxyFallback.getPriority(), serviceInfoSnapshot)))
 
-                .filter(fallback -> fallback.getTarget().getProperty(BridgeServiceProperty.IS_ONLINE).orElse(false))
+                .filter(fallback -> fallback.getTarget().isConnected() && fallback.getTarget().getProperty(BridgeServiceProperty.IS_ONLINE).orElse(false))
                 .filter(fallback -> !fallback.getTarget().getName().equals(currentServer))
                 .filter(fallback -> profile.canConnect(fallback.getTarget()))
 

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityCloudNetListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityCloudNetListener.java
@@ -1,5 +1,6 @@
 package de.dytanic.cloudnet.ext.bridge.velocity.listener;
 
+import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import de.dytanic.cloudnet.driver.event.EventListener;
 import de.dytanic.cloudnet.driver.event.events.channel.ChannelMessageReceiveEvent;
@@ -45,9 +46,9 @@ public final class VelocityCloudNetListener {
         if (VelocityCloudNetHelper.isServiceEnvironmentTypeProvidedForVelocity(event.getServiceInfo())) {
             String name = event.getServiceInfo().getServiceId().getName();
 
-            if (VelocityCloudNetHelper.getProxyServer().getServer(name).isPresent()) {
-                VelocityCloudNetHelper.getProxyServer().unregisterServer(VelocityCloudNetHelper.getProxyServer().getServer(name).get().getServerInfo());
-            }
+            VelocityCloudNetHelper.getProxyServer().getServer(name)
+                    .map(RegisteredServer::getServerInfo)
+                    .ifPresent(VelocityCloudNetHelper.getProxyServer()::unregisterServer);
 
             VelocityCloudNetHelper.removeServerToVelocityPrioritySystemConfiguration(event.getServiceInfo(), name);
             BridgeProxyHelper.cacheServiceInfoSnapshot(event.getServiceInfo());
@@ -95,7 +96,7 @@ public final class VelocityCloudNetListener {
     @EventListener
     public void handle(CloudServiceUnregisterEvent event) {
         if (VelocityCloudNetHelper.isServiceEnvironmentTypeProvidedForVelocity(event.getServiceInfo())) {
-            BridgeProxyHelper.cacheServiceInfoSnapshot(event.getServiceInfo());
+            BridgeProxyHelper.removeCachedServiceInfoSnapshot(event.getServiceInfo());
         }
 
         this.velocityCall(new VelocityCloudServiceUnregisterEvent(event.getServiceInfo()));


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

With #305 I fixed that you cannot connect to servers that are not registered in the proxy. I and @derrop noticed that the ServiceInfoSnapshots were not removed from the cache after the service was unregistered.
