### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "05:00"
+    open-pull-requests-limit: 20
+    target-branch: development


### PR DESCRIPTION
The dependabot.yml has to be in the base branch for the DependaBot to work