### PR TITLE
Implement chat variable to PermissionGroup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,6 +106,7 @@ pipeline {
         sh 'cp -r cloudnet/build/libs/*.jar temp/'
         sh 'cp -r cloudnet-driver/build/libs/*.jar temp/'
         sh 'cp -r cloudnet-modules/**/build/libs/*.jar temp/'
+        sh 'cp cloudnet-launcher/build/libs/launcher.jar temp/launcher.jar'
         sh 'cp -r **/build/libs/*.cnl temp/'
         zip archive: true, dir: 'temp', glob: '', zipFile: 'AutoUpdater.zip'
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ defaultTasks 'build', 'checkLicenses', 'test', 'jar'
 
 allprojects {
 
-  def major = 3, minor = 4, patch = 0, versionType = "SNAPSHOT"
+  def major = 3, minor = 4, patch = 0, versionType = "RELEASE"
 
   group 'de.dytanic.cloudnet'
   version "$major.$minor.$patch-$versionType"

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissionGroup.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/IPermissionGroup.java
@@ -47,4 +47,8 @@ public interface IPermissionGroup extends IPermissible {
 
   void setDisplay(@NotNull String display);
 
+  String getChat();
+
+  void setChat(@NotNull String chat);
+
 }

--- a/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionGroup.java
+++ b/cloudnet-driver/src/main/java/de/dytanic/cloudnet/driver/permission/PermissionGroup.java
@@ -45,6 +45,7 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
   private String color = "&7";
   private String suffix = "&f";
   private String display = "&7";
+  private String chat = "&7";
 
   private int sortId = 0;
 
@@ -61,7 +62,7 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
   }
 
   public PermissionGroup(String name, int potency, Collection<String> groups, String prefix, String color,
-    String suffix, String display, int sortId, boolean defaultGroup) {
+    String suffix, String display, String chat, int sortId, boolean defaultGroup) {
     super();
 
     this.name = name;
@@ -71,6 +72,7 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
     this.color = color;
     this.suffix = suffix;
     this.display = display;
+    this.chat = chat;
     this.sortId = sortId;
     this.defaultGroup = defaultGroup;
   }
@@ -115,6 +117,14 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
     this.display = display;
   }
 
+  public String getChat() {
+    return chat;
+  }
+
+  public void setChat(@NotNull String chat) {
+    this.chat = chat;
+  }
+
   public int getSortId() {
     return this.sortId;
   }
@@ -141,6 +151,7 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
     buffer.writeString(this.color);
     buffer.writeString(this.suffix);
     buffer.writeString(this.display);
+    buffer.writeString(this.chat);
 
     buffer.writeInt(this.sortId);
     buffer.writeBoolean(this.defaultGroup);
@@ -156,6 +167,7 @@ public class PermissionGroup extends AbstractPermissible implements IPermissionG
     this.color = buffer.readString();
     this.suffix = buffer.readString();
     this.display = buffer.readString();
+    this.chat = buffer.readString();
 
     this.sortId = buffer.readInt();
     this.defaultGroup = buffer.readBoolean();

