### PR TITLE
Add a new property to start tasks with different java versions

### DIFF
--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
@@ -22,6 +22,7 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
     protected ServiceId serviceId;
 
     protected String runtime;
+    protected String javaCommand;
 
     protected boolean autoDeleteOnStop, staticService;
 
@@ -42,18 +43,18 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
     protected int port;
 
     public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, int port) {
-        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, new String[0], processConfig, port);
+        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, new String[0], processConfig, port, null);
     }
 
-    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, String[] deletedFilesAfterStop, ProcessConfiguration processConfig, int port) {
-        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, deletedFilesAfterStop, processConfig, JsonDocument.newDocument(), port);
+    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, String[] deletedFilesAfterStop, ProcessConfiguration processConfig, int port, String javaCommand) {
+        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, deletedFilesAfterStop, processConfig, JsonDocument.newDocument(), port, javaCommand);
     }
 
-    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, JsonDocument properties, int port) {
-        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, new String[0], processConfig, properties, port);
+    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, JsonDocument properties, int port, String javaCommand) {
+        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, new String[0], processConfig, properties, port, javaCommand);
     }
 
-    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, String[] deletedFilesAfterStop, ProcessConfiguration processConfig, JsonDocument properties, int port) {
+    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, String[] deletedFilesAfterStop, ProcessConfiguration processConfig, JsonDocument properties, int port, String javaCommand) {
         this.serviceId = serviceId;
         this.runtime = runtime;
         this.autoDeleteOnStop = autoDeleteOnStop;
@@ -66,6 +67,7 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
         this.processConfig = processConfig;
         this.properties = properties;
         this.port = port;
+        this.javaCommand = javaCommand;
     }
 
     public ServiceConfiguration() {
@@ -104,6 +106,15 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
 
     public void setStaticService(boolean staticService) {
         this.staticService = staticService;
+    }
+
+    @Nullable
+    public String getJavaCommand() {
+        return this.javaCommand;
+    }
+
+    public void setJavaCommand(String javaCommand) {
+        this.javaCommand = javaCommand;
     }
 
     @NotNull
@@ -215,6 +226,7 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
     public void write(@NotNull ProtocolBuffer buffer) {
         buffer.writeObject(this.serviceId);
         buffer.writeOptionalString(this.runtime);
+        buffer.writeOptionalString(this.javaCommand);
         buffer.writeBoolean(this.autoDeleteOnStop);
         buffer.writeBoolean(this.staticService);
         buffer.writeStringCollection(this.groups == null ? Collections.emptyList() : Arrays.asList(this.groups));
@@ -247,6 +259,7 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
     public void read(@NotNull ProtocolBuffer buffer) {
         this.serviceId = buffer.readObject(ServiceId.class);
         this.runtime = buffer.readOptionalString();
+        this.javaCommand = buffer.readOptionalString();
         this.autoDeleteOnStop = buffer.readBoolean();
         this.staticService = buffer.readBoolean();
         this.groups = buffer.readStringCollection().toArray(new String[0]);
@@ -324,7 +337,8 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
                     .maxHeapMemory(task.getProcessConfiguration().getMaxHeapMemorySize())
                     .jvmOptions(task.getProcessConfiguration().getJvmOptions())
                     .processParameters(task.getProcessConfiguration().getProcessParameters())
-                    .startPort(task.getStartPort());
+                    .startPort(task.getStartPort())
+                    .javaCommand(task.getJavaCommand());
         }
 
         /**
@@ -380,6 +394,12 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
         @NotNull
         public Builder uniqueId(@NotNull UUID uniqueId) {
             this.config.serviceId.uniqueId = uniqueId;
+            return this;
+        }
+
+        @NotNull
+        public Builder javaCommand(@Nullable String javaCommand) {
+            this.config.javaCommand = javaCommand;
             return this;
         }
 

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceConfiguration.java
@@ -46,12 +46,24 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
         this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, new String[0], processConfig, port, null);
     }
 
+    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, String[] deletedFilesAfterStop, ProcessConfiguration processConfig, int port) {
+        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, deletedFilesAfterStop, processConfig, JsonDocument.newDocument(), port, null);
+    }
+
     public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, String[] deletedFilesAfterStop, ProcessConfiguration processConfig, int port, String javaCommand) {
         this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, deletedFilesAfterStop, processConfig, JsonDocument.newDocument(), port, javaCommand);
     }
 
+    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, JsonDocument properties, int port) {
+        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, new String[0], processConfig, properties, port, null);
+    }
+
     public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, ProcessConfiguration processConfig, JsonDocument properties, int port, String javaCommand) {
         this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, new String[0], processConfig, properties, port, javaCommand);
+    }
+
+    public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, String[] deletedFilesAfterStop, ProcessConfiguration processConfig, JsonDocument properties, int port) {
+        this(serviceId, runtime, autoDeleteOnStop, staticService, groups, includes, templates, deployments, deletedFilesAfterStop, processConfig, properties, port, null);
     }
 
     public ServiceConfiguration(ServiceId serviceId, String runtime, boolean autoDeleteOnStop, boolean staticService, String[] groups, ServiceRemoteInclusion[] includes, ServiceTemplate[] templates, ServiceDeployment[] deployments, String[] deletedFilesAfterStop, ProcessConfiguration processConfig, JsonDocument properties, int port, String javaCommand) {
@@ -397,6 +409,10 @@ public class ServiceConfiguration extends SerializableJsonDocPropertyable implem
             return this;
         }
 
+        /**
+         * the java command to start the service with
+         * if this is null the default value from the config.json will be used
+         */
         @NotNull
         public Builder javaCommand(@Nullable String javaCommand) {
             this.config.javaCommand = javaCommand;

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTask.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/service/ServiceTask.java
@@ -6,6 +6,7 @@ import de.dytanic.cloudnet.driver.serialization.SerializableObject;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -17,6 +18,8 @@ public class ServiceTask extends ServiceConfigurationBase implements INameable, 
     private String name;
 
     private String runtime;
+
+    private String javaCommand;
 
     private boolean disableIpRewrite;
 
@@ -52,6 +55,12 @@ public class ServiceTask extends ServiceConfigurationBase implements INameable, 
     }
 
     public ServiceTask(Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
+                       String name, String runtime, boolean autoDeleteOnStop, boolean staticServices, Collection<String> associatedNodes, Collection<String> groups,
+                       Collection<String> deletedFilesAfterStop, ProcessConfiguration processConfiguration, int startPort, int minServiceCount, String javaCommand) {
+        this(includes, templates, deployments, name, runtime, false, autoDeleteOnStop, staticServices, associatedNodes, groups, deletedFilesAfterStop, processConfiguration, startPort, minServiceCount, javaCommand);
+    }
+
+    public ServiceTask(Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
                        String name, String runtime, boolean maintenance, boolean autoDeleteOnStop, boolean staticServices, Collection<String> associatedNodes, Collection<String> groups,
                        ProcessConfiguration processConfiguration, int startPort, int minServiceCount) {
         this(includes, templates, deployments, name, runtime, maintenance, autoDeleteOnStop, staticServices, associatedNodes, groups, new ArrayList<>(), processConfiguration, startPort, minServiceCount);
@@ -60,6 +69,12 @@ public class ServiceTask extends ServiceConfigurationBase implements INameable, 
     public ServiceTask(Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
                        String name, String runtime, boolean maintenance, boolean autoDeleteOnStop, boolean staticServices, Collection<String> associatedNodes, Collection<String> groups,
                        Collection<String> deletedFilesAfterStop, ProcessConfiguration processConfiguration, int startPort, int minServiceCount) {
+        this(includes, templates, deployments, name, runtime, maintenance, autoDeleteOnStop, staticServices, associatedNodes, groups, deletedFilesAfterStop, processConfiguration, startPort, minServiceCount, null);
+    }
+
+    public ServiceTask(Collection<ServiceRemoteInclusion> includes, Collection<ServiceTemplate> templates, Collection<ServiceDeployment> deployments,
+                       String name, String runtime, boolean maintenance, boolean autoDeleteOnStop, boolean staticServices, Collection<String> associatedNodes, Collection<String> groups,
+                       Collection<String> deletedFilesAfterStop, ProcessConfiguration processConfiguration, int startPort, int minServiceCount, String javaCommand) {
         super(includes, templates, deployments);
         this.name = name;
         this.runtime = runtime;
@@ -72,6 +87,7 @@ public class ServiceTask extends ServiceConfigurationBase implements INameable, 
         this.startPort = startPort;
         this.minServiceCount = minServiceCount;
         this.staticServices = staticServices;
+        this.javaCommand = javaCommand;
     }
 
     public ServiceTask() {
@@ -115,6 +131,15 @@ public class ServiceTask extends ServiceConfigurationBase implements INameable, 
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Nullable
+    public String getJavaCommand() {
+        return this.javaCommand;
+    }
+
+    public void setJavaCommand(String javaCommand) {
+        this.javaCommand = javaCommand;
     }
 
     public String getRuntime() {
@@ -217,7 +242,8 @@ public class ServiceTask extends ServiceConfigurationBase implements INameable, 
                         new ArrayList<>(this.processConfiguration.getProcessParameters())
                 ),
                 this.startPort,
-                this.minServiceCount
+                this.minServiceCount,
+                this.javaCommand
         );
     }
 
@@ -226,6 +252,7 @@ public class ServiceTask extends ServiceConfigurationBase implements INameable, 
         super.write(buffer);
         buffer.writeString(this.name);
         buffer.writeString(this.runtime);
+        buffer.writeOptionalString(this.javaCommand);
         buffer.writeBoolean(this.disableIpRewrite);
         buffer.writeBoolean(this.maintenance);
         buffer.writeBoolean(this.autoDeleteOnStop);
@@ -243,6 +270,7 @@ public class ServiceTask extends ServiceConfigurationBase implements INameable, 
         super.read(buffer);
         this.name = buffer.readString();
         this.runtime = buffer.readString();
+        this.javaCommand = buffer.readOptionalString();
         this.disableIpRewrite = buffer.readBoolean();
         this.maintenance = buffer.readBoolean();
         this.autoDeleteOnStop = buffer.readBoolean();

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandCreate.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandCreate.java
@@ -42,7 +42,8 @@ public class CommandCreate extends SubCommandHandler {
                                             serviceTask.getGroups(),
                                             serviceTask.getDeletedFilesAfterStop(),
                                             serviceTask.getProcessConfiguration(),
-                                            serviceTask.getStartPort()
+                                            serviceTask.getStartPort(),
+                                            serviceTask.getJavaCommand()
                                     );
 
                                     if (serviceInfoSnapshots.isEmpty()) {
@@ -95,7 +96,8 @@ public class CommandCreate extends SubCommandHandler {
                                                         new ArrayList<>(),
                                                         new ArrayList<>()
                                                 ),
-                                                environment.getDefaultStartPort()
+                                                environment.getDefaultStartPort(),
+                                                null
                                         );
 
                                         listAndStartServices(sender, serviceInfoSnapshots, properties);
@@ -117,6 +119,7 @@ public class CommandCreate extends SubCommandHandler {
                                                         "- memory=<mb>",
                                                         "- groups=[Lobby, Prime, TestLobby]",
                                                         "- runtime=<name>",
+                                                        "- javaCommand=<command>",
                                                         "- jvmOptions=[-XX:OptimizeStringConcat;-Xms256M]",
                                                         "- templates=[storage:prefix/name  local:Lobby/Lobby;local:/PremiumLobby]",
                                                         "- deployments=[storage:prefix/name  local:Lobby/Lobby;local:/PremiumLobby]",
@@ -165,7 +168,8 @@ public class CommandCreate extends SubCommandHandler {
             Collection<String> groups,
             Collection<String> deletedFilesAfterStop,
             ProcessConfiguration processConfiguration,
-            int startPort
+            int startPort,
+            String javaCommand
     ) {
         Collection<ServiceInfoSnapshot> serviceInfoSnapshots = new ArrayList<>(count);
 
@@ -203,7 +207,8 @@ public class CommandCreate extends SubCommandHandler {
                                     processConfiguration.getProcessParameters())
                     ),
                     finalStartPort,
-                    0
+                    0,
+                    properties.getOrDefault("javaCommand", javaCommand)
             ));
 
             if (serviceInfoSnapshot != null) {

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/ICloudService.java
@@ -16,6 +16,9 @@ public interface ICloudService {
     @ApiStatus.Internal
     void init();
 
+    @Nullable
+    String getJavaCommand();
+
     @NotNull
     String getRuntime();
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/DefaultEmptyCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/DefaultEmptyCloudService.java
@@ -10,6 +10,7 @@ import de.dytanic.cloudnet.service.ICloudService;
 import de.dytanic.cloudnet.service.ICloudServiceManager;
 import de.dytanic.cloudnet.service.handler.CloudServiceHandler;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -40,6 +41,11 @@ public abstract class DefaultEmptyCloudService implements ICloudService {
     @Override
     public String getRuntime() {
         return this.runtime;
+    }
+
+    @Override
+    public @Nullable String getJavaCommand() {
+        return this.serviceConfiguration.getJavaCommand();
     }
 
     @Override

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/JVMCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/JVMCloudService.java
@@ -119,7 +119,13 @@ final class JVMCloudService extends DefaultMinecraftCloudService implements IClo
     protected void startProcess() throws Exception {
         List<String> commandArguments = new ArrayList<>();
 
-        commandArguments.add(CloudNet.getInstance().getConfig().getJVMCommand());
+        String javaCommand = this.getJavaCommand();
+        if (javaCommand == null) {
+            commandArguments.add(CloudNet.getInstance().getConfig().getJVMCommand());
+        } else {
+            commandArguments.add(javaCommand);
+        }
+
         commandArguments.addAll(CloudNet.getInstance().getConfig().getDefaultJVMFlags().getJvmFlags());
 
         commandArguments.addAll(Arrays.asList(

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/JVMCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/JVMCloudService.java
@@ -120,11 +120,7 @@ final class JVMCloudService extends DefaultMinecraftCloudService implements IClo
         List<String> commandArguments = new ArrayList<>();
 
         String javaCommand = this.getJavaCommand();
-        if (javaCommand == null) {
-            commandArguments.add(CloudNet.getInstance().getConfig().getJVMCommand());
-        } else {
-            commandArguments.add(javaCommand);
-        }
+        commandArguments.add(javaCommand == null ? CloudNet.getInstance().getConfig().getJVMCommand() : javaCommand);
 
         commandArguments.addAll(CloudNet.getInstance().getConfig().getDefaultJVMFlags().getJvmFlags());
 


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Added a property to set a custom javaCommand for each task.

### Documentation of test results:

1. https://tentact.de/xbackbone/NAtE2/XuhEmirE25.png/raw (create a service without task → starts with java 15 as shown in task-manager)

2. created a service with a task (create by TASK 1 --start → starts with java 15 as shown in task-manager)

### Related issues/discussions:

https://discord.com/channels/325362837184577536/536594865530601483/779416632120442982
