### PR TITLE
feat: add a simple placeholder expansion

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ bungeecord = "1.18-R0.1-SNAPSHOT"
 vault = "1.7.1"
 adventure = "4.9.3"
 modlauncher = "8.0.9"
+placeholderApi = "2.11.1"
 protocolLib = "master-SNAPSHOT"
 npcLib = "development-SNAPSHOT"
 
@@ -133,7 +134,9 @@ adventureSerializerLegacy = { group = "net.kyori", name = "adventure-text-serial
 vault = { group = "com.github.MilkBowl", name = "VaultAPI", version.ref = "vault" }
 npcLib = { group = "com.github.juliarn", name = "npc-lib", version.ref = "npcLib" }
 modLauncher = { group = "cpw.mods", name = "modlauncher", version.ref = "modlauncher" }
+placeholderApi = { group = "me.clip", name = "placeholderapi", version.ref = "placeholderApi" }
 protocolLib = { group = "com.github.dmulloy2", name = "ProtocolLib", version.ref = "protocolLib" }
+
 
 [bundles]
 

--- a/plugins/papi-expansion/build.gradle.kts
+++ b/plugins/papi-expansion/build.gradle.kts
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 
-plugins {
-  id("net.kyori.blossom") version Versions.blossom apply false
+repositories {
+  maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
 }
 
-subprojects {
-  apply(plugin = "net.kyori.blossom")
+dependencies {
+  compileOnly(libs.spigot)
+  compileOnly(libs.placeholderApi)
+  compileOnly(projects.cloudnetWrapperJvm)
+  compileOnly(projects.cloudnetModules.bridge)
+}
 
-  repositories {
-    maven("https://repo.spongepowered.org/maven/")
-    maven("https://repo.opencollab.dev/maven-snapshots/")
-    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
-  }
-
-  tasks.named<Copy>("processResources") {
-    filter {
-      it
-        .replace("{project.build.version}", project.version.toString())
-        .replace("{project.perms.build.version}", projects.cloudnetModules.cloudperms.version.toString())
-    }
-  }
+configure<net.kyori.blossom.BlossomExtension> {
+  replaceToken("{project.build.version}", project.version)
 }

--- a/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
+++ b/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.plugins.papi;
+
+import eu.cloudnetservice.cloudnet.wrapper.Wrapper;
+import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class CloudNetPapiExpansion extends PlaceholderExpansion {
+
+  @Override
+  public @NotNull String getIdentifier() {
+    return "cloudnet";
+  }
+
+  @Override
+  public @NotNull String getName() {
+    return "CloudNet";
+  }
+
+  @Override
+  public @NotNull String getAuthor() {
+    return "CloudNetService";
+  }
+
+  @Override
+  public @NotNull String getVersion() {
+    return "{project.build.version}";
+  }
+
+  @Override
+  public @Nullable String getRequiredPlugin() {
+    return "CloudNet-Bridge";
+  }
+
+  @Override
+  public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
+    // This is a bit tricky - PlaceholderAPI requires us to return "null" if the placeholder is unknown.
+    // The bridge will just replace all placeholders in the string with the correct association.
+    // We can just return null if the resulting string matches the input string
+    var input = '%' + params + '%';
+    var out = BridgeServiceHelper.fillCommonPlaceholders(input, null, Wrapper.instance().currentServiceInfo());
+
+    return out.equals(input) ? null : out;
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ initializeProjects("bom", "ext", "common", "driver", "node", "wrapper-jvm", "lau
 // external lib helpers
 initializeSubProjects("ext", "modlauncher", "adventure-helper", "bukkit-command", "updater")
 // plugins
-initializeSubProjects("plugins", "chat", "simplenametags")
+initializeSubProjects("plugins", "chat", "simplenametags", "papi-expansion")
 // modules
 initializeSubProjects("modules",
   "bridge",


### PR DESCRIPTION
This adds a simple expansion for the [PlaceholderAPI](https://github.com/PlaceholderAPI/PlaceholderAPI). It supports all placeholders the bridge supports as well (these are all used for example on signs or in npc inventories).

Closes #331