--- a/cloudnet-driver/src/test/java/de/dytanic/cloudnet/driver/serialization/PermissionGroupSerializerTest.java
+++ b/cloudnet-driver/src/test/java/de/dytanic/cloudnet/driver/serialization/PermissionGroupSerializerTest.java
@@ -34,6 +34,7 @@ public class PermissionGroupSerializerTest {
       " \\ Admin \\ ",
       "§c",
       " / Team /",
+      " \\ Admin \\ ",
       "Administrator | ",
       1,
       false

--- a/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/configuration/SyncProxyTabList.java
+++ b/cloudnet-modules/cloudnet-syncproxy/src/main/java/de/dytanic/cloudnet/ext/syncproxy/configuration/SyncProxyTabList.java
@@ -65,6 +65,7 @@ public class SyncProxyTabList {
           input = input.replace("%prefix%", group.getPrefix())
             .replace("%suffix%", group.getSuffix())
             .replace("%display%", group.getDisplay())
+            .replace("%chat%", group.getChat())
             .replace("%color%", group.getColor())
             .replace("%group%", group.getName());
         }

--- a/cloudnet-plugins/cloudnet-chat/src/main/java/de/dytanic/cloudnet/ext/chat/CloudNetChatPlugin.java
+++ b/cloudnet-plugins/cloudnet-chat/src/main/java/de/dytanic/cloudnet/ext/chat/CloudNetChatPlugin.java
@@ -75,6 +75,7 @@ public class CloudNetChatPlugin extends JavaPlugin implements Listener {
           .replace("%prefix%", group.getPrefix())
           .replace("%suffix%", group.getSuffix())
           .replace("%color%", group.getColor())
+          .replace("%chat%", group.getChat())
       );
     } else {
       format = ChatColor.translateAlternateColorCodes('&',
@@ -84,6 +85,7 @@ public class CloudNetChatPlugin extends JavaPlugin implements Listener {
           .replace("%prefix%", "")
           .replace("%suffix%", "")
           .replace("%color%", "")
+          .replace("%chat%", "")
       );
     }
 

--- a/cloudnet-plugins/cloudnet-chat/src/main/resources/config.yml
+++ b/cloudnet-plugins/cloudnet-chat/src/main/resources/config.yml
@@ -10,4 +10,4 @@
 
 # permission to use "&" in messages for color: cloudnet.chat.color
 
-format: "%display%%name% &8:&f %message%"
+format: "%chat%%name% &8:&f %message%"

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandPermissions.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/command/commands/CommandPermissions.java
@@ -389,6 +389,13 @@ public class CommandPermissions extends SubCommandHandler {
       )
       .generateCommand(
         (subCommand, sender, command, args, commandLine, properties, internalProperties) -> ((IPermissionGroup) internalProperties
+          .get("group")).setChat((String) args.argument(4)),
+        subCommand -> subCommand.setMinArgs(5).setMaxArgs(Integer.MAX_VALUE),
+        exactStringIgnoreCase("chat"),
+        dynamicString("chat")
+      )
+      .generateCommand(
+        (subCommand, sender, command, args, commandLine, properties, internalProperties) -> ((IPermissionGroup) internalProperties
           .get("group")).setPrefix((String) args.argument(4)),
         subCommand -> subCommand.setMinArgs(5).setMaxArgs(Integer.MAX_VALUE),
         exactStringIgnoreCase("prefix"),
@@ -620,7 +627,9 @@ public class CommandPermissions extends SubCommandHandler {
       "Suffix: " + (sender instanceof ConsoleCommandSender ? permissionGroup.getSuffix()
         : permissionGroup.getSuffix().replace("&", "§")),
       "Display: " + (sender instanceof ConsoleCommandSender ? permissionGroup.getDisplay()
-        : permissionGroup.getDisplay().replace("&", "§"))
+        : permissionGroup.getDisplay().replace("&", "§")),
+      "Chat: " + (sender instanceof ConsoleCommandSender ? permissionGroup.getChat()
+        : permissionGroup.getChat().replace("&", "§"))
     );
 
     displayPermissions(sender, permissionGroup);

--- a/cloudnet/src/main/java/de/dytanic/cloudnet/setup/DefaultInstallation.java
+++ b/cloudnet/src/main/java/de/dytanic/cloudnet/setup/DefaultInstallation.java
@@ -114,6 +114,7 @@ public class DefaultInstallation {
       adminPermissionGroup.setColor("&7");
       adminPermissionGroup.setSuffix("&f");
       adminPermissionGroup.setDisplay("&4");
+      adminPermissionGroup.setChat("&4");
       adminPermissionGroup.setSortId(10);
 
       CloudNet.getInstance().getPermissionManagement().addGroup(adminPermissionGroup);
@@ -125,6 +126,7 @@ public class DefaultInstallation {
       defaultPermissionGroup.setColor("&7");
       defaultPermissionGroup.setSuffix("&f");
       defaultPermissionGroup.setDisplay("&7");
+      defaultPermissionGroup.setChat("&7");
       defaultPermissionGroup.setSortId(10);
 
       CloudNet.getInstance().getPermissionManagement().addGroup(defaultPermissionGroup);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

<!-- A brief description of the changes done in this pull request. -->
Add chat variable to permission group to provide an extra layout option for the cloudnet-chat plugin.

### Documentation of test results:

<!-- Add test results before and after applying your changes. -->
Tested at 3.4 in the [add-chat-variable](https://github.com/germanluca/CloudNet-v3/tree/add-chat-variable) at my fork.

### Related issues/discussions:

<!-- Add any related issues here by mentioning them (e.g. Fixes #1). -->  
There are no issues.
