### PR TITLE
Invoke event listeners by runtime generated invokers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ allprojects {
         dependencyNpcLibVersion = 'development-SNAPSHOT'
         dependencyCommonsNetVersion = '3.8.0'
         dependencyJschVersion = '0.1.55'
+        dependencyJavassistVersion = '3.27.0-GA'
 
         testJunitVersion = '4.13.2'
 

--- a/cloudnet-driver/build.gradle
+++ b/cloudnet-driver/build.gradle
@@ -21,4 +21,5 @@ dependencies {
     api group: 'io.netty', name: 'netty-codec-http', version: dependencyNettyVersion
     api group: 'io.netty', name: 'netty-transport-native-epoll', version: dependencyNettyVersion, classifier: 'linux-x86_64'
     api group: 'io.netty', name: 'netty-transport-native-kqueue', version: dependencyNettyVersion, classifier: 'osx-x86_64'
+    implementation group: 'org.javassist', name: 'javassist', version: dependencyJavassistVersion
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/DefaultEventManager.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/DefaultEventManager.java
@@ -173,11 +173,8 @@ public final class DefaultEventManager implements IEventManager {
                 }
             });
 
-            if (!this.registeredListeners.containsKey(eventListener.channel())) {
-                this.registeredListeners.put(eventListener.channel(), new CopyOnWriteArrayList<>());
-            }
-
-            this.registeredListeners.get(eventListener.channel()).add(registeredEventListener);
+            this.registeredListeners.computeIfAbsent(eventListener.channel(),
+                    key -> new CopyOnWriteArrayList<>()).add(registeredEventListener);
         }
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/DefaultRegisteredEventListener.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/DefaultRegisteredEventListener.java
@@ -33,27 +33,29 @@ public class DefaultRegisteredEventListener implements IRegisteredEventListener 
     public void fireEvent(Event event) {
         Preconditions.checkNotNull(event);
 
-        if (this.getEventClass().isAssignableFrom(event.getClass())) {
-            if (event.isShowDebug()) {
-                CloudNetDriver.optionalInstance().ifPresent(cloudNetDriver -> {
-                    if (cloudNetDriver.getLogger().getLevel() >= LogLevel.DEBUG.getLevel()) {
-                        cloudNetDriver.getLogger().debug(String.format(
-                                "Calling event %s on listener %s",
-                                event.getClass().getName(),
-                                this.getInstance().getClass().getName()
-                        ));
-                    }
-                });
-            }
+        if (!this.getEventClass().isAssignableFrom(event.getClass())) {
+            return;
+        }
 
-            try {
-                this.listenerInvoker.invoke(event);
-            } catch (Exception exception) {
-                throw new EventListenerException(String.format(
-                        "Error while invoking event listener %s in class %s",
-                        this.methodName,
-                        this.instance.getClass().getName()), exception);
-            }
+        if (event.isShowDebug()) {
+            CloudNetDriver.optionalInstance().ifPresent(cloudNetDriver -> {
+                if (cloudNetDriver.getLogger().getLevel() >= LogLevel.DEBUG.getLevel()) {
+                    cloudNetDriver.getLogger().debug(String.format(
+                            "Calling event %s on listener %s",
+                            event.getClass().getName(),
+                            this.getInstance().getClass().getName()
+                    ));
+                }
+            });
+        }
+
+        try {
+            this.listenerInvoker.invoke(event);
+        } catch (Exception exception) {
+            throw new EventListenerException(String.format(
+                    "Error while invoking event listener %s in class %s",
+                    this.methodName,
+                    this.instance.getClass().getName()), exception);
         }
     }
 

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/DefaultRegisteredEventListener.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/DefaultRegisteredEventListener.java
@@ -1,41 +1,89 @@
 package de.dytanic.cloudnet.driver.event;
 
-import java.lang.reflect.Method;
+import com.google.common.base.Preconditions;
+import de.dytanic.cloudnet.common.logging.LogLevel;
+import de.dytanic.cloudnet.driver.CloudNetDriver;
+import de.dytanic.cloudnet.driver.event.invoker.ListenerInvoker;
 
 public class DefaultRegisteredEventListener implements IRegisteredEventListener {
 
     private final EventListener eventListener;
     private final EventPriority priority;
-
     private final Object instance;
-    private final Method handlerMethod;
-    private final Class<? extends Event> eventClass;
+    private final Class<?> eventClass;
+    private final String methodName;
+    private final ListenerInvoker listenerInvoker;
 
-    public DefaultRegisteredEventListener(EventListener eventListener, EventPriority priority, Object instance, Method handlerMethod, Class<? extends Event> eventClass) {
+    public DefaultRegisteredEventListener(
+            EventListener eventListener,
+            EventPriority priority,
+            Object instance,
+            Class<? extends Event> eventClass,
+            String methodName,
+            ListenerInvoker listenerInvoker) {
         this.eventListener = eventListener;
         this.priority = priority;
         this.instance = instance;
-        this.handlerMethod = handlerMethod;
         this.eventClass = eventClass;
+        this.methodName = methodName;
+        this.listenerInvoker = listenerInvoker;
     }
 
+    @Override
+    public void fireEvent(Event event) {
+        Preconditions.checkNotNull(event);
+
+        if (this.getEventClass().isAssignableFrom(event.getClass())) {
+            if (event.isShowDebug()) {
+                CloudNetDriver.optionalInstance().ifPresent(cloudNetDriver -> {
+                    if (cloudNetDriver.getLogger().getLevel() >= LogLevel.DEBUG.getLevel()) {
+                        cloudNetDriver.getLogger().debug(String.format(
+                                "Calling event %s on listener %s",
+                                event.getClass().getName(),
+                                this.getInstance().getClass().getName()
+                        ));
+                    }
+                });
+            }
+
+            try {
+                this.listenerInvoker.invoke(event);
+            } catch (Exception exception) {
+                throw new EventListenerException(String.format(
+                        "Error while invoking event listener %s in class %s",
+                        this.methodName,
+                        this.instance.getClass().getName()), exception);
+            }
+        }
+    }
+
+    @Override
     public EventListener getEventListener() {
         return this.eventListener;
     }
 
+    @Override
     public EventPriority getPriority() {
         return this.priority;
     }
 
+    @Override
     public Object getInstance() {
         return this.instance;
     }
 
-    public Method getHandlerMethod() {
-        return this.handlerMethod;
+    @Override
+    public Class<?> getEventClass() {
+        return this.eventClass;
     }
 
-    public Class<? extends Event> getEventClass() {
-        return this.eventClass;
+    @Override
+    public String getMethodName() {
+        return this.methodName;
+    }
+
+    @Override
+    public ListenerInvoker getInvoker() {
+        return this.listenerInvoker;
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/EventListener.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/EventListener.java
@@ -12,5 +12,4 @@ public @interface EventListener {
     String channel() default "*";
 
     EventPriority priority() default EventPriority.NORMAL;
-
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/IEventManager.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/IEventManager.java
@@ -20,7 +20,6 @@ public interface IEventManager {
 
     <T extends Event> T callEvent(String channel, T event);
 
-
     default <T extends Event> T callEvent(T event) {
         return this.callEvent("*", event);
     }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/IRegisteredEventListener.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/IRegisteredEventListener.java
@@ -1,12 +1,10 @@
 package de.dytanic.cloudnet.driver.event;
 
-import com.google.common.base.Preconditions;
-import de.dytanic.cloudnet.common.logging.LogLevel;
-import de.dytanic.cloudnet.driver.CloudNetDriver;
-
-import java.lang.reflect.Method;
+import de.dytanic.cloudnet.driver.event.invoker.ListenerInvoker;
 
 public interface IRegisteredEventListener extends Comparable<IRegisteredEventListener> {
+
+    void fireEvent(Event event);
 
     EventListener getEventListener();
 
@@ -14,40 +12,14 @@ public interface IRegisteredEventListener extends Comparable<IRegisteredEventLis
 
     Object getInstance();
 
-    Method getHandlerMethod();
+    ListenerInvoker getInvoker();
 
-    Class<? extends Event> getEventClass();
+    Class<?> getEventClass();
 
-    default <T extends Event> T fireEvent(T event) {
-        Preconditions.checkNotNull(event);
-
-        if (this.getEventClass().isAssignableFrom(event.getClass())) {
-
-            if (event.isShowDebug()) {
-                CloudNetDriver.optionalInstance().ifPresent(cloudNetDriver -> {
-                    if (cloudNetDriver.getLogger().getLevel() >= LogLevel.DEBUG.getLevel()) {
-                        cloudNetDriver.getLogger().debug(String.format(
-                                "Calling event %s on listener %s",
-                                event.getClass().getName(),
-                                this.getInstance().getClass().getName()
-                        ));
-                    }
-                });
-            }
-
-            try {
-                this.getHandlerMethod().setAccessible(true);
-                this.getHandlerMethod().invoke(this.getInstance(), event);
-            } catch (Exception ex) {
-                throw new EventListenerException("An error on offerTask method " + this.getHandlerMethod().getName() + " in class " + this.getInstance().getClass(), ex);
-            }
-        }
-
-        return event;
-    }
+    String getMethodName();
 
     @Override
-    default int compareTo(IRegisteredEventListener o) {
-        return this.getPriority().compareTo(o.getPriority());
+    default int compareTo(IRegisteredEventListener other) {
+        return this.getPriority().compareTo(other.getPriority());
     }
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvoker.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvoker.java
@@ -1,0 +1,19 @@
+package de.dytanic.cloudnet.driver.event.invoker;
+
+
+import de.dytanic.cloudnet.driver.event.Event;
+
+/**
+ * Responsible for invoking event listener methods without reflection.
+ * An implementation is automatically generated for every event listener method when registered.
+ */
+public interface ListenerInvoker {
+
+    /**
+     * Invokes the event listener method.
+     *
+     * @param event The event the listener method should be invoked with.
+     *              Passing an event with the wrong type will result in an exception
+     */
+    void invoke(Event event);
+}

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvoker.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvoker.java
@@ -1,6 +1,5 @@
 package de.dytanic.cloudnet.driver.event.invoker;
 
-
 import de.dytanic.cloudnet.driver.event.Event;
 
 /**

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvoker.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvoker.java
@@ -6,6 +6,7 @@ import de.dytanic.cloudnet.driver.event.Event;
  * Responsible for invoking event listener methods without reflection.
  * An implementation is automatically generated for every event listener method when registered.
  */
+@FunctionalInterface
 public interface ListenerInvoker {
 
     /**

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvokerClassLoader.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvokerClassLoader.java
@@ -1,0 +1,18 @@
+package de.dytanic.cloudnet.driver.event.invoker;
+
+
+import java.security.SecureClassLoader;
+
+/**
+ * {@link SecureClassLoader} giving the possibility to define new classes.
+ */
+public class ListenerInvokerClassLoader extends SecureClassLoader {
+
+    public ListenerInvokerClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
+    public Class<?> defineClass(String className, byte[] bytes) {
+        return super.defineClass(className, bytes, 0, bytes.length);
+    }
+}

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvokerClassLoader.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvokerClassLoader.java
@@ -1,6 +1,5 @@
 package de.dytanic.cloudnet.driver.event.invoker;
 
-
 import java.security.SecureClassLoader;
 
 /**

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvokerGenerator.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvokerGenerator.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Generates {@link ListenerInvoker} implementations for certain event handler methods.
+ * Generates {@link ListenerInvoker} implementations for certain event listener methods.
  *
  * @see ListenerInvoker
  */
@@ -43,7 +43,7 @@ public class ListenerInvokerGenerator {
     /**
      * Generates a new {@link ListenerInvoker}.
      *
-     * @param listener   The listener object the event listener method is in
+     * @param listener   The listener class instance the event listener method is in
      * @param methodName The name of the event listener method
      * @param eventClass The class of the event the listener method is handling
      * @return The new generated {@link ListenerInvoker}, being able the invoke the event listener method.
@@ -65,8 +65,8 @@ public class ListenerInvokerGenerator {
                     listenerClass.getClassLoader(),
                     ListenerInvokerClassLoader::new);
 
-            // listener classes might be loaded by another class loader (for example module listeners), add them to the
-            // class path of the class pool
+            // listener classes might be loaded by another class loader (for example module listeners),
+            // add them to the class path of the class pool
             this.classPool.appendClassPath(new LoaderClassPath(invokerClassLoader));
 
             CtClass listenerInvokerClass = this.classPool.makeClass(className);

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvokerGenerator.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/event/invoker/ListenerInvokerGenerator.java
@@ -1,0 +1,117 @@
+package de.dytanic.cloudnet.driver.event.invoker;
+
+import de.dytanic.cloudnet.driver.event.Event;
+import de.dytanic.cloudnet.driver.event.EventListenerException;
+import javassist.CannotCompileException;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtConstructor;
+import javassist.CtField;
+import javassist.CtMethod;
+import javassist.CtNewConstructor;
+import javassist.CtNewMethod;
+import javassist.LoaderClassPath;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Generates {@link ListenerInvoker} implementations for certain event handler methods.
+ *
+ * @see ListenerInvoker
+ */
+public class ListenerInvokerGenerator {
+
+    private static final String GENERATED_CLASS_TEMPLATE = "GeneratedListenerInvoker_%s";
+
+    private static final String LISTENER_FIELD_NAME = "listener";
+
+    private static final String INVOKE_METHOD_NAME = "invoke";
+
+    private final ClassPool classPool;
+
+    private final Map<ClassLoader, ListenerInvokerClassLoader> invokerClassLoaders;
+
+    public ListenerInvokerGenerator() {
+        this.classPool = new ClassPool(ClassPool.getDefault());
+        this.invokerClassLoaders = new HashMap<>();
+    }
+
+    /**
+     * Generates a new {@link ListenerInvoker}.
+     *
+     * @param listener   The listener object the event listener method is in
+     * @param methodName The name of the event listener method
+     * @param eventClass The class of the event the listener method is handling
+     * @return The new generated {@link ListenerInvoker}, being able the invoke the event listener method.
+     */
+    public ListenerInvoker generate(Object listener, String methodName, Class<? extends Event> eventClass) {
+        Class<?> listenerClass = listener.getClass();
+        String listenerClassName = listenerClass.getName();
+        String className = String.format(GENERATED_CLASS_TEMPLATE, UUID.randomUUID().toString().replace("-", ""));
+
+        try {
+            if (!Modifier.isPublic(listenerClass.getModifiers())) {
+                throw new IllegalStateException(String.format("Listener class %s has to be public", listenerClassName));
+            }
+            if (!Modifier.isPublic(eventClass.getModifiers())) {
+                throw new IllegalStateException(String.format("Event class %s has to be public", eventClass.getName()));
+            }
+
+            ListenerInvokerClassLoader invokerClassLoader = this.invokerClassLoaders.computeIfAbsent(
+                    listenerClass.getClassLoader(),
+                    ListenerInvokerClassLoader::new);
+
+            // listener classes might be loaded by another class loader (for example module listeners), add them to the
+            // class path of the class pool
+            this.classPool.appendClassPath(new LoaderClassPath(invokerClassLoader));
+
+            CtClass listenerInvokerClass = this.classPool.makeClass(className);
+            listenerInvokerClass.addInterface(this.classPool.get(ListenerInvoker.class.getName()));
+
+            listenerInvokerClass.addField(this.generateListenerField(listenerInvokerClass, listenerClassName));
+            listenerInvokerClass.addConstructor(this.generateInvokerConstructor(listenerInvokerClass, listenerClassName));
+            listenerInvokerClass.addMethod(this.generateInvokeImplementation(listenerInvokerClass, methodName, eventClass.getName()));
+
+            Class<?> generatedListenerInvokerClass = invokerClassLoader.defineClass(className, listenerInvokerClass.toBytecode());
+
+            Constructor<?> constructor = generatedListenerInvokerClass.getDeclaredConstructor(listenerClass);
+            return (ListenerInvoker) constructor.newInstance(listener);
+        } catch (Exception exception) {
+            throw new EventListenerException(String.format(
+                    "Failed to generate invoker for listener method %s:%s",
+                    listenerClassName,
+                    methodName), exception);
+        }
+    }
+
+    private CtField generateListenerField(CtClass listenerInvokerClass, String listenerClassName) throws CannotCompileException {
+        return CtField.make(
+                String.format("private final %s %s;", listenerClassName, LISTENER_FIELD_NAME),
+                listenerInvokerClass);
+    }
+
+    private CtConstructor generateInvokerConstructor(CtClass listenerInvokerClass, String listenerClassName) throws CannotCompileException {
+        return CtNewConstructor.make(String.format(
+                "public %s(%s %s) { this.%s = %s; }",
+                listenerInvokerClass.getSimpleName(),
+                listenerClassName,
+                LISTENER_FIELD_NAME,
+                LISTENER_FIELD_NAME,
+                LISTENER_FIELD_NAME), listenerInvokerClass);
+    }
+
+    private CtMethod generateInvokeImplementation(CtClass listenerInvokerClass, String methodName, String eventClassName) throws CannotCompileException {
+        return CtNewMethod.make(String.format(
+                "public void %s(%s event) { this.%s.%s((%s) event); }",
+                INVOKE_METHOD_NAME,
+                Event.class.getName(),
+                LISTENER_FIELD_NAME,
+                methodName,
+                eventClassName
+        ), listenerInvokerClass);
+    }
+}

--- a/cloudnet-driver/src/test/java/de/dytanic/cloudnet/driver/event/DefaultEventManagerTest.java
+++ b/cloudnet-driver/src/test/java/de/dytanic/cloudnet/driver/event/DefaultEventManagerTest.java
@@ -60,7 +60,7 @@ public final class DefaultEventManagerTest {
         Assert.assertEquals("value_789", testEvent.value);
     }
 
-    private static final class TestEvent extends Event {
+    public static final class TestEvent extends Event {
 
         public String value;
 
@@ -70,7 +70,7 @@ public final class DefaultEventManagerTest {
     }
 
 
-    private final class ListenerTest {
+    public final class ListenerTest {
 
         @EventListener(channel = "set")
         public void onTestExecute(TestEvent testEvent) {
@@ -86,7 +86,7 @@ public final class DefaultEventManagerTest {
         }
     }
 
-    private final class ListenerTest2 {
+    public final class ListenerTest2 {
 
         @EventListener(channel = "test_channel_2", priority = EventPriority.HIGHEST)
         public void onTestExecute(TestEvent testEvent) {


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

Event listeners are no longer invoked via reflections, but via runtime generated invokers.
This change requires that the listener class, the listener method and the event class are publicly acessible.

### Documentation of test results:
All CloudNet event listeners are registered and called.

### Related issues/discussions:
/
