### PR TITLE
Fetch latest build using paper-api for papermc software

### DIFF
--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocument.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/document/gson/JsonDocument.java
@@ -1,19 +1,40 @@
 package de.dytanic.cloudnet.common.document.gson;
 
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.internal.bind.TypeAdapters;
 import de.dytanic.cloudnet.common.document.IDocument;
 import de.dytanic.cloudnet.common.document.IReadable;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * The Gson implementation of IDocument class.
@@ -23,15 +44,13 @@ import java.util.*;
 @EqualsAndHashCode
 public class JsonDocument implements IDocument<JsonDocument>, Cloneable {
 
+    public static final JsonDocument EMPTY = newDocument();
     public static Gson GSON = new GsonBuilder()
             .serializeNulls()
             .disableHtmlEscaping()
             .setPrettyPrinting()
             .registerTypeAdapterFactory(TypeAdapters.newTypeHierarchyFactory(JsonDocument.class, new JsonDocumentTypeAdapter()))
             .create();
-
-    public static final JsonDocument EMPTY = newDocument();
-
     protected final JsonObject jsonObject;
 
     /**
@@ -152,6 +171,12 @@ public class JsonDocument implements IDocument<JsonDocument>, Cloneable {
         JsonDocument document = new JsonDocument();
 
         document.read(path);
+        return document;
+    }
+
+    public static JsonDocument newDocument(InputStream stream) {
+        JsonDocument document = new JsonDocument();
+        document.read(stream);
         return document;
     }
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/ServiceVersion.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/ServiceVersion.java
@@ -8,13 +8,14 @@ import java.util.Map;
 import java.util.Optional;
 
 public class ServiceVersion {
+    private final Map<String, String> additionalDownloads = new HashMap<>();
     private String name;
     private String url;
-    private int minJavaVersion, maxJavaVersion;
+    private int minJavaVersion;
+    private int maxJavaVersion;
     private boolean deprecated;
     private boolean cacheFiles = true;
     private JsonDocument properties = new JsonDocument();
-    private final Map<String, String> additionalDownloads = new HashMap<>();
 
     public ServiceVersion(String name, String url, int minJavaVersion, int maxJavaVersion, boolean deprecated, boolean cacheFiles, JsonDocument properties) {
         this.name = name;
@@ -64,6 +65,10 @@ public class ServiceVersion {
         return this.url;
     }
 
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
     public JsonDocument getProperties() {
         return this.properties;
     }
@@ -71,5 +76,4 @@ public class ServiceVersion {
     public Map<String, String> getAdditionalDownloads() {
         return this.additionalDownloads;
     }
-
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/ServiceVersionProvider.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/ServiceVersionProvider.java
@@ -141,10 +141,7 @@ public class ServiceVersionProvider {
             } else {
                 Files.createDirectories(workingDirectory);
 
-                List<InstallStep> installSteps = new ArrayList<>();
-
-                installSteps.add(InstallStep.DOWNLOAD);
-                installSteps.addAll(serviceVersionType.getInstallSteps());
+                List<InstallStep> installSteps = new ArrayList<>(serviceVersionType.getInstallSteps());
                 installSteps.add(InstallStep.DEPLOY);
 
                 Set<Path> lastStepResult = new HashSet<>();

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/InstallInformation.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/InstallInformation.java
@@ -1,6 +1,5 @@
 package de.dytanic.cloudnet.template.install.run;
 
-
 import de.dytanic.cloudnet.driver.service.ServiceTemplate;
 import de.dytanic.cloudnet.template.ITemplateStorage;
 import de.dytanic.cloudnet.template.install.ServiceVersion;
@@ -9,11 +8,8 @@ import de.dytanic.cloudnet.template.install.ServiceVersionType;
 public class InstallInformation {
 
     private final ServiceVersionType serviceVersionType;
-
     private final ServiceVersion serviceVersion;
-
     private final ITemplateStorage templateStorage;
-
     private final ServiceTemplate serviceTemplate;
 
     public InstallInformation(ServiceVersionType serviceVersionType, ServiceVersion serviceVersion, ITemplateStorage templateStorage, ServiceTemplate serviceTemplate) {

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/InstallStep.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/InstallStep.java
@@ -1,7 +1,13 @@
 package de.dytanic.cloudnet.template.install.run.step;
 
 import de.dytanic.cloudnet.template.install.run.InstallInformation;
-import de.dytanic.cloudnet.template.install.run.step.executor.*;
+import de.dytanic.cloudnet.template.install.run.step.executor.BuildStepExecutor;
+import de.dytanic.cloudnet.template.install.run.step.executor.CopyFilterStepExecutor;
+import de.dytanic.cloudnet.template.install.run.step.executor.DeployStepExecutor;
+import de.dytanic.cloudnet.template.install.run.step.executor.DownloadStepExecutor;
+import de.dytanic.cloudnet.template.install.run.step.executor.InstallStepExecutor;
+import de.dytanic.cloudnet.template.install.run.step.executor.PaperApiVersionFetchStepExecutor;
+import de.dytanic.cloudnet.template.install.run.step.executor.UnzipStepExecutor;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -13,7 +19,8 @@ public enum InstallStep {
     BUILD(new BuildStepExecutor()),
     UNZIP(new UnzipStepExecutor()),
     COPY_FILTER(new CopyFilterStepExecutor()),
-    DEPLOY(new DeployStepExecutor());
+    DEPLOY(new DeployStepExecutor()),
+    PAPER_API(new PaperApiVersionFetchStepExecutor());
 
     private final InstallStepExecutor executor;
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/executor/PaperApiVersionFetchStepExecutor.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/executor/PaperApiVersionFetchStepExecutor.java
@@ -1,0 +1,79 @@
+package de.dytanic.cloudnet.template.install.run.step.executor;
+
+import com.google.gson.reflect.TypeToken;
+import de.dytanic.cloudnet.CloudNet;
+import de.dytanic.cloudnet.common.document.gson.JsonDocument;
+import de.dytanic.cloudnet.template.install.ServiceVersionType;
+import de.dytanic.cloudnet.template.install.run.InstallInformation;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+public class PaperApiVersionFetchStepExecutor implements InstallStepExecutor {
+
+    private static final String DOWNLOAD_URL = "https://papermc.io/api/v2/projects/%s/versions/%s/builds/%d/downloads/%s-%s-%d.jar";
+    private static final Type INT_SET_TYPE = TypeToken.getParameterized(Set.class, Integer.class).getType();
+
+    @Override
+    public @NotNull Set<Path> execute(@NotNull InstallInformation installInformation, @NotNull Path workingDirectory, @NotNull Set<Path> inputPaths) throws IOException {
+        boolean enabled = installInformation.getServiceVersion().getProperties().getBoolean("fetch-over-paper-api");
+        String versionGroup = installInformation.getServiceVersion().getProperties().getString("version-group");
+        if (enabled && versionGroup != null) {
+            String project = this.decideApiProjectName(installInformation.getServiceVersionType());
+            JsonDocument versionInformation = this.makeRequest("https://papermc.io/api/v2/projects/" + project + "/versions/" + versionGroup);
+            if (versionInformation.contains("builds")) {
+                Set<Integer> builds = versionInformation.get("builds", INT_SET_TYPE);
+                Optional<Integer> newestBuild = builds.stream().reduce(Math::max);
+                if (newestBuild.isPresent()) {
+                    int build = newestBuild.get();
+                    installInformation.getServiceVersion().setUrl(String.format(DOWNLOAD_URL, project, versionGroup, build, project, versionGroup, build));
+                } else {
+                    CloudNet.getInstance().getLogger().error("Unable to retrieve latest build for papermc project " + project + " version-group " + versionGroup);
+                }
+            } else {
+                CloudNet.getInstance().getLogger().error("Unable to load build information for papermc project " + project + " version-group " + versionGroup);
+            }
+        }
+
+        return Collections.emptySet();
+    }
+
+    private JsonDocument makeRequest(@NotNull String apiUrl) {
+        try {
+            HttpURLConnection connection = (HttpURLConnection) new URL(apiUrl).openConnection();
+            connection.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.95 Safari/537.11");
+            connection.setRequestProperty("accepts", "application/json");
+            connection.connect();
+            if (connection.getResponseCode() == 200) {
+                try (InputStream stream = connection.getInputStream()) {
+                    return JsonDocument.newDocument(stream);
+                }
+            }
+        } catch (IOException exception) {
+            exception.printStackTrace();
+        }
+        return JsonDocument.EMPTY;
+    }
+
+    @NotNull
+    private String decideApiProjectName(@NotNull ServiceVersionType type) {
+        switch (type.getName().toLowerCase()) {
+            case "paperspigot":
+                return "paper";
+            case "waterfall":
+                return "waterfall";
+            case "travertine":
+                return "travertine";
+            default:
+                throw new IllegalStateException("Unsupported paper api project type " + type.getName());
+        }
+    }
+}

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/executor/PaperApiVersionFetchStepExecutor.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/executor/PaperApiVersionFetchStepExecutor.java
@@ -1,7 +1,6 @@
 package de.dytanic.cloudnet.template.install.run.step.executor;
 
 import com.google.gson.reflect.TypeToken;
-import de.dytanic.cloudnet.CloudNet;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.template.install.ServiceVersionType;
 import de.dytanic.cloudnet.template.install.run.InstallInformation;
@@ -36,10 +35,10 @@ public class PaperApiVersionFetchStepExecutor implements InstallStepExecutor {
                     int build = newestBuild.get();
                     installInformation.getServiceVersion().setUrl(String.format(DOWNLOAD_URL, project, versionGroup, build, project, versionGroup, build));
                 } else {
-                    CloudNet.getInstance().getLogger().error("Unable to retrieve latest build for papermc project " + project + " version-group " + versionGroup);
+                    throw new IllegalStateException("Unable to retrieve latest build for papermc project " + project + " version-group " + versionGroup);
                 }
             } else {
-                CloudNet.getInstance().getLogger().error("Unable to load build information for papermc project " + project + " version-group " + versionGroup);
+                throw new IllegalStateException("Unable to load build information for papermc project " + project + " version-group " + versionGroup);
             }
         }
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/executor/PaperApiVersionFetchStepExecutor.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/executor/PaperApiVersionFetchStepExecutor.java
@@ -23,8 +23,8 @@ public class PaperApiVersionFetchStepExecutor implements InstallStepExecutor {
 
     @Override
     public @NotNull Set<Path> execute(@NotNull InstallInformation installInformation, @NotNull Path workingDirectory, @NotNull Set<Path> inputPaths) throws IOException {
-        boolean enabled = installInformation.getServiceVersion().getProperties().getBoolean("fetch-over-paper-api");
-        String versionGroup = installInformation.getServiceVersion().getProperties().getString("version-group");
+        boolean enabled = installInformation.getServiceVersion().getProperties().getBoolean("fetchOverPaperApi");
+        String versionGroup = installInformation.getServiceVersion().getProperties().getString("versionGroup");
         if (enabled && versionGroup != null) {
             String project = this.decideApiProjectName(installInformation.getServiceVersionType());
             JsonDocument versionInformation = this.makeRequest("https://papermc.io/api/v2/projects/" + project + "/versions/" + versionGroup);

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/executor/PaperApiVersionFetchStepExecutor.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/template/install/run/step/executor/PaperApiVersionFetchStepExecutor.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 public class PaperApiVersionFetchStepExecutor implements InstallStepExecutor {
 
+    private static final String VERSION_LIST_URL = "https://papermc.io/api/v2/projects/%s/versions/%s";
     private static final String DOWNLOAD_URL = "https://papermc.io/api/v2/projects/%s/versions/%s/builds/%d/downloads/%s-%s-%d.jar";
     private static final Type INT_SET_TYPE = TypeToken.getParameterized(Set.class, Integer.class).getType();
 
@@ -27,7 +28,7 @@ public class PaperApiVersionFetchStepExecutor implements InstallStepExecutor {
         String versionGroup = installInformation.getServiceVersion().getProperties().getString("versionGroup");
         if (enabled && versionGroup != null) {
             String project = this.decideApiProjectName(installInformation.getServiceVersionType());
-            JsonDocument versionInformation = this.makeRequest("https://papermc.io/api/v2/projects/" + project + "/versions/" + versionGroup);
+            JsonDocument versionInformation = this.makeRequest(String.format(VERSION_LIST_URL, project, versionGroup));
             if (versionInformation.contains("builds")) {
                 Set<Integer> builds = versionInformation.get("builds", INT_SET_TYPE);
                 Optional<Integer> newestBuild = builds.stream().reduce(Math::max);

--- a/cloudnet/src/main/resources/files/versions.json
+++ b/cloudnet/src/main/resources/files/versions.json
@@ -22,8 +22,8 @@
             "jvmOptions": [
               "-Dpaperclip.patchonly=true"
             ],
-            "fetch-over-paper-api": true,
-            "version-group": "1.16.4"
+            "fetchOverPaperApi": true,
+            "versionGroup": "1.16.4"
           }
         },
         {
@@ -35,8 +35,8 @@
             "jvmOptions": [
               "-Dpaperclip.patchonly=true"
             ],
-            "fetch-over-paper-api": true,
-            "version-group": "1.16.4"
+            "fetchOverPaperApi": true,
+            "versionGroup": "1.16.4"
           }
         },
         {
@@ -710,8 +710,8 @@
           "name": "latest",
           "cacheFiles": false,
           "properties": {
-            "fetch-over-paper-api": true,
-            "version-group": "1.16"
+            "fetchOverPaperApi": true,
+            "versionGroup": "1.16"
           }
         }
       ]
@@ -744,8 +744,8 @@
           "name": "latest",
           "cacheFiles": false,
           "properties": {
-            "fetch-over-paper-api": true,
-            "version-group": "1.16"
+            "fetchOverPaperApi": true,
+            "versionGroup": "1.16"
           }
         }
       ]

--- a/cloudnet/src/main/resources/files/versions.json
+++ b/cloudnet/src/main/resources/files/versions.json
@@ -5,6 +5,8 @@
       "name": "paperspigot",
       "targetEnvironment": "MINECRAFT_SERVER_PAPER_SPIGOT",
       "installSteps": [
+        "PAPER_API",
+        "DOWNLOAD",
         "BUILD",
         "COPY_FILTER"
       ],
@@ -12,7 +14,6 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://papermc.io/ci/job/Paper-1.16/lastSuccessfulBuild/artifact/paperclip.jar",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -20,24 +21,27 @@
             },
             "jvmOptions": [
               "-Dpaperclip.patchonly=true"
-            ]
+            ],
+            "fetch-over-paper-api": true,
+            "version-group": "1.16.4"
           }
         },
         {
           "name": "1.16.4",
-          "url": "https://papermc.io/ci/job/Paper-1.16/lastSuccessfulBuild/artifact/paperclip.jar",
           "properties": {
             "copy": {
               "cache/patched.*\\.jar": "paper.jar"
             },
             "jvmOptions": [
               "-Dpaperclip.patchonly=true"
-            ]
+            ],
+            "fetch-over-paper-api": true,
+            "version-group": "1.16.4"
           }
         },
         {
           "name": "1.15.2",
-          "url": "https://papermc.io/ci/job/Paper-1.15/lastSuccessfulBuild/artifact/paperclip.jar",
+          "url": "https://papermc.io/api/v2/projects/paper/versions/1.15.2/builds/391/downloads/paper-1.15.2-391.jar",
           "properties": {
             "copy": {
               "cache/patched.*\\.jar": "paper.jar"
@@ -49,7 +53,7 @@
         },
         {
           "name": "1.14.4",
-          "url": "https://papermc.io/ci/job/Paper-1.14/lastSuccessfulBuild/artifact/paperclip.jar",
+          "url": "https://papermc.io/api/v2/projects/paper/versions/1.14.4/builds/243/downloads/paper-1.14.4-243.jar",
           "properties": {
             "copy": {
               "cache/patched.*\\.jar": "paper.jar"
@@ -61,7 +65,7 @@
         },
         {
           "name": "1.13.2",
-          "url": "https://papermc.io/ci/job/Paper-1.13/lastSuccessfulBuild/artifact/paperclip.jar",
+          "url": "https://papermc.io/api/v2/projects/paper/versions/1.13.2/builds/655/downloads/paper-1.13.2-655.jar",
           "properties": {
             "copy": {
               "cache/patched.*\\.jar": "paper.jar"
@@ -73,7 +77,7 @@
         },
         {
           "name": "1.12.2",
-          "url": "https://papermc.io/ci/job/Paper/lastSuccessfulBuild/artifact/paperclip-1618.jar",
+          "url": "https://papermc.io/api/v2/projects/paper/versions/1.12.2/builds/1618/downloads/paper-1.12.2-1618.jar",
           "properties": {
             "copy": {
               "cache/patched.*\\.jar": "paper.jar"
@@ -85,7 +89,7 @@
         },
         {
           "name": "1.11.2",
-          "url": "https://papermc.io/ci/job/Paper/1104/artifact/paperclip.jar",
+          "url": "https://papermc.io/api/v2/projects/paper/versions/1.11.2/builds/1104/downloads/paper-1.11.2-1104.jar",
           "deprecated": true,
           "maxJavaVersion": 8,
           "properties": {
@@ -99,7 +103,7 @@
         },
         {
           "name": "1.10.2",
-          "url": "https://papermc.io/ci/job/Paper/916/artifact/paperclip-916.2.jar",
+          "url": "https://papermc.io/api/v2/projects/paper/versions/1.10.2/builds/916/downloads/paper-1.10.2-916.jar",
           "deprecated": true,
           "maxJavaVersion": 8,
           "properties": {
@@ -110,7 +114,7 @@
         },
         {
           "name": "1.9.4",
-          "url": "https://papermc.io/ci/job/Paper/773/artifact/paperclip-773.jar",
+          "url": "https://papermc.io/api/v2/projects/paper/versions/1.9.4/builds/773/downloads/paper-1.9.4-773.jar",
           "deprecated": true,
           "maxJavaVersion": 8,
           "properties": {
@@ -121,7 +125,7 @@
         },
         {
           "name": "1.8.8",
-          "url": "https://papermc.io/ci/job/Paper/443/artifact/paperclip-1.8.8-fix.jar",
+          "url": "https://papermc.io/api/v2/projects/paper/versions/1.8.8/builds/443/downloads/paper-1.8.8-443.jar",
           "deprecated": true,
           "maxJavaVersion": 8,
           "properties": {
@@ -136,6 +140,9 @@
       "name": "spigot",
       "targetEnvironment": "MINECRAFT_SERVER_SPIGOT",
       "website": "https://getbukkit.org",
+      "installSteps": [
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
@@ -188,6 +195,7 @@
       "name": "buildtools",
       "targetEnvironment": "MINECRAFT_SERVER_SPIGOT",
       "installSteps": [
+        "DOWNLOAD",
         "BUILD",
         "COPY_FILTER"
       ],
@@ -330,6 +338,9 @@
       "name": "spongevanilla",
       "targetEnvironment": "MINECRAFT_SERVER_SPONGE_VANILLA",
       "website": "https://spongepowered.org",
+      "installSteps": [
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
@@ -354,6 +365,7 @@
       "name": "forge",
       "targetEnvironment": "MINECRAFT_SERVER_FORGE",
       "installSteps": [
+        "DOWNLOAD",
         "BUILD",
         "COPY_FILTER"
       ],
@@ -542,6 +554,7 @@
       "name": "spongeforge",
       "targetEnvironment": "MINECRAFT_SERVER_FORGE",
       "installSteps": [
+        "DOWNLOAD",
         "BUILD",
         "COPY_FILTER"
       ],
@@ -630,6 +643,9 @@
       "name": "glowstone",
       "targetEnvironment": "GLOWSTONE_DEFAULT",
       "website": "https://github.com/GlowstoneMC",
+      "installSteps": [
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
@@ -650,6 +666,9 @@
       "name": "waterdog",
       "targetEnvironment": "WATERDOG_DEFAULT",
       "website": "https://ci.codemc.org/job/yesdog/job/Waterdog",
+      "installSteps": [
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
@@ -667,6 +686,9 @@
       "name": "bungeecord",
       "targetEnvironment": "BUNGEECORD_DEFAULT",
       "website": "https://ci.md-5.net/job/BungeeCord",
+      "installSteps": [
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
@@ -679,11 +701,18 @@
       "name": "travertine",
       "targetEnvironment": "BUNGEECORD_TRAVERTINE",
       "website": "https://papermc.io",
+      "installSteps": [
+        "PAPER_API",
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
-          "url": "https://papermc.io/ci/job/Travertine/lastSuccessfulBuild/artifact/Travertine-Proxy/bootstrap/target/Travertine.jar",
-          "cacheFiles": false
+          "cacheFiles": false,
+          "properties": {
+            "fetch-over-paper-api": true,
+            "version-group": "1.16"
+          }
         }
       ]
     },
@@ -691,6 +720,9 @@
       "name": "hexacord",
       "targetEnvironment": "BUNGEECORD_HEXACORD",
       "website": "https://github.com/HexagonMC/BungeeCord",
+      "installSteps": [
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
@@ -703,11 +735,18 @@
       "name": "waterfall",
       "targetEnvironment": "BUNGEECORD_WATERFALL",
       "website": "https://papermc.io",
+      "installSteps": [
+        "PAPER_API",
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
-          "url": "https://ci.destroystokyo.com/job/Waterfall/lastSuccessfulBuild/artifact/Waterfall-Proxy/bootstrap/target/Waterfall.jar",
-          "cacheFiles": false
+          "cacheFiles": false,
+          "properties": {
+            "fetch-over-paper-api": true,
+            "version-group": "1.16"
+          }
         }
       ]
     },
@@ -715,6 +754,9 @@
       "name": "velocity",
       "targetEnvironment": "VELOCITY_DEFAULT",
       "website": "https://velocitypowered.com",
+      "installSteps": [
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
@@ -732,6 +774,9 @@
       "name": "nukkit",
       "targetEnvironment": "NUKKIT_DEFAULT",
       "website": "https://nukkitx.com",
+      "installSteps": [
+        "DOWNLOAD"
+      ],
       "versions": [
         {
           "name": "latest",
@@ -744,6 +789,7 @@
       "name": "gomint",
       "targetEnvironment": "GO_MINT_DEFAULT",
       "installSteps": [
+        "DOWNLOAD",
         "UNZIP",
         "COPY_FILTER"
       ],


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

Since the papermc ci went private, no installations of latest paper software was possible. This pull requests re-introduces the possibility to download the latest server/proxy software using the papermc v2 downloads-api.
