### PR TITLE
Handle command exceptions for websocket messages as well

### DIFF
--- a/modules/rest/src/main/java/de/dytanic/cloudnet/ext/rest/v2/V2HttpHandlerNode.java
+++ b/modules/rest/src/main/java/de/dytanic/cloudnet/ext/rest/v2/V2HttpHandlerNode.java
@@ -16,7 +16,6 @@
 
 package de.dytanic.cloudnet.ext.rest.v2;
 
-import cloud.commandframework.exceptions.CommandParseException;
 import de.dytanic.cloudnet.CloudNet;
 import de.dytanic.cloudnet.common.log.AbstractHandler;
 import de.dytanic.cloudnet.common.log.LogManager;
@@ -34,11 +33,9 @@ import de.dytanic.cloudnet.http.HttpSession;
 import de.dytanic.cloudnet.http.WebSocketAbleV2HttpHandler;
 import de.dytanic.cloudnet.permission.command.PermissionUserCommandSource;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Formatter;
-import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
 import lombok.NonNull;
@@ -189,18 +186,10 @@ public class V2HttpHandlerNode extends WebSocketAbleV2HttpHandler {
 
         var commandSource = new PermissionUserCommandSource(user,
           V2HttpHandlerNode.this.node().permissionManagement());
-
-        try {
-          V2HttpHandlerNode.this.node().commandProvider().execute(commandSource, commandLine).join();
-        } catch (CompletionException exception) {
-          Throwable cause = exception.getCause();
-          if (!(cause instanceof CommandParseException)) {
-            throw exception;
-          }
-        }
+        V2HttpHandlerNode.this.node().commandProvider().execute(commandSource, commandLine).join();
 
         for (var message : commandSource.messages()) {
-          publish(new LogRecord(Level.INFO, message));
+          this.channel.sendWebSocketFrame(WebSocketFrameType.TEXT, message);
         }
       }
     }

--- a/modules/rest/src/main/java/de/dytanic/cloudnet/ext/rest/v2/V2HttpHandlerNode.java
+++ b/modules/rest/src/main/java/de/dytanic/cloudnet/ext/rest/v2/V2HttpHandlerNode.java
@@ -36,6 +36,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Formatter;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
 import lombok.NonNull;
@@ -189,7 +190,7 @@ public class V2HttpHandlerNode extends WebSocketAbleV2HttpHandler {
         V2HttpHandlerNode.this.node().commandProvider().execute(commandSource, commandLine).join();
 
         for (var message : commandSource.messages()) {
-          this.channel.sendWebSocketFrame(WebSocketFrameType.TEXT, message);
+          publish(new LogRecord(Level.INFO, message));
         }
       }
     }

--- a/node/src/main/java/de/dytanic/cloudnet/command/defaults/DefaultCommandProvider.java
+++ b/node/src/main/java/de/dytanic/cloudnet/command/defaults/DefaultCommandProvider.java
@@ -118,8 +118,10 @@ public class DefaultCommandProvider implements CommandProvider {
    */
   @Override
   public @NonNull CompletableFuture<?> execute(@NonNull CommandSource source, @NonNull String input) {
-    return this.commandManager.executeCommand(source, input)
-      .whenComplete((result, throwable) -> this.exceptionHandler.handleCommandExceptions(source, throwable));
+    return this.commandManager.executeCommand(source, input).handle((result, throwable) -> {
+      this.exceptionHandler.handleCommandExceptions(source, throwable);
+      return result;
+    });
   }
 
   /**


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:
Command-Exceptions thrown by cloud are handled in the native console by catching every exception type and printing a human-readable message to the user. When sending commands using the WebSocket connection, the thrown exceptions are wrapped by a CompletionException and the full stack trace is printed to sout (see Before-image).
Now the CompletionException and their underlying Exception is handled and **not** thrown if the Exception is handled by CommandExceptionHandler.

### Documentation of test results:

Before: ![grafik](https://user-images.githubusercontent.com/27054324/147596763-7f4a3782-5025-4e8c-9a0f-b8d21f2d94dc.png)
After: ![grafik](https://user-images.githubusercontent.com/27054324/147596814-6e7e5d31-524f-4254-9d9c-71679fdf0272.png)


### Related issues/discussions:
N/A
