### PR TITLE
Fix that the command system does loads of unnecessary work

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/sub/SubCommandHandler.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/sub/SubCommandHandler.java
@@ -72,19 +72,16 @@ public class SubCommandHandler extends Command implements ITabCompleter {
                 .findFirst();
 
         if (!optionalSubCommand.isPresent()) {
-            Optional<String> optionalInvalidMessage = this.subCommands.stream()
-                    .map(subCommand -> subCommand.getInvalidArgumentMessage(args))
-                    .filter(Objects::nonNull)
-                    .filter(pair -> pair.getSecond() == 0) // all static values must match
-                    .findFirst()
-                    .map(Pair::getFirst);
+            for (SubCommand subCommand : this.subCommands) {
+                Pair<String, Integer> invalidArgumentMessage = subCommand.getInvalidArgumentMessage(args);
 
-            if (optionalInvalidMessage.isPresent()) {
-                sender.sendMessage(optionalInvalidMessage.get());
-            } else {
-                this.sendHelp(sender);
+                if (invalidArgumentMessage != null && invalidArgumentMessage.getSecond() == 0) {
+                    sender.sendMessage(invalidArgumentMessage.getFirst());
+                    return;
+                }
             }
 
+            this.sendHelp(sender);
             return;
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

The command system now does not test every registered sub command when trying to execute a command, caused by the streams usage.

### Documentation of test results:

Tested the permission command as described in the releated issue, it now loads the user only once (all sub commands are still working as expected)


### Related issues/discussions:

Fixed #366 
