### PR TITLE
Remove fallback in config of velocity

### DIFF
--- a/cloudnet/src/main/resources/files/velocity/velocity.toml
+++ b/cloudnet/src/main/resources/files/velocity/velocity.toml
@@ -34,7 +34,6 @@ announce-forge = false
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value
 # represents the IP address of the server to connect to.
-#fallback = "127.0.0.1:30066"
 
 # In what order we should try servers when a player logs in or is kicked from aserver.
 try = []

--- a/cloudnet/src/main/resources/files/velocity/velocity.toml
+++ b/cloudnet/src/main/resources/files/velocity/velocity.toml
@@ -34,18 +34,13 @@ announce-forge = false
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value
 # represents the IP address of the server to connect to.
-fallback = "127.0.0.1:30066"
+#fallback = "127.0.0.1:30066"
 
 # In what order we should try servers when a player logs in or is kicked from aserver.
-try = [
-  "fallback"
-]
+try = []
 
 [forced-hosts]
 # Configure your forced hosts here.
-"fallback.example.com" = [
-  "fallback"
-]
 
 [advanced]
 # How large a Minecraft packet has to be before we compress it. Setting this to zero will


### PR DESCRIPTION


This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Remove the default fallback in the velocity config to prevent errors if the only cloudnet fallback closes.

### Documentation of test results:
Tested the updated config with 1 / 2 cloudnet fallbacks and the issue is resolved.

