### PR TITLE
Prevent startup fail because of missing jansi native library

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
@@ -50,7 +50,7 @@ public final class JLine3Console implements IConsole {
 
         try {
             AnsiConsole.systemInstall();
-        }catch (UnsatisfiedLinkError ignored) {
+        } catch (UnsatisfiedLinkError ignored) {
         }
 
         this.terminal = TerminalBuilder.builder().system(true).encoding(StandardCharsets.UTF_8).build();

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
@@ -48,8 +48,9 @@ public final class JLine3Console implements IConsole {
     public JLine3Console() throws Exception {
         System.setProperty("library.jansi.version", "CloudNET");
 
-        if (!System.getProperty("os.version").contains("raspi")) {
+        try {
             AnsiConsole.systemInstall();
+        }catch (UnsatisfiedLinkError ignored) {
         }
 
         this.terminal = TerminalBuilder.builder().system(true).encoding(StandardCharsets.UTF_8).build();

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
@@ -50,7 +50,7 @@ public final class JLine3Console implements IConsole {
 
         try {
             AnsiConsole.systemInstall();
-        } catch (UnsatisfiedLinkError ignored) {
+        } catch (Throwable ignored) {
         }
 
         this.terminal = TerminalBuilder.builder().system(true).encoding(StandardCharsets.UTF_8).build();


### PR DESCRIPTION

This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Catch exceptions that may occur on raspi and M1 when installing ansi to prevent errors 
### Documentation of test results:

https://paste.gg/p/anonymous/e598cc9033d741f5a0702d4d2acec2e1

![grafik](https://user-images.githubusercontent.com/60936899/114097647-9ff97280-98c0-11eb-8e3b-e87520236f88.png)



### Related issues/discussions:

Fixes #421 
