### PR TITLE
Fix service state when stopping a service

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/DefaultCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/DefaultCloudService.java
@@ -325,6 +325,7 @@ public abstract class DefaultCloudService extends DefaultEmptyCloudService {
         }
 
         this.serviceInfoSnapshot = this.createServiceInfoSnapshot(ServiceLifeCycle.STOPPED);
+        this.getCloudServiceManager().getGlobalServiceInfoSnapshots().put(this.serviceInfoSnapshot.getServiceId().getUniqueId(), this.serviceInfoSnapshot);
 
         CloudNet.getInstance().sendAll(new PacketClientServerServiceInfoPublisher(this.serviceInfoSnapshot, PacketClientServerServiceInfoPublisher.PublisherType.STOPPED));
 

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/JVMCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/JVMCloudService.java
@@ -85,8 +85,6 @@ final class JVMCloudService extends DefaultMinecraftCloudService implements IClo
     private void invokeAutoDeleteOnStopIfNotRestart() {
         if (this.getServiceConfiguration().isAutoDeleteOnStop() && !this.restartState) {
             this.delete();
-        } else {
-            this.initAndPrepareService();
         }
     }
 
@@ -102,8 +100,10 @@ final class JVMCloudService extends DefaultMinecraftCloudService implements IClo
 
     @Override
     public boolean isAlive() {
-        return this.lifeCycle == ServiceLifeCycle.DEFINED || this.lifeCycle == ServiceLifeCycle.PREPARED ||
-                (this.lifeCycle == ServiceLifeCycle.RUNNING && this.process != null && this.process.isAlive());
+        return this.lifeCycle == ServiceLifeCycle.DEFINED
+                || this.lifeCycle == ServiceLifeCycle.PREPARED
+                || this.lifeCycle == ServiceLifeCycle.STOPPED
+                || (this.lifeCycle == ServiceLifeCycle.RUNNING && this.process != null && this.process.isAlive());
     }
 
     @Override


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

When stopping a service using `ser NAME stop` and `autoDeleteOnStop` is set to `false` the service will rest in the STOPPED state rather than changing back the prepared state. This is the only logic thing to do, as you can now see which services were stopped and which services were prepared. This may help the user so they don't need to take notes which services got stopped by them and which got created.

### Documentation of test results:

Looks fine for now.

### Related issues/discussions:

%
