### PR TITLE
Added RaspberryPI support

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
@@ -47,7 +47,9 @@ public final class JLine3Console implements IConsole {
 
     public JLine3Console() throws Exception {
         System.setProperty("library.jansi.version", "CloudNET");
-        AnsiConsole.systemInstall();
+        if (!System.getProperty("os.version").contains("raspi")) {
+            AnsiConsole.systemInstall();
+        }
 
         this.terminal = TerminalBuilder.builder().system(true).encoding(StandardCharsets.UTF_8).build();
         this.lineReader = new InternalLineReaderBuilder(this.terminal)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Added RaspberryPI support

### Documentation of test results:

Tested CloudNet on RaspberryPI, located error --> de.dytanic.cloudnet.console.JLine2Console.<init> AnsiConsole#systemInstall
Now the CloudNet checks if the OS is a raspberryPi and just if this is the case the command is executed.

### Related issues/discussions:

https://discordapp.com/channels/325362837184577536/553304283857289268/765208993030209556