### PR TITLE
Return a bad request response if a handler fails

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/cloudnet/driver/network/netty/http/NettyHttpServerHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/cloudnet/driver/network/netty/http/NettyHttpServerHandler.java
@@ -275,10 +275,13 @@ final class NettyHttpServerHandler extends SimpleChannelInboundHandler<HttpReque
       httpHandlerEntry.httpHandler().handle(fullPath.toLowerCase(), context);
       return true;
     } catch (Exception exception) {
-      LOGGER.severe(
+      LOGGER.finer(
         "Exception posting http request to handler %s",
         exception,
         httpHandlerEntry.httpHandler().getClass().getName());
+      // assume that the request was bad so that the handler was unable to handle it
+      context.response().status(HttpResponseCode.BAD_REQUEST);
+      // continue with the next handler in the chain
       return false;
     }
   }


### PR DESCRIPTION
Closes #567. There is no real need for us in the rest api to validate input of the developer as every wrong input is checked (either manually using Preconditions or automatically using lombok) and will cause an exception. However there is no need to log every exception if someone sends a bad request, nor is there a need to respond with 404 rather than 400 which gives the developer a rough idea that something went wrong.