### PR TITLE
Removed kicked from server message

### DIFF
--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/velocity/listener/VelocityPlayerListener.java
@@ -77,7 +77,6 @@ public final class VelocityPlayerListener {
 
             VelocityCloudNetHelper.getNextFallback(event.getPlayer())
                     .ifPresent(registeredServer -> event.setResult(KickedFromServerEvent.RedirectPlayer.create(registeredServer)));
-            event.getOriginalReason().ifPresent(component -> event.getPlayer().sendMessage(component));
         }
     }
 


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Velocity currently sends a message that can not be canceled without a velocity fork. The Message appends a prefix, but it can be changed by leaving the prefix string blank in the velocity config.
With this message the user will receive two kick messages and I don't think that's the goal, right?

### Documentation of test results:

It's just a removed line. Not much to test.
