### PR TITLE
Fix NPE when checking velocity console permissions

### DIFF
--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionProvider.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/velocity/VelocityCloudNetCloudPermissionsPermissionProvider.java
@@ -17,7 +17,7 @@ public class VelocityCloudNetCloudPermissionsPermissionProvider implements Permi
 
     @Override
     public @MaybePresent PermissionFunction createFunction(@MaybePresent PermissionSubject subject) {
-        return subject instanceof Player ? new VelocityCloudNetCloudPermissionsPermissionFunction(((Player) subject).getUniqueId(), this.permissionsManagement) : null;
+        return subject instanceof Player ? new VelocityCloudNetCloudPermissionsPermissionFunction(((Player) subject).getUniqueId(), this.permissionsManagement) : PermissionFunction.ALWAYS_TRUE;
     }
 
 }


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:
Return a permission function even when the PermissionSubject is not a player to prevent errors when executing some commands from the console in Velocity