### PR TITLE
Fix bug reported on Discord Server

### DIFF
--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/NukkitCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/nukkit/NukkitCloudNetHelper.java
@@ -152,7 +152,7 @@ public final class NukkitCloudNetHelper extends BridgeServerHelper {
                 null,
                 player.getHealth(),
                 player.getMaxHealth(),
-                player.getFoodData().getLevel(),
+                player.getFoodData() == null ? -1 : player.getFoodData().getLevel(),
                 player.getExperienceLevel(),
                 worldPosition,
                 new HostAndPort(player.getAddress(), player.getPort()),


### PR DESCRIPTION
Reported by: SuprexDE#3700 

CloudNet-Version: CloudNet Hurricane 3.4.0-SNAPSHOT-c55369b
Betriebssystem: Debian 10
Java-Version: 8
Multi-Root: Ja
Bereich: Konsole
Beleg: https://paste.devin.id/ebukequjol.cs
Fehlerbeschreibung: Wenn der Nukkit-Server auf der Whitelist ist oder der Server ist voll, dann kommt dieser Fehler.

The error occurred because the player is disconnected at login, but the player's food data is only loaded after login.