### PR TITLE
Remove unsafe socket address casts

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgeManagement.java
@@ -17,7 +17,6 @@
 package eu.cloudnetservice.modules.bridge.platform.bukkit;
 
 import eu.cloudnetservice.cloudnet.common.registry.ServicesRegistry;
-import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.cloudnet.wrapper.Wrapper;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
@@ -26,6 +25,7 @@ import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
 import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.bridge.player.ServicePlayer;
 import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
+import eu.cloudnetservice.modules.bridge.util.BridgeHostAndPortUtil;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
@@ -74,7 +74,7 @@ final class BukkitBridgeManagement extends PlatformBridgeManagement<Player, Netw
       player.getUniqueId(),
       player.getName(),
       null,
-      new HostAndPort(player.getAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(player.getAddress()),
       this.ownNetworkServiceInfo);
   }
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgeManagement.java
@@ -18,7 +18,6 @@ package eu.cloudnetservice.modules.bridge.platform.bungeecord;
 
 import com.google.common.collect.Iterables;
 import eu.cloudnetservice.cloudnet.common.registry.ServicesRegistry;
-import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.cloudnet.wrapper.Wrapper;
@@ -28,7 +27,7 @@ import eu.cloudnetservice.modules.bridge.player.NetworkPlayerProxyInfo;
 import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.bridge.player.ServicePlayer;
 import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
-import java.net.InetSocketAddress;
+import eu.cloudnetservice.modules.bridge.util.BridgeHostAndPortUtil;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
@@ -83,8 +82,8 @@ final class BungeeCordBridgeManagement extends PlatformBridgeManagement<ProxiedP
       player.getName(),
       null,
       player.getPendingConnection().getVersion(),
-      new HostAndPort((InetSocketAddress) player.getSocketAddress()),
-      new HostAndPort((InetSocketAddress) player.getPendingConnection().getListener().getSocketAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(player.getSocketAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(player.getPendingConnection().getListener().getSocketAddress()),
       player.getPendingConnection().isOnlineMode(),
       this.ownNetworkServiceInfo);
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
@@ -18,13 +18,12 @@ package eu.cloudnetservice.modules.bridge.platform.bungeecord;
 
 import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
 
-import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
 import eu.cloudnetservice.cloudnet.wrapper.Wrapper;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.helper.ProxyPlatformHelper;
 import eu.cloudnetservice.modules.bridge.player.NetworkPlayerProxyInfo;
-import java.net.InetSocketAddress;
+import eu.cloudnetservice.modules.bridge.util.BridgeHostAndPortUtil;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
@@ -87,8 +86,8 @@ final class BungeeCordPlayerManagementListener implements Listener {
       event.getConnection().getName(),
       null,
       event.getConnection().getVersion(),
-      new HostAndPort((InetSocketAddress) event.getConnection().getSocketAddress()),
-      new HostAndPort((InetSocketAddress) event.getConnection().getListener().getSocketAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(event.getConnection().getSocketAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(event.getConnection().getListener().getSocketAddress()),
       event.getConnection().isOnlineMode(),
       this.management.ownNetworkServiceInfo()));
     if (!loginResult.permitLogin()) {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgeManagement.java
@@ -20,7 +20,6 @@ import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.permission.Permissible;
 import eu.cloudnetservice.cloudnet.common.registry.ServicesRegistry;
-import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.cloudnet.wrapper.Wrapper;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
@@ -29,6 +28,7 @@ import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
 import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.bridge.player.ServicePlayer;
 import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
+import eu.cloudnetservice.modules.bridge.util.BridgeHostAndPortUtil;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
@@ -70,7 +70,7 @@ final class NukkitBridgeManagement extends PlatformBridgeManagement<Player, Netw
       player.getUniqueId(),
       player.getName(),
       player.getLoginChainData().getXUID(),
-      new HostAndPort(player.getSocketAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(player.getSocketAddress()),
       this.ownNetworkServiceInfo);
   }
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgeManagement.java
@@ -17,7 +17,6 @@
 package eu.cloudnetservice.modules.bridge.platform.sponge;
 
 import eu.cloudnetservice.cloudnet.common.registry.ServicesRegistry;
-import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.cloudnet.wrapper.Wrapper;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
@@ -26,6 +25,7 @@ import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
 import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.bridge.player.ServicePlayer;
 import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
+import eu.cloudnetservice.modules.bridge.util.BridgeHostAndPortUtil;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
@@ -71,7 +71,7 @@ final class SpongeBridgeManagement extends PlatformBridgeManagement<ServerPlayer
       player.uniqueId(),
       player.name(),
       null,
-      new HostAndPort(player.connection().address()),
+      BridgeHostAndPortUtil.fromSocketAddress(player.connection().address()),
       this.ownNetworkServiceInfo);
   }
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgeManagement.java
@@ -24,7 +24,6 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import eu.cloudnetservice.cloudnet.common.registry.ServicesRegistry;
-import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.cloudnet.wrapper.Wrapper;
@@ -34,6 +33,7 @@ import eu.cloudnetservice.modules.bridge.player.NetworkPlayerProxyInfo;
 import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.bridge.player.ServicePlayer;
 import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
