### PR TITLE
Set the tab header & footer to null if there is no configuration

### DIFF
--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeSyncProxyManagement.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeSyncProxyManagement.java
@@ -44,12 +44,12 @@ public class BungeeSyncProxyManagement extends AbstractSyncProxyManagement {
 
     public void updateTabList(ProxiedPlayer proxiedPlayer) {
         proxiedPlayer.setTabHeader(
-                this.asComponents(proxiedPlayer, super.tabListHeader),
-                this.asComponents(proxiedPlayer, super.tabListFooter)
+                this.getTabValues(proxiedPlayer, super.tabListHeader),
+                this.getTabValues(proxiedPlayer, super.tabListFooter)
         );
     }
 
-    private BaseComponent[] asComponents(ProxiedPlayer proxiedPlayer, String value) {
+    private BaseComponent[] getTabValues(ProxiedPlayer proxiedPlayer, String value) {
         return value == null ? null : TextComponent.fromLegacyText(this.replaceTabListItem(proxiedPlayer, ChatColor.translateAlternateColorCodes('&', value)));
     }
 

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeSyncProxyManagement.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeSyncProxyManagement.java
@@ -9,6 +9,7 @@ import de.dytanic.cloudnet.ext.syncproxy.configuration.SyncProxyProxyLoginConfig
 import de.dytanic.cloudnet.ext.syncproxy.configuration.SyncProxyTabList;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
@@ -43,15 +44,13 @@ public class BungeeSyncProxyManagement extends AbstractSyncProxyManagement {
 
     public void updateTabList(ProxiedPlayer proxiedPlayer) {
         proxiedPlayer.setTabHeader(
-                TextComponent.fromLegacyText(super.tabListHeader != null ?
-                        this.replaceTabListItem(proxiedPlayer, ChatColor.translateAlternateColorCodes('&', super.tabListHeader))
-                        : null
-                ),
-                TextComponent.fromLegacyText(super.tabListFooter != null ?
-                        this.replaceTabListItem(proxiedPlayer, ChatColor.translateAlternateColorCodes('&', super.tabListFooter))
-                        : null
-                )
+                this.asComponents(proxiedPlayer, super.tabListHeader),
+                this.asComponents(proxiedPlayer, super.tabListFooter)
         );
+    }
+
+    private BaseComponent[] asComponents(ProxiedPlayer proxiedPlayer, String value) {
+        return value == null ? null : TextComponent.fromLegacyText(this.replaceTabListItem(proxiedPlayer, ChatColor.translateAlternateColorCodes('&', value)));
     }
 
     private String replaceTabListItem(ProxiedPlayer proxiedPlayer, String input) {

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeSyncProxyManagement.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeSyncProxyManagement.java
@@ -43,6 +43,9 @@ public class BungeeSyncProxyManagement extends AbstractSyncProxyManagement {
     }
 
     public void updateTabList(ProxiedPlayer proxiedPlayer) {
+        if(super.tabListHeader == null && super.tabListFooter == null) {
+            return;
+        }
         proxiedPlayer.setTabHeader(
                 this.getTabValues(proxiedPlayer, super.tabListHeader),
                 this.getTabValues(proxiedPlayer, super.tabListFooter)

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeSyncProxyManagement.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/bungee/BungeeSyncProxyManagement.java
@@ -45,11 +45,11 @@ public class BungeeSyncProxyManagement extends AbstractSyncProxyManagement {
         proxiedPlayer.setTabHeader(
                 TextComponent.fromLegacyText(super.tabListHeader != null ?
                         this.replaceTabListItem(proxiedPlayer, ChatColor.translateAlternateColorCodes('&', super.tabListHeader))
-                        : ""
+                        : null
                 ),
                 TextComponent.fromLegacyText(super.tabListFooter != null ?
                         this.replaceTabListItem(proxiedPlayer, ChatColor.translateAlternateColorCodes('&', super.tabListFooter))
-                        : ""
+                        : null
                 )
         );
     }

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/velocity/VelocitySyncProxyManagement.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/velocity/VelocitySyncProxyManagement.java
@@ -8,7 +8,9 @@ import de.dytanic.cloudnet.ext.bridge.proxy.BridgeProxyHelper;
 import de.dytanic.cloudnet.ext.syncproxy.AbstractSyncProxyManagement;
 import de.dytanic.cloudnet.ext.syncproxy.configuration.SyncProxyConfiguration;
 import de.dytanic.cloudnet.ext.syncproxy.configuration.SyncProxyTabList;
+import net.kyori.text.Component;
 import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
+import net.md_5.bungee.api.ChatColor;
 
 import java.util.concurrent.TimeUnit;
 
@@ -41,10 +43,17 @@ public class VelocitySyncProxyManagement extends AbstractSyncProxyManagement {
     }
 
     public void updateTabList(Player player) {
+        if(super.tabListHeader == null && super.tabListFooter == null) {
+            return;
+        }
         player.getTabList().setHeaderAndFooter(
-                LegacyComponentSerializer.legacyLinking().deserialize(super.tabListHeader != null ? this.replaceTabListItem(player, super.tabListHeader) : ""),
-                LegacyComponentSerializer.legacyLinking().deserialize(super.tabListFooter != null ? this.replaceTabListItem(player, super.tabListFooter) : "")
+                this.getTabValue(player, super.tabListHeader),
+                this.getTabValue(player, super.tabListFooter)
         );
+    }
+
+    private Component getTabValue(Player player, String value) {
+        return value == null ? null : LegacyComponentSerializer.legacyLinking().deserialize(this.replaceTabListItem(player, ChatColor.translateAlternateColorCodes('&', value)));
     }
 
     private String replaceTabListItem(Player player, String input) {

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/velocity/VelocitySyncProxyManagement.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/velocity/VelocitySyncProxyManagement.java
@@ -10,7 +10,6 @@ import de.dytanic.cloudnet.ext.syncproxy.configuration.SyncProxyConfiguration;
 import de.dytanic.cloudnet.ext.syncproxy.configuration.SyncProxyTabList;
 import net.kyori.text.Component;
 import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
-import net.md_5.bungee.api.ChatColor;
 
 import java.util.concurrent.TimeUnit;
 
@@ -53,7 +52,7 @@ public class VelocitySyncProxyManagement extends AbstractSyncProxyManagement {
     }
 
     private Component getTabValue(Player player, String value) {
-        return value == null ? null : LegacyComponentSerializer.legacyLinking().deserialize(this.replaceTabListItem(player, ChatColor.translateAlternateColorCodes('&', value)));
+        return value == null ? null : LegacyComponentSerializer.legacyLinking().deserialize(this.replaceTabListItem(player, value));
     }
 
     private String replaceTabListItem(Player player, String input) {


### PR DESCRIPTION


This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

The tablist header & footer are now set to null instead of an empty string

### Documentation of test results:

https://imgur.com/a/5IeGqL3
Due to this change the tablist is now like in vanilla

### Related issues/discussions:

Fixes #365 
