### PR TITLE
Fix that group permissions aren't included in the permission check

### DIFF
--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/DefaultPermissionManagement.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/DefaultPermissionManagement.java
@@ -1,5 +1,6 @@
 package de.dytanic.cloudnet.driver.permission;
 
+import com.google.common.collect.Iterables;
 import de.dytanic.cloudnet.common.concurrent.ITask;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -7,10 +8,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -127,65 +128,82 @@ public abstract class DefaultPermissionManagement implements IPermissionManageme
     @Override
     @NotNull
     public PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull Permission permission) {
-        Permission bestMatch = permissible.findMatchingPermission(permissible.getPermissions(), permission);
-        Permission bestGroupMatch = tryExtendedGroups(bestMatch == null ? permission : bestMatch, permissible, null, new HashSet<>());
-
-        if (bestMatch == null || bestGroupMatch == null) {
-            return PermissionCheckResult.fromPermission(bestMatch == null ? bestGroupMatch : bestMatch);
-        } else {
-            return PermissionCheckResult.fromPermission(bestGroupMatch.compareTo(bestMatch) > 0 ? bestGroupMatch : bestMatch);
-        }
+        return PermissionCheckResult.fromPermission(this.findHighestPermission(this.collectAllPermissions(permissible, null), permission));
     }
 
     @Override
     @NotNull
     public PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull String group, @NotNull Permission permission) {
-        Collection<Permission> permissions = permissible.getGroupPermissions().get(group);
-        if (permissions != null) {
-            Permission bestMatch = permissible.findMatchingPermission(permissions, permission);
-            Permission bestGroupMatch = tryExtendedGroups(bestMatch == null ? permission : bestMatch, permissible, group, new HashSet<>());
-
-            if (bestMatch == null || bestGroupMatch == null) {
-                return PermissionCheckResult.fromPermission(bestMatch == null ? bestGroupMatch : bestMatch);
-            } else {
-                return PermissionCheckResult.fromPermission(bestGroupMatch.compareTo(bestMatch) > 0 ? bestGroupMatch : bestMatch);
-            }
-        }
-        return PermissionCheckResult.DENIED;
+        return this.getPermissionResult(permissible, Collections.singleton(group), permission);
     }
 
