### PR TITLE
Add server group specific fallbacks to bridge

### DIFF
--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
@@ -47,7 +47,7 @@ public class ProxyFallback implements Comparable<ProxyFallback> {
     }
 
     public Collection<String> getAvailableOnGroups() {
-        return availableOnGroups;
+        return this.availableOnGroups;
     }
 
     public void setAvailableOnGroups(Collection<String> availableOnGroups) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/ProxyFallback.java
@@ -3,11 +3,17 @@ package de.dytanic.cloudnet.ext.bridge;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 @ToString
 @EqualsAndHashCode
 public class ProxyFallback implements Comparable<ProxyFallback> {
 
     protected String task, permission;
+
+    protected Collection<String> availableOnGroups = new ArrayList<>();
+
     private int priority;
 
     public ProxyFallback(String task, String permission, int priority) {
@@ -38,6 +44,14 @@ public class ProxyFallback implements Comparable<ProxyFallback> {
 
     public void setPermission(String permission) {
         this.permission = permission;
+    }
+
+    public Collection<String> getAvailableOnGroups() {
+        return availableOnGroups;
+    }
+
+    public void setAvailableOnGroups(Collection<String> availableOnGroups) {
+        this.availableOnGroups = availableOnGroups;
     }
 
     public int getPriority() {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetHelper.java
@@ -45,15 +45,19 @@ public final class BungeeCloudNetHelper {
     }
 
     public static boolean isOnMatchingFallbackInstance(ProxiedPlayer player) {
-        ServerInfo currentServer = player.getServer() == null ? null : player.getServer().getInfo();
+        String currentServer = player.getServer() == null ? null : player.getServer().getInfo().getName();
 
         if (currentServer != null) {
-            return BridgeProxyHelper.filterPlayerFallbacks(
-                    player.getUniqueId(),
-                    currentServer.getName(),
-                    player::hasPermission
-            ).anyMatch(proxyFallback ->
-                    proxyFallback.getTask().equals(BridgeProxyHelper.getCachedServiceInfoSnapshot(currentServer.getName()).getServiceId().getTaskName()));
+            ServiceInfoSnapshot currentService = BridgeProxyHelper.getCachedServiceInfoSnapshot(currentServer);
+
+            if (currentService != null) {
+                return BridgeProxyHelper.filterPlayerFallbacks(
+                        player.getUniqueId(),
+                        currentServer,
+                        player::hasPermission
+                ).anyMatch(proxyFallback ->
+                        proxyFallback.getTask().equals(currentService.getServiceId().getTaskName()));
+            }
         }
 
         return false;

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/BungeeCloudNetHelper.java
@@ -44,8 +44,19 @@ public final class BungeeCloudNetHelper {
         return lastOnlineCount;
     }
 
-    public static boolean isOnAFallbackInstance(ProxiedPlayer proxiedPlayer) {
-        return proxiedPlayer.getServer() != null && isFallbackServer(proxiedPlayer.getServer().getInfo());
+    public static boolean isOnMatchingFallbackInstance(ProxiedPlayer player) {
+        ServerInfo currentServer = player.getServer() == null ? null : player.getServer().getInfo();
+
+        if (currentServer != null) {
+            return BridgeProxyHelper.filterPlayerFallbacks(
+                    player.getUniqueId(),
+                    currentServer.getName(),
+                    player::hasPermission
+            ).anyMatch(proxyFallback ->
+                    proxyFallback.getTask().equals(BridgeProxyHelper.getCachedServiceInfoSnapshot(currentServer.getName()).getServiceId().getTaskName()));
+        }
+
+        return false;
     }
 
     public static boolean isFallbackServer(ServerInfo serverInfo) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/command/CommandHub.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bungee/command/CommandHub.java
@@ -27,7 +27,7 @@ public final class CommandHub extends Command {
 
         ProxiedPlayer proxiedPlayer = (ProxiedPlayer) sender;
 
-        if (BungeeCloudNetHelper.isOnAFallbackInstance(proxiedPlayer)) {
+        if (BungeeCloudNetHelper.isOnMatchingFallbackInstance(proxiedPlayer)) {
             sender.sendMessage(TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', BridgeConfigurationProvider.load().getMessages().get("command-hub-already-in-hub"))));
             return;
         }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxy/BridgeProxyHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/proxy/BridgeProxyHelper.java
@@ -34,15 +34,15 @@ public class BridgeProxyHelper {
                 .filter(serviceInfoSnapshot -> serviceInfoSnapshot.getServiceId().getTaskName().equals(task));
     }
 
-    public static ServiceInfoSnapshot getCachedServiceInfoSnapshot(String name) {
+    public static ServiceInfoSnapshot getCachedServiceInfoSnapshot(@NotNull String name) {
         return SERVICE_CACHE.get(name);
     }
 
-    public static void cacheServiceInfoSnapshot(ServiceInfoSnapshot serviceInfoSnapshot) {
+    public static void cacheServiceInfoSnapshot(@NotNull ServiceInfoSnapshot serviceInfoSnapshot) {
         SERVICE_CACHE.put(serviceInfoSnapshot.getName(), serviceInfoSnapshot);
     }
 
-    public static void removeCachedServiceInfoSnapshot(ServiceInfoSnapshot serviceInfoSnapshot) {
+    public static void removeCachedServiceInfoSnapshot(@NotNull ServiceInfoSnapshot serviceInfoSnapshot) {
         SERVICE_CACHE.remove(serviceInfoSnapshot.getName());
     }
 
@@ -80,14 +80,14 @@ public class BridgeProxyHelper {
     }
 
     public static Stream<ProxyFallback> filterPlayerFallbacks(@NotNull UUID uniqueId, @Nullable String currentServer, @NotNull Predicate<String> permissionTester) {
-        ServiceInfoSnapshot playerService = currentServer == null ? null : SERVICE_CACHE.get(currentServer);
-        Collection<String> playerServiceGroups = playerService == null ? new ArrayList<>() : Arrays.asList(playerService.getConfiguration().getGroups());
+        ServiceInfoSnapshot currentService = currentServer == null ? null : SERVICE_CACHE.get(currentServer);
+        Collection<String> serviceGroups = currentService == null ? new ArrayList<>() : Arrays.asList(currentService.getConfiguration().getGroups());
 
         return getFallbacks()
                 .filter(proxyFallback -> proxyFallback.getPermission() == null || permissionTester.test(proxyFallback.getPermission()))
                 .filter(proxyFallback -> proxyFallback.getAvailableOnGroups() == null
                         || proxyFallback.getAvailableOnGroups().isEmpty()
-                        || proxyFallback.getAvailableOnGroups().stream().anyMatch(playerServiceGroups::contains));
+                        || proxyFallback.getAvailableOnGroups().stream().anyMatch(serviceGroups::contains));
     }
 
     public static Optional<ServiceInfoSnapshot> getNextFallback(@NotNull UUID uniqueId, @Nullable String currentServer, @NotNull Predicate<String> permissionTester) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
@@ -143,8 +143,19 @@ public final class VelocityCloudNetHelper {
         return serviceInfoSnapshot.getServiceId().getEnvironment().isMinecraftJavaServer();
     }
 
-    public static boolean isOnAFallbackInstance(Player player) {
-        return player.getCurrentServer().isPresent() && isFallbackServer(player.getCurrentServer().get().getServerInfo());
+    public static boolean isOnMatchingFallbackInstance(Player player) {
+        if (player.getCurrentServer().isPresent()) {
+            ServerInfo currentServer = player.getCurrentServer().get().getServerInfo();
+
+            return BridgeProxyHelper.filterPlayerFallbacks(
+                    player.getUniqueId(),
+                    player.getCurrentServer().map(ServerConnection::getServerInfo).map(ServerInfo::getName).orElse(null),
+                    player::hasPermission
+            ).anyMatch(proxyFallback ->
+                    proxyFallback.getTask().equals(BridgeProxyHelper.getCachedServiceInfoSnapshot(currentServer.getName()).getServiceId().getTaskName()));
+        }
+
+        return false;
     }
 
     public static boolean isFallbackServer(ServerInfo serverInfo) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
@@ -144,18 +144,16 @@ public final class VelocityCloudNetHelper {
     }
 
     public static boolean isOnMatchingFallbackInstance(Player player) {
-        if (player.getCurrentServer().isPresent()) {
-            ServerInfo currentServer = player.getCurrentServer().get().getServerInfo();
+        return player.getCurrentServer().map(serverConnection -> BridgeProxyHelper.filterPlayerFallbacks(
+                player.getUniqueId(),
+                serverConnection.getServerInfo().getName(),
+                player::hasPermission
+        ).anyMatch(proxyFallback ->
+                proxyFallback.getTask().equals(
+                        BridgeProxyHelper.getCachedServiceInfoSnapshot(serverConnection.getServerInfo().getName()).getServiceId().getTaskName()
+                )
+        )).orElse(false);
 
-            return BridgeProxyHelper.filterPlayerFallbacks(
-                    player.getUniqueId(),
-                    player.getCurrentServer().map(ServerConnection::getServerInfo).map(ServerInfo::getName).orElse(null),
-                    player::hasPermission
-            ).anyMatch(proxyFallback ->
-                    proxyFallback.getTask().equals(BridgeProxyHelper.getCachedServiceInfoSnapshot(currentServer.getName()).getServiceId().getTaskName()));
-        }
-
-        return false;
     }
 
     public static boolean isFallbackServer(ServerInfo serverInfo) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
@@ -144,16 +144,20 @@ public final class VelocityCloudNetHelper {
     }
 
     public static boolean isOnMatchingFallbackInstance(Player player) {
-        return player.getCurrentServer().map(serverConnection -> BridgeProxyHelper.filterPlayerFallbacks(
-                player.getUniqueId(),
-                serverConnection.getServerInfo().getName(),
-                player::hasPermission
-        ).anyMatch(proxyFallback ->
-                proxyFallback.getTask().equals(
-                        BridgeProxyHelper.getCachedServiceInfoSnapshot(serverConnection.getServerInfo().getName()).getServiceId().getTaskName()
-                )
-        )).orElse(false);
+        return player.getCurrentServer().map(serverConnection -> {
+            String currentServer = serverConnection.getServerInfo().getName();
+            ServiceInfoSnapshot currentService = BridgeProxyHelper.getCachedServiceInfoSnapshot(currentServer);
 
+            if (currentService == null) {
+                return false;
+            }
+
+            return BridgeProxyHelper.filterPlayerFallbacks(
+                    player.getUniqueId(),
+                    currentServer,
+                    player::hasPermission
+            ).anyMatch(proxyFallback -> proxyFallback.getTask().equals(currentService.getServiceId().getTaskName()));
+        }).orElse(false);
     }
 
     public static boolean isFallbackServer(ServerInfo serverInfo) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/command/CommandHub.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/command/CommandHub.java
@@ -21,7 +21,7 @@ public final class CommandHub implements Command {
 
         Player player = (Player) source;
 
-        if (VelocityCloudNetHelper.isOnAFallbackInstance(player)) {
+        if (VelocityCloudNetHelper.isOnMatchingFallbackInstance(player)) {
             source.sendMessage(LegacyComponentSerializer.legacyLinking().deserialize(BridgeConfigurationProvider.load().getMessages().get("command-hub-already-in-hub").replace("&", "§")));
             return;
         }


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:
Add a list of groups on which the fallback should be availabe to every proxy fallback. Leaving the list empty will make it a normal fallback which is available on all groups.

![image](https://user-images.githubusercontent.com/42209193/96899386-23e5ac80-1491-11eb-9b64-ebd9271d46b9.png)

In this example, "Impostor-Lobby" is only available as a fallback if the player is on a service with the "Impostor-Game" group.

### Related issues/discussions:
fixes #350 
