### PR TITLE
Replace usages of AsyncPrintStream with PrintStream and reformat shit

### DIFF
--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/AsyncPrintStream.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/AsyncPrintStream.java
@@ -17,6 +17,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  * The actual console output is still executed in a thread where its priority
  * is as low as possible to affect the program even less
  */
+@Deprecated
 public class AsyncPrintStream extends PrintStream {
 
     static final BlockingQueue<Runnable> ASYNC_QUEUE = new LinkedBlockingQueue<>();

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/DefaultLogFormatter.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/DefaultLogFormatter.java
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat;
  */
 public final class DefaultLogFormatter implements IFormatter {
 
-    private final DateFormat dateFormat = new SimpleDateFormat("dd.MM HH:mm:ss.SSS");
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("dd.MM HH:mm:ss.SSS");
 
     @Override
     public @NotNull String format(@NotNull LogEntry logEntry) {
@@ -28,7 +28,7 @@ public final class DefaultLogFormatter implements IFormatter {
             if (message != null) {
                 stringBuilder
                         .append("[")
-                        .append(this.dateFormat.format(logEntry.getTimeStamp()))
+                        .append(DATE_FORMAT.format(logEntry.getTimeStamp()))
                         .append("] ")
                         .append(logEntry.getLogLevel().getUpperName())
                         .append(": ")
@@ -37,9 +37,7 @@ public final class DefaultLogFormatter implements IFormatter {
             }
         }
 
-
         stringBuilder.append(builder);
-
         return stringBuilder.toString();
     }
 }

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogEntryDispatcher.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LogEntryDispatcher.java
@@ -1,0 +1,48 @@
+package de.dytanic.cloudnet.common.logging;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class LogEntryDispatcher extends Thread {
+
+    private final ILogger parentLogger;
+    private final BlockingQueue<LogEntry> queue = new LinkedBlockingQueue<>();
+
+    public LogEntryDispatcher(ILogger parentLogger) {
+        super("Log record dispatcher thread");
+        this.setPriority(Thread.MIN_PRIORITY);
+
+        this.parentLogger = parentLogger;
+    }
+
+    @Override
+    public void run() {
+        while (!super.isInterrupted()) {
+            try {
+                this.dispatchLogEntry(this.queue.take());
+            } catch (InterruptedException exception) {
+                break;
+            }
+        }
+
+        for (LogEntry logEntry : this.queue) {
+            this.dispatchLogEntry(logEntry);
+        }
+    }
+
+    protected void enqueueLogEntry(LogEntry entry) {
+        if (!super.isInterrupted()) {
+            this.queue.add(entry);
+        }
+    }
+
+    protected void dispatchLogEntry(LogEntry entry) {
+        for (ILogHandler logHandler : this.parentLogger.getLogHandlers()) {
+            try {
+                logHandler.handle(entry);
+            } catch (Exception exception) {
+                exception.printStackTrace();
+            }
+        }
+    }
+}

--- a/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LoggingUtils.java
+++ b/cloudnet-common/src/main/java/de/dytanic/cloudnet/common/logging/LoggingUtils.java
@@ -3,7 +3,7 @@ package de.dytanic.cloudnet.common.logging;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-public class LoggingUtils {
+public final class LoggingUtils {
 
     private LoggingUtils() {
         throw new UnsupportedOperationException();
@@ -16,5 +16,4 @@ public class LoggingUtils {
             builder.append(writer).append(System.lineSeparator());
         }
     }
-
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/Main.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/Main.java
@@ -2,7 +2,6 @@ package de.dytanic.cloudnet;
 
 import de.dytanic.cloudnet.common.language.LanguageManager;
 import de.dytanic.cloudnet.common.logging.AbstractLogHandler;
-import de.dytanic.cloudnet.common.logging.AsyncPrintStream;
 import de.dytanic.cloudnet.common.logging.DefaultAsyncLogger;
 import de.dytanic.cloudnet.common.logging.DefaultFileLogHandler;
 import de.dytanic.cloudnet.common.logging.DefaultLogFormatter;
@@ -14,6 +13,8 @@ import de.dytanic.cloudnet.console.IConsole;
 import de.dytanic.cloudnet.console.JLine3Console;
 import de.dytanic.cloudnet.console.log.ColouredLogFormatter;
 
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
@@ -48,7 +49,7 @@ public final class Main {
             logger.addLogHandler(logHandler);
         }
 
-        System.setOut(new AsyncPrintStream(new LogOutputStream(logger, LogLevel.INFO)));
-        System.setErr(new AsyncPrintStream(new LogOutputStream(logger, LogLevel.ERROR)));
+        System.setOut(new PrintStream(new LogOutputStream(logger, LogLevel.INFO), true, StandardCharsets.UTF_8.name()));
+        System.setErr(new PrintStream(new LogOutputStream(logger, LogLevel.ERROR), true, StandardCharsets.UTF_8.name()));
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/JLine3Console.java
@@ -18,7 +18,12 @@ import org.jline.utils.InfoCmp;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -218,7 +223,7 @@ public final class JLine3Console implements IConsole {
     public @NotNull IConsole forceWriteLine(@NotNull String text) {
         text = ConsoleColor.toColouredString('&', text);
         if (!text.endsWith(System.lineSeparator())) {
-            text = text + System.lineSeparator();
+            text += System.lineSeparator();
         }
 
         this.print(Ansi.ansi().eraseLine(Ansi.Erase.ALL).toString() + '\r' + text + Ansi.ansi().reset().toString());

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/console/log/ColouredLogFormatter.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/console/log/ColouredLogFormatter.java
@@ -34,8 +34,7 @@ public final class ColouredLogFormatter implements IFormatter {
                         .append(ConsoleColor.DARK_GRAY)
                         .append(": ")
                         .append(logEntry.getLogLevel().isColorized() ? ConsoleColor.YELLOW : ConsoleColor.DEFAULT)
-                        .append(message)
-                        .append(System.lineSeparator());
+                        .append(message);
             }
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

The usages of AsyncPrintStream were removed completly. The AsyncPrintStream enqueues the print operations to the stream into an extra dispatcher thread which will then hand it to the logger. As a LogLevel has the possibility to decide if the logs should be sync or async that just makes no sense...

### Documentation of test results:

The changes were tested and are functional.