+import eu.cloudnetservice.modules.bridge.util.BridgeHostAndPortUtil;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Optional;
@@ -92,8 +92,8 @@ final class VelocityBridgeManagement extends PlatformBridgeManagement<Player, Ne
       player.getUsername(),
       null,
       player.getProtocolVersion().getProtocol(),
-      new HostAndPort(player.getRemoteAddress()),
-      new HostAndPort(this.proxyServer.getBoundAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(player.getRemoteAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(this.proxyServer.getBoundAddress()),
       player.isOnlineMode(),
       this.ownNetworkServiceInfo);
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgeManagement.java
@@ -22,7 +22,6 @@ import dev.waterdog.waterdogpe.command.CommandSender;
 import dev.waterdog.waterdogpe.network.serverinfo.BedrockServerInfo;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 import eu.cloudnetservice.cloudnet.common.registry.ServicesRegistry;
-import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.cloudnet.wrapper.Wrapper;
@@ -32,6 +31,7 @@ import eu.cloudnetservice.modules.bridge.player.NetworkPlayerProxyInfo;
 import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.bridge.player.ServicePlayer;
 import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
+import eu.cloudnetservice.modules.bridge.util.BridgeHostAndPortUtil;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Optional;
@@ -88,8 +88,8 @@ final class WaterDogPEBridgeManagement extends PlatformBridgeManagement<ProxiedP
       player.getName(),
       player.getXuid(),
       player.getProtocol().getRaknetVersion(),
-      new HostAndPort(player.getAddress()),
-      new HostAndPort(ProxyServer.getInstance().getConfiguration().getBindAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(player.getAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(ProxyServer.getInstance().getConfiguration().getBindAddress()),
       player.getLoginData().isXboxAuthed(),
       this.ownNetworkServiceInfo);
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/util/BridgeHostAndPortUtil.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/util/BridgeHostAndPortUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.modules.bridge.util;
+
+import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.unix.DomainSocketAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnixDomainSocketAddress;
+import lombok.NonNull;
+
+public final class BridgeHostAndPortUtil {
+
+  private BridgeHostAndPortUtil() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static @NonNull HostAndPort fromSocketAddress(@NonNull SocketAddress address) {
+    // default java.net addresses are supported by default
+    if (address instanceof InetSocketAddress || address instanceof UnixDomainSocketAddress) {
+      return HostAndPort.fromSocketAddress(address);
+    }
+    // netty unix domain socket version
+    if (address instanceof DomainSocketAddress domain) {
+      return new HostAndPort(domain.path(), HostAndPort.NO_PORT);
+    }
+    // netty local address
+    if (address instanceof LocalAddress local) {
+      return new HostAndPort(local.id(), HostAndPort.NO_PORT);
+    }
+    // unsupported address
+    throw new IllegalArgumentException("Unsupported socket address type: " + address.getClass().getName());
+  }
+}


### PR DESCRIPTION
Especaially for bungeecord, as noted in the documentation you can connect to the proxy using a domain socket address which is not an InetSocketAddress.

We cannot move the netty casts to the HostAndPort class directly because of the relocation happening during the compile.