### PR TITLE
Fixed Endless kick Loop in Velocity Bridge Implementation

### DIFF
--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
@@ -90,10 +90,11 @@ public final class VelocityCloudNetHelper {
                 BridgeHelper.createOwnNetworkServiceInfo()
         );
     }
-    public static Optional<RegisteredServer> getNextFallback(Player player, RegisteredServer registeredServer) {
+
+    public static Optional<RegisteredServer> getNextFallback(Player player) {
         return BridgeProxyHelper.getNextFallback(
                 player.getUniqueId(),
-                registeredServer != null ? registeredServer.getServerInfo().getName() : null,
+                player.getCurrentServer().map(ServerConnection::getServerInfo).map(ServerInfo::getName).orElse(null),
                 player::hasPermission
         ).map(serviceInfoSnapshot -> new VelocityPlayerFallbackEvent(player, serviceInfoSnapshot, serviceInfoSnapshot.getName()))
                 .map(event -> proxyServer.getEventManager().fire(event))
@@ -107,11 +108,6 @@ public final class VelocityCloudNetHelper {
                 })
                 .map(VelocityPlayerFallbackEvent::getFallbackName)
                 .flatMap(proxyServer::getServer);
-    }
-
-    public static Optional<RegisteredServer> getNextFallback(Player player) {
-        return getNextFallback(player, player.getCurrentServer()
-                .map(ServerConnection::getServer).orElse(null));
     }
 
     public static CompletableFuture<ServiceInfoSnapshot> connectToFallback(Player player, String currentServer) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/VelocityCloudNetHelper.java
@@ -90,11 +90,10 @@ public final class VelocityCloudNetHelper {
                 BridgeHelper.createOwnNetworkServiceInfo()
         );
     }
-
-    public static Optional<RegisteredServer> getNextFallback(Player player) {
+    public static Optional<RegisteredServer> getNextFallback(Player player, RegisteredServer registeredServer) {
         return BridgeProxyHelper.getNextFallback(
                 player.getUniqueId(),
-                player.getCurrentServer().map(ServerConnection::getServerInfo).map(ServerInfo::getName).orElse(null),
+                registeredServer != null ? registeredServer.getServerInfo().getName() : null,
                 player::hasPermission
         ).map(serviceInfoSnapshot -> new VelocityPlayerFallbackEvent(player, serviceInfoSnapshot, serviceInfoSnapshot.getName()))
                 .map(event -> proxyServer.getEventManager().fire(event))
@@ -108,6 +107,11 @@ public final class VelocityCloudNetHelper {
                 })
                 .map(VelocityPlayerFallbackEvent::getFallbackName)
                 .flatMap(proxyServer::getServer);
+    }
+
+    public static Optional<RegisteredServer> getNextFallback(Player player) {
+        return getNextFallback(player, player.getCurrentServer()
+                .map(ServerConnection::getServer).orElse(null));
     }
 
     public static CompletableFuture<ServiceInfoSnapshot> connectToFallback(Player player, String currentServer) {

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
@@ -72,7 +72,7 @@ public final class VelocityPlayerListener {
 
     @Subscribe
     public void handle(KickedFromServerEvent event) {
-        if(event.getPlayer().isActive()) {
+        if (event.getPlayer().isActive()) {
             BridgeProxyHelper.handleConnectionFailed(event.getPlayer().getUniqueId(), event.getServer().getServerInfo().getName());
 
             VelocityCloudNetHelper.getNextFallback(event.getPlayer())

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
@@ -72,7 +72,7 @@ public final class VelocityPlayerListener {
 
     @Subscribe
     public void handle(KickedFromServerEvent event) {
-        VelocityCloudNetHelper.getNextFallback(event.getPlayer())
+        VelocityCloudNetHelper.getNextFallback(event.getPlayer(), event.getServer())
                 .ifPresent(registeredServer -> event.setResult(KickedFromServerEvent.RedirectPlayer.create(registeredServer)));
         event.getOriginalReason().ifPresent(component -> event.getPlayer().sendMessage(component));
     }

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
@@ -72,8 +72,14 @@ public final class VelocityPlayerListener {
 
     @Subscribe
     public void handle(KickedFromServerEvent event) {
+        if(!event.getPlayer().isActive())
+            return;
+
+        BridgeProxyHelper.handleConnectionFailed(event.getPlayer().getUniqueId(), event.getServer().getServerInfo().getName());
+
         VelocityCloudNetHelper.getNextFallback(event.getPlayer(), event.getServer())
                 .ifPresent(registeredServer -> event.setResult(KickedFromServerEvent.RedirectPlayer.create(registeredServer)));
+
         event.getOriginalReason().ifPresent(component -> event.getPlayer().sendMessage(component));
     }
 

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
@@ -72,15 +72,13 @@ public final class VelocityPlayerListener {
 
     @Subscribe
     public void handle(KickedFromServerEvent event) {
-        if(!event.getPlayer().isActive())
-            return;
+        if(event.getPlayer().isActive()) {
+            BridgeProxyHelper.handleConnectionFailed(event.getPlayer().getUniqueId(), event.getServer().getServerInfo().getName());
 
-        BridgeProxyHelper.handleConnectionFailed(event.getPlayer().getUniqueId(), event.getServer().getServerInfo().getName());
-
-        VelocityCloudNetHelper.getNextFallback(event.getPlayer(), event.getServer())
-                .ifPresent(registeredServer -> event.setResult(KickedFromServerEvent.RedirectPlayer.create(registeredServer)));
-
-        event.getOriginalReason().ifPresent(component -> event.getPlayer().sendMessage(component));
+            VelocityCloudNetHelper.getNextFallback(event.getPlayer())
+                    .ifPresent(registeredServer -> event.setResult(KickedFromServerEvent.RedirectPlayer.create(registeredServer)));
+            event.getOriginalReason().ifPresent(component -> event.getPlayer().sendMessage(component));
+        }
     }
 
     @Subscribe


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

I fixed the bug that I documented here: https://discord.com/channels/325362837184577536/536594898321670154/788033187770400819

For Users that aren't on the Discord/don't speak German:

If you connect to Velocity on a 1.16 network in an older version of Minecraft (1.8 for example) the console is spammed in CloudNet, Velocity and the target server. The server always kicks the player for a too old version and your Velocity plugin sends the player back to the specific server that kicked the player.... This causes an endless loop until disconnection.

What I have fixed:
I compared the Bungeecord and the Velocity implementations and implemented the missing lines in the Velocity implementation.

### Documentation of test results:

I tested with one and two Lobbys. Everything works fine.

With 2 Lobbys:
CloudNet seems to send the player twice to Lobby-1 and once to Lobby-2 and then: KICK. Works perfectly. No endless loop.

With 1 Lobby:
It again sends the player twice to Lobby-1 and then kicks him.

### Related issues/discussions:

https://discord.com/channels/325362837184577536/536594898321670154/788033187770400819