-    private Permission tryExtendedGroups(Permission permission, IPermissible permissible, String currentGroup, Set<String> testedGroups) {
-        Permission bestResult = null;
-        for (IPermissionGroup group : this.getGroups(permissible)) {
-            if (group == null) {
+    @Override
+    public @NotNull PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull Iterable<String> groups, @NotNull Permission permission) {
+        return this.getPermissionResult(permissible, Iterables.toArray(groups, String.class), permission);
+    }
+
+    @Override
+    public @NotNull PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull String[] groups, @NotNull Permission permission) {
+        return PermissionCheckResult.fromPermission(this.findHighestPermission(this.collectAllPermissions(permissible, groups), permission));
+    }
+
+    @Override
+    @Nullable
+    public Permission findHighestPermission(@NotNull Collection<Permission> permissions, @NotNull Permission permission) {
+        Permission lastMatch = null;
+        // search for a better match
+        for (Permission permissionEntry : permissions) {
+            Permission used = lastMatch == null ? permission : lastMatch;
+            // the "star" permission represents a permission which allows access to every command
+            if (permissionEntry.getName().equals("*") && permissionEntry.compareTo(used) > 0) {
+                lastMatch = permissionEntry;
                 continue;
             }
-
-            if (!testedGroups.add(group.getName())) {
-                return bestResult;
-            }
-
-            Collection<Permission> permissions = currentGroup != null
-                    ? group.getGroupPermissions().get(currentGroup)
-                    : group.getPermissions();
-            if (permissions == null) {
-                // (╯°□°）╯︵ ┻━┻
+            // searches for "perm.*"-permissions (allowing all sub permissions of the given permission name start
+            if (permissionEntry.getName().endsWith("*")
+                    && permission.getName().contains(permissionEntry.getName().replace("*", ""))
+                    && permissionEntry.compareTo(used) > 0) {
+                lastMatch = permissionEntry;
                 continue;
             }
-
-            Permission matching = group.findMatchingPermission(permissions, permission);
-            if (matching != null && matching.compareTo(bestResult == null ? permission : bestResult) > 0) {
-                bestResult = matching;
-            }
-
-            Permission bestRecursive = tryExtendedGroups(bestResult == null ? permission : bestResult, group, currentGroup, testedGroups);
-            if (bestRecursive != null) {
-                // the recursive result is always based on the previous checked result so a null check is enough here
-                bestResult = bestRecursive;
+            // checks if the current permission is exactly (case-sensitive) the permission for which we are searching
+            if (permission.getName().equalsIgnoreCase(permissionEntry.getName()) && permissionEntry.compareTo(used) > 0) {
+                lastMatch = permissionEntry;
             }
         }
 
-        return bestResult;
+        return lastMatch;
+    }
+
+    protected Collection<Permission> collectAllPermissions(@NotNull IPermissible permissible, @Nullable String[] groups) {
+        return this.collectAllPermissionsTo(new HashSet<>(), permissible, groups);
+    }
+
+    protected Collection<Permission> collectAllPermissionsTo(@NotNull Collection<Permission> target, @NotNull IPermissible permissible,
+                                                             @Nullable String[] groups) {
+        this.collectPermissionsInto(target, permissible, groups);
+        this.collectAllGroupPermissionsInto(target, this.getGroups(permissible), groups, new HashSet<>());
+
+        return target;
+    }
+
+    protected void collectAllGroupPermissionsInto(@NotNull Collection<Permission> target, @NotNull Collection<IPermissionGroup> groups,
+                                                  @Nullable String[] taskGroups, @NotNull Collection<String> travelledGroups) {
+        for (IPermissionGroup permissionGroup : groups) {
+            if (permissionGroup != null && travelledGroups.add(permissionGroup.getName())) {
+                this.collectPermissionsInto(target, permissionGroup, taskGroups);
+                this.collectAllGroupPermissionsInto(target, this.getGroups(permissionGroup), taskGroups, travelledGroups);
+            }
+        }
+    }
+
+    protected void collectPermissionsInto(@NotNull Collection<Permission> permissions, @NotNull IPermissible permissible, @Nullable String[] groups) {
+        permissions.addAll(permissible.getPermissions());
+        if (groups != null) {
+            for (String group : groups) {
+                permissions.addAll(permissible.getGroupPermissions().getOrDefault(group, Collections.emptySet()));
+            }
+        }
     }
 
     /**

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissible.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissible.java
@@ -2,6 +2,7 @@ package de.dytanic.cloudnet.driver.permission;
 
 import de.dytanic.cloudnet.common.INameable;
 import de.dytanic.cloudnet.common.document.gson.IJsonDocPropertyable;
+import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.serialization.SerializableObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -259,29 +260,7 @@ public interface IPermissible extends INameable, IJsonDocPropertyable, Comparabl
      * @return the logic permission which has the highest potency.
      */
     default @Nullable Permission findMatchingPermission(@NotNull Collection<Permission> permissions, @NotNull Permission permission) {
-        Permission lastMatch = null;
-        // search for a better match
-        for (Permission permissionEntry : permissions) {
-            Permission used = lastMatch == null ? permission : lastMatch;
-            // the "star" permission represents a permission which allows access to every command
-            if (permissionEntry.getName().equals("*") && permissionEntry.compareTo(used) > 0) {
-                lastMatch = permissionEntry;
-                continue;
-            }
-            // searches for "perm.*"-permissions (allowing all sub permissions of the given permission name start
-            if (permissionEntry.getName().endsWith("*")
-                    && permission.getName().contains(permissionEntry.getName().replace("*", ""))
-                    && permissionEntry.compareTo(used) > 0) {
-                lastMatch = permissionEntry;
-                continue;
-            }
-            // checks if the current permission is exactly (case-sensitive) the permission for which we are searching
-            if (permission.getName().equalsIgnoreCase(permissionEntry.getName()) && permissionEntry.compareTo(used) > 0) {
-                lastMatch = permissionEntry;
-            }
-        }
-
-        return lastMatch;
+        return CloudNetDriver.getInstance().getPermissionManagement().findHighestPermission(permissions, permission);
     }
 
     /**

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissionManagement.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissionManagement.java
@@ -53,7 +53,7 @@ public interface IPermissionManagement {
     void init();
 
     /**
-     * Reloads this permission manegement
+     * Reloads this permission management
      *
      * @return {@code true} if the reload was successful
      */
@@ -207,6 +207,39 @@ public interface IPermissionManagement {
      */
     @NotNull
     PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull String group, @NotNull Permission permission);
+
+    /**
+     * Checks if the given {@code permissible} has the given {@code permission}.
+     *
+     * @param permissible the permissible to check if the permission is set.
+     * @param groups      the groups to get the permissions on.
+     * @param permission  the permission to check.
+     * @return the check result. {@link PermissionCheckResult#DENIED} indicates that there was no allowing/forbidding permission.
+     */
+    @NotNull
+    PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull Iterable<String> groups, @NotNull Permission permission);
+
+    /**
+     * Checks if the given {@code permissible} has the given {@code permission}.
+     *
+     * @param permissible the permissible to check if the permission is set.
+     * @param groups      the groups to get the permissions on.
+     * @param permission  the permission to check.
+     * @return the check result. {@link PermissionCheckResult#DENIED} indicates that there was no allowing/forbidding permission.
+     */
+    @NotNull
+    PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull String[] groups, @NotNull Permission permission);
+
+    /**
+     * Finds the highest permission (sorted by the potency) in the given {@code permissions} array using the given
+     * {@code permission} potency as the starting point.
+     *
+     * @param permissions the permissions to check through.
+     * @param permission  the starting point for the check to run.
+     * @return the highest permission in the given {@code permission} or {@code null} if there is no permission with a higher potency in the given collection
+     */
+    @Nullable
+    Permission findHighestPermission(@NotNull Collection<Permission> permissions, @NotNull Permission permission);
 
     /**
      * Gets all permission of the specified {@code permissible}

--- a/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsManagement.java
+++ b/cloudnet-modules/cloudnet-cloudperms/src/main/java/de/dytanic/cloudnet/ext/cloudperms/CloudPermissionsManagement.java
@@ -2,12 +2,23 @@ package de.dytanic.cloudnet.ext.cloudperms;
 
 import de.dytanic.cloudnet.common.concurrent.ITask;
 import de.dytanic.cloudnet.driver.CloudNetDriver;
-import de.dytanic.cloudnet.driver.permission.*;
+import de.dytanic.cloudnet.driver.permission.CachedPermissionManagement;
+import de.dytanic.cloudnet.driver.permission.IPermissible;
+import de.dytanic.cloudnet.driver.permission.IPermissionGroup;
+import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
+import de.dytanic.cloudnet.driver.permission.IPermissionUser;
+import de.dytanic.cloudnet.driver.permission.Permission;
+import de.dytanic.cloudnet.driver.permission.PermissionCheckResult;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 @Deprecated
@@ -144,6 +155,21 @@ public class CloudPermissionsManagement implements IPermissionManagement, Cached
     @NotNull
     public PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull String group, @NotNull Permission permission) {
         return wrapped.getPermissionResult(permissible, group, permission);
+    }
+
+    @Override
+    public @NotNull PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull Iterable<String> groups, @NotNull Permission permission) {
+        return wrapped.getPermissionResult(permissible, groups, permission);
+    }
+
+    @Override
+    public @NotNull PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull String[] groups, @NotNull Permission permission) {
+        return wrapped.getPermissionResult(permissible, groups, permission);
+    }
+
+    @Override
+    public @Nullable Permission findHighestPermission(@NotNull Collection<Permission> permissions, @NotNull Permission permission) {
+        return wrapped.findHighestPermission(permissions, permission);
     }
 
     @Override

--- a/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/permission/WrapperPermissionManagement.java
+++ b/cloudnet-wrapper-jvm/src/main/java/de/dytanic/cloudnet/wrapper/permission/WrapperPermissionManagement.java
@@ -331,14 +331,7 @@ public class WrapperPermissionManagement extends DefaultPermissionManagement
 
     @Override
     public @NotNull PermissionCheckResult getPermissionResult(@NotNull IPermissible permissible, @NotNull Permission permission) {
-        for (String group : this.wrapper.getCurrentServiceInfoSnapshot().getConfiguration().getGroups()) {
-            PermissionCheckResult result = this.getPermissionResult(permissible, group, permission);
-            if (result == PermissionCheckResult.ALLOWED || result == PermissionCheckResult.FORBIDDEN) {
-                return result;
-            }
-        }
-
-        return super.getPermissionResult(permissible, permission);
+        return this.getPermissionResult(permissible, this.wrapper.getCurrentServiceInfoSnapshot().getConfiguration().getGroups(), permission);
     }
 
     @Override

--- a/cloudnet/src/test/java/de/dytanic/cloudnet/EmptyCloudNetDriver.java
+++ b/cloudnet/src/test/java/de/dytanic/cloudnet/EmptyCloudNetDriver.java
@@ -1,0 +1,107 @@
+package de.dytanic.cloudnet;
+
+import de.dytanic.cloudnet.common.collection.Pair;
+import de.dytanic.cloudnet.common.concurrent.ITask;
+import de.dytanic.cloudnet.common.logging.LogLevel;
+import de.dytanic.cloudnet.driver.CloudNetDriver;
+import de.dytanic.cloudnet.driver.database.DatabaseProvider;
+import de.dytanic.cloudnet.driver.network.INetworkClient;
+import de.dytanic.cloudnet.driver.provider.service.SpecificCloudServiceProvider;
+import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
+import de.dytanic.cloudnet.driver.service.ServiceTemplate;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.UUID;
+
+public class EmptyCloudNetDriver extends CloudNetDriver {
+
+    public EmptyCloudNetDriver() {
+        super(null);
+    }
+
+    @Override
+    public void start() throws Exception {
+
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public @NotNull String getComponentName() {
+        return null;
+    }
+
+    @Override
+    public @NotNull String getNodeUniqueId() {
+        return null;
+    }
+
+    @Override
+    public @NotNull DatabaseProvider getDatabaseProvider() {
+        return null;
+    }
+
+    @Override
+    public @NotNull SpecificCloudServiceProvider getCloudServiceProvider(@NotNull String name) {
+        return null;
+    }
+
+    @Override
+    public @NotNull SpecificCloudServiceProvider getCloudServiceProvider(@NotNull UUID uniqueId) {
+        return null;
+    }
+
+    @Override
+    public @NotNull SpecificCloudServiceProvider getCloudServiceProvider(@NotNull ServiceInfoSnapshot serviceInfoSnapshot) {
+        return null;
+    }
+
+    @Override
+    public @NotNull INetworkClient getNetworkClient() {
+        return null;
+    }
+
+    @Override
+    public @NotNull ITask<Collection<ServiceTemplate>> getLocalTemplateStorageTemplatesAsync() {
+        return null;
+    }
+
+    @Override
+    public @NotNull ITask<Collection<ServiceTemplate>> getTemplateStorageTemplatesAsync(@NotNull String serviceName) {
+        return null;
+    }
+
+    @Override
+    public Collection<ServiceTemplate> getLocalTemplateStorageTemplates() {
+        return null;
+    }
+
+    @Override
+    public Collection<ServiceTemplate> getTemplateStorageTemplates(@NotNull String serviceName) {
+        return null;
+    }
+
+    @Override
+    public void setGlobalLogLevel(@NotNull LogLevel logLevel) {
+
+    }
+
+    @Override
+    public void setGlobalLogLevel(int logLevel) {
+
+    }
+
+    @Override
+    public Pair<Boolean, String[]> sendCommandLineAsPermissionUser(@NotNull UUID uniqueId, @NotNull String commandLine) {
+        return null;
+    }
+
+    @Override
+    public @NotNull ITask<Pair<Boolean, String[]>> sendCommandLineAsPermissionUserAsync(@NotNull UUID uniqueId, @NotNull String commandLine) {
+        return null;
+    }
+}

--- a/cloudnet/src/test/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagementTest.java
+++ b/cloudnet/src/test/java/de/dytanic/cloudnet/permission/DefaultDatabasePermissionManagementTest.java
@@ -1,8 +1,10 @@
 package de.dytanic.cloudnet.permission;
 
+import de.dytanic.cloudnet.EmptyCloudNetDriver;
 import de.dytanic.cloudnet.common.io.FileUtils;
 import de.dytanic.cloudnet.database.AbstractDatabaseProvider;
 import de.dytanic.cloudnet.database.h2.H2DatabaseProvider;
+import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.permission.IPermissionGroup;
 import de.dytanic.cloudnet.driver.permission.IPermissionManagement;
 import de.dytanic.cloudnet.driver.permission.IPermissionUser;
@@ -34,6 +36,11 @@ public class DefaultDatabasePermissionManagementTest {
 
         IPermissionManagement permissionManagement = new DefaultDatabasePermissionManagement(() -> databaseProvider);
         permissionManagement.init();
+
+        CloudNetDriver driver = new EmptyCloudNetDriver() {{
+            setInstance(this);
+        }};
+        driver.setPermissionManagement(permissionManagement);
 
         IPermissionUser permissionUser = permissionManagement.addUser(userName, "1234", (byte) 5);
         Assert.assertNotNull(permissionUser);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

During the last permission system change there was an issue introduced preventing group sepcific permission from working as expected. This pull request fixes that issue.

### Documentation of test results:

Works as expected, the permission `minecraft.command.gamemode` is unset for group Lobby (works with positive permissions as well)

![image](https://user-images.githubusercontent.com/40468651/115001610-1808ff00-9ea4-11eb-8659-db8d964c6ca0.png)
