### PR TITLE
Revert change of sql syntax to insert or update

### DIFF
--- a/cloudnet/src/main/java/de/dytanic/cloudnet/database/h2/H2Database.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/database/h2/H2Database.java
@@ -1,7 +1,5 @@
 package de.dytanic.cloudnet.database.h2;
 
-import com.google.common.base.Preconditions;
-import de.dytanic.cloudnet.common.document.gson.JsonDocument;
 import de.dytanic.cloudnet.database.sql.SQLDatabase;
 
 import java.util.concurrent.ExecutorService;
@@ -15,16 +13,5 @@ public final class H2Database extends SQLDatabase {
     @Override
     public boolean isSynced() {
         return false;
-    }
-
-    @Override
-    public boolean insertOrUpdate(String key, JsonDocument document) {
-        Preconditions.checkNotNull(key);
-        Preconditions.checkNotNull(document);
-
-        return this.databaseProvider.executeUpdate(
-                String.format("MERGE INTO `%s` (%s, %s) VALUES (?, ?);", this.name, TABLE_COLUMN_KEY, TABLE_COLUMN_VALUE),
-                key, document.toString()
-        ) != -1;
     }
 }

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/database/sql/SQLDatabase.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/database/sql/SQLDatabase.java
@@ -71,7 +71,6 @@ public abstract class SQLDatabase implements IDatabase {
         return this.insertOrUpdate(key, document);
     }
 
-    @Deprecated
     public boolean insert0(String key, JsonDocument document) {
         Preconditions.checkNotNull(key);
         Preconditions.checkNotNull(document);
@@ -94,7 +93,6 @@ public abstract class SQLDatabase implements IDatabase {
         return this.insertOrUpdate(key, document);
     }
 
-    @Deprecated
     public boolean update0(String key, JsonDocument document) {
         return this.databaseProvider.executeUpdate(
                 "UPDATE `" + this.name + "` SET " + TABLE_COLUMN_VALUE + "=? WHERE " + TABLE_COLUMN_KEY + "=?",
@@ -106,11 +104,7 @@ public abstract class SQLDatabase implements IDatabase {
         Preconditions.checkNotNull(key);
         Preconditions.checkNotNull(document);
 
-        return this.databaseProvider.executeUpdate(String.format(
-                "INSERT INTO `%s` (%s, %s) VALUES (?, ?) ON DUPLICATE KEY UPDATE %s = VALUES(%s);",
-                this.name, TABLE_COLUMN_KEY, TABLE_COLUMN_VALUE, TABLE_COLUMN_VALUE, TABLE_COLUMN_VALUE
-                ), key, document.toString()
-        ) != -1;
+        return this.contains(key) ? this.update0(key, document) : this.insert0(key, document);
     }
 
     @Override


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:

<!-- A brief description of the changes done in this pull request. -->

### Documentation of test results:

Reverts a change to the sql syntax INSERT ON DUPLICATE KEY UPDATE as older databases don't have a primary key.