### PR TITLE
Print logs of services which failed to start

### DIFF
--- a/cloudnet-modules/cloudnet-report/src/main/java/de/dytanic/cloudnet/ext/report/CloudNetReportModule.java
+++ b/cloudnet-modules/cloudnet-report/src/main/java/de/dytanic/cloudnet/ext/report/CloudNetReportModule.java
@@ -66,6 +66,7 @@ public final class CloudNetReportModule extends NodeCloudNetModule {
         this.getConfig().getString("recordDestinationDirectory", "records");
         this.getConfig().get("pasteServerType", PasteServerType.class, PasteServerType.HASTE);
         this.getConfig().getString("pasteServerUrl", "https://just-paste.it");
+        this.getConfig().getLong("serviceLifetimeLogPrint", 5000L);
 
         this.saveConfig();
     }
@@ -78,7 +79,7 @@ public final class CloudNetReportModule extends NodeCloudNetModule {
 
     @ModuleTask(order = 64, event = ModuleLifeCycle.STARTED)
     public void registerListeners() {
-        this.registerListener(new CloudNetReportListener());
+        this.registerListener(new CloudNetReportListener(this));
     }
 
     @ModuleTask(order = 16, event = ModuleLifeCycle.STARTED)

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/DefaultCloudService.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/service/defaults/DefaultCloudService.java
@@ -157,10 +157,10 @@ public abstract class DefaultCloudService extends DefaultEmptyCloudService {
             properties = this.serviceInfoSnapshot.getProperties();
         }
         return new ServiceInfoSnapshot(
-                System.currentTimeMillis(),
+                this.serviceInfoSnapshot == null ? System.currentTimeMillis() : this.serviceInfoSnapshot.getCreationTime(),
                 new HostAndPort(CloudNet.getInstance().getConfig().getHostAddress(), this.serviceConfiguration.getPort()),
                 new HostAndPort(CloudNet.getInstance().getConfig().getConnectHostAddress(), this.serviceConfiguration.getPort()),
-                -1,
+                this.serviceInfoSnapshot == null ? -1 : this.serviceInfoSnapshot.getConnectedTime(),
                 lifeCycle,
                 this.serviceInfoSnapshot != null && this.isAlive() ? this.serviceInfoSnapshot.getProcessSnapshot() : ProcessSnapshot.empty(),
                 properties,


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:
Print logs of services automatically when their lifetime is lower than a lifetime configurable in the Report Module config.

### Documentation of test results:
When a service stops for example because of the port is already used, the log will be printed.