### PR TITLE
Fix double wrapped arguments passed to launcher patcher

### DIFF
--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherUpdater.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherUpdater.java
@@ -47,8 +47,8 @@ public final class LauncherUpdater implements Updater<LauncherUpdaterContext> {
             "-jar",
             launcherPatcherPath.toAbsolutePath().toString(),
             Long.toString(ProcessHandle.current().pid()),
-            String.format("\"%s\"", currentJar.toAbsolutePath()),
-            String.format("\"%s\"", launcherPath.toAbsolutePath()));
+            currentJar.toAbsolutePath().toString(),
+            launcherPath.toAbsolutePath().toString());
           var updaterLogFile = context.launcher().workingDirectory().resolve("launcher_updater.log").toFile();
           // start the process
           new ProcessBuilder(command)


### PR DESCRIPTION
This causes the launcher patcher to fail while replacing the old launcher jar with the new one.
Output before fix:
```
Exception in thread "main" java.io.UncheckedIOException: java.nio.file.NoSuchFileException: "/opt/Playo Cloud/launcher/launcher-update.jar"
    at eu.cloudnetservice.launcher.patcher.CloudNetLauncherPatcher.replaceOldLauncher(CloudNetLauncherPatcher.java:53)
    at eu.cloudnetservice.launcher.patcher.CloudNetLauncherPatcher.main(CloudNetLauncherPatcher.java:44)
Caused by: java.nio.file.NoSuchFileException: "/opt/Playo Cloud/launcher/launcher-update.jar"
    at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
    at java.base/sun.nio.fs.UnixCopyFile.copy(UnixCopyFile.java:548)
    at java.base/sun.nio.fs.UnixFileSystemProvider.copy(UnixFileSystemProvider.java:258)
    at java.base/java.nio.file.Files.copy(Files.java:1305)
    at eu.cloudnetservice.launcher.patcher.CloudNetLauncherPatcher.replaceOldLauncher(CloudNetLauncherPatcher.java:51)
    ... 1 more
```

Output after fix:
```
Picked up options: /opt/Playo Cloud/launcher.jar -> /opt/Playo Cloud/launcher/launcher-update.jar (pid: 1194554)
Running patcher on file /opt/Playo Cloud/launcher.jar
```