### PR TITLE
Update LabyMod LMC channel name

### DIFF
--- a/cloudnet-modules/cloudnet-labymod/src/main/java/eu/cloudnetservice/cloudnet/ext/labymod/LabyModConstants.java
+++ b/cloudnet-modules/cloudnet-labymod/src/main/java/eu/cloudnetservice/cloudnet/ext/labymod/LabyModConstants.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 
 public interface LabyModConstants {
 
-    String LMC_CHANNEL_NAME = "LMC";
+    String LMC_CHANNEL_NAME = "labymod3:main";
     String GET_CONFIGURATION = "get_cloudnet_labymod_config";
     String GET_PLAYER_JOIN_SECRET = "get_player_by_join_secret";
     String GET_PLAYER_SPECTATE_SECRET = "get_player_by_spectate_secret";


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

LabyMod channel name changed, as this has also been changed in LabyMod as well.

### Documentation of test results:

The module works with LabyMod 3.8 now
