### PR TITLE
Make translation stuff easier to access for modules

### DIFF
--- a/common/src/main/java/eu/cloudnetservice/cloudnet/common/language/I18n.java
+++ b/common/src/main/java/eu/cloudnetservice/cloudnet/common/language/I18n.java
@@ -16,153 +16,223 @@
 
 package eu.cloudnetservice.cloudnet.common.language;
 
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.SetMultimap;
+import eu.cloudnetservice.cloudnet.common.io.FileUtil;
 import eu.cloudnetservice.cloudnet.common.log.LogManager;
 import eu.cloudnetservice.cloudnet.common.log.Logger;
-import java.io.BufferedReader;
+import eu.cloudnetservice.cloudnet.common.unsafe.ResourceResolver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * The LanguageManager is a static service, which handles messages from different languages, which are registered or
- * loaded there
+ * The main entry point for localization made in the CloudNet system. Language files can be registered in multiple ways
+ * to this registry. Multiple language files for the same language will be combined to one entry and can be translated.
+ * If multiple language files with the same language key are registered, the first registered language file will be used
+ * to translate the requested key.
+ * <p>
+ * Unregistering language files can be done via the class loader which must be given for message loading.
+ *
+ * @since 4.0
  */
 public final class I18n {
 
-  private static final Logger LOGGER = LogManager.logger(I18n.class);
-  private static final Map<String, Map<String, MessageFormat>> LANGUAGE_CACHE = new ConcurrentHashMap<>();
   // https://regex101.com/r/syFEig/1
   private static final Pattern MESSAGE_FORMAT = Pattern.compile("\\{(.+?)\\$.+?\\$}");
 
-  /**
-   * The current language, which the trans() method will the message return
-   */
-  private static volatile String language;
+  private static final Logger LOGGER = LogManager.logger(I18n.class);
+  private static final SetMultimap<String, Entry> REGISTERED_ENTRIES = HashMultimap.create();
+  private static final AtomicReference<String> CURRENT_LANGUAGE = new AtomicReference<>("en_US");
 
   private I18n() {
     throw new UnsupportedOperationException();
   }
 
-  public static void loadFromLanguageRegistryFile(@NonNull ClassLoader source) {
-    try (var reader = new BufferedReader(new InputStreamReader(
-      Objects.requireNonNull(source.getResourceAsStream("languages.txt")),
-      StandardCharsets.UTF_8))
-    ) {
-      String lang;
-      while ((lang = reader.readLine()) != null) {
-        var stream = source.getResourceAsStream("lang/" + lang);
-        if (stream != null) {
-          addLanguageFile(lang.replace(".properties", ""), stream);
-        } else {
-          LOGGER.fine("Skipping default language %s because the file is missing", null, lang);
-        }
+  /**
+   * Loads all language files which are located in the jar at given class source and registers them to the loader of the
+   * given class. All language files in the jar must be located in the {@code lang/} directory and their extension must
+   * be properties. Subdirectories are ignored by this method.
+   *
+   * @param clazzSource the source which tries to register all language files.
+   * @throws NullPointerException if the given class source is null.
+   */
+  public static void loadFromLangPath(@NonNull Class<?> clazzSource) {
+    var resourcePath = Path.of(ResourceResolver.resolveURIFromResourceByClass(clazzSource));
+    FileUtil.openZipFileSystem(resourcePath, fs -> {
+      // get the language directory
+      var langDir = fs.getPath("lang/");
+      if (Files.notExists(langDir) || !Files.isDirectory(langDir)) {
+        throw new IllegalStateException("lang/ must be an existing directory inside the jar to load");
       }
+      // visit each file and register it as a language source
+      FileUtil.walkFileTree(langDir, ($, sub) -> {
+        // try to load and register the language file
+        try (var stream = Files.newInputStream(sub)) {
+          var lang = sub.getFileName().toString().replace(".properties", "");
+          addLanguageFile(lang, stream, clazzSource.getClassLoader());
+        } catch (IOException exception) {
+          LOGGER.severe("Unable to open language file for reading @ %s", exception, sub);
+        }
+      }, false, "*.properties");
+    });
+  }
+
+  /**
+   * Registers the language properties file at the given path to the given language and loader source.
+   *
+   * @param lang   the language to register the file to.
+   * @param file   the location of the language file to load.
+   * @param source the class loader to which the requester belongs.
+   * @throws NullPointerException if either the given language, file or loader is null.
+   */
+  public static void addLanguageFile(@NonNull String lang, @NonNull Path file, @NonNull ClassLoader source) {
+    try (var inputStream = Files.newInputStream(file)) {
+      addLanguageFile(lang, inputStream, source);
     } catch (IOException exception) {
-      LOGGER.severe("Unable to load language registry", exception);
+      LOGGER.severe("Exception while reading language file", exception);
     }
   }
 
   /**
-   * Resolve and returns the following message in the language which is currently set as member "language"
+   * Registers the language properties file which must be loadable from the given stream to the given language and
+   * loader source. This method uses utf-8 to decode the stream.
    *
-   * @param messageKey the following message property, which should sort out
-   * @return the message which is defined in language cache or a fallback message like {@literal "<language LANGUAGE not
-   * found>"} or {@literal "<message property not found in LANGUAGE>"}
+   * @param lang   the language to register the file to.
+   * @param stream the stream from which the properties should get loaded.
+   * @param source the class loader to which the requester belongs.
+   * @throws NullPointerException if either the given language, stream or loader is null.
+   */
+  public static void addLanguageFile(@NonNull String lang, @NonNull InputStream stream, @NonNull ClassLoader source) {
+    try (var reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+      // load the properties
+      var properties = new Properties();
+      properties.load(reader);
+      // register all language keys
+      addLanguageFile(lang, properties, source);
+    } catch (IOException exception) {
+      LOGGER.severe("Exception while reading language file", exception);
+    }
+  }
+
+  /**
+   * Registers the language properties file to the given language and loader source.
+   *
+   * @param lang    the language to register the file to.
+   * @param entries the entries of the language file to register.
+   * @param source  the class loader to which the requester belongs.
+   * @throws NullPointerException if either the given language, entries or loader is null.
+   */
+  public static void addLanguageFile(@NonNull String lang, @NonNull Properties entries, @NonNull ClassLoader source) {
+    var format = ImmutableMap.<String, MessageFormat>builder();
+    // register for each property key the associated value wrapped by a MessageFormat for later formatting
+    // this also unwraps message formatting keys for easier translation like {0$service$} to {0}
+    for (var key : entries.stringPropertyNames()) {
+      format.put(key, new MessageFormat(MESSAGE_FORMAT.matcher(entries.getProperty(key)).replaceAll("{$1}")));
+    }
+
+    // register all translations for the language
+    REGISTERED_ENTRIES.put(lang, new Entry(source, format.build()));
+    LOGGER.fine("Registering language file %s with %d translations", null, lang, entries.size());
+  }
+
+  /**
+   * Unregisters all language files which were registered by providing the given class loader.
+   *
+   * @param loader the loader to unregister the language files of.
+   * @throws NullPointerException if the given loader is null.
+   */
+  public static void unregisterLanguageFiles(@NonNull ClassLoader loader) {
+    for (var entry : REGISTERED_ENTRIES.entries()) {
+      if (entry.getValue().source().equals(loader)) {
+        REGISTERED_ENTRIES.remove(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  /**
+   * Tries to translate the given message key using all currently registered language files for the language this
+   * registry currently uses. This method uses the first language entry which can translate the given key, ignoring all
+   * duplicate keys.
+   * <p>
+   * This method will never return null. However, it does return a string which either indicates that no language files
+   * are registered for the current language, or that no registered entry is able to translate the given key.
+   *
+   * @param messageKey the key of the message to translate.
+   * @param args       the arguments for the translation.
+   * @throws NullPointerException if either the given key or argument array is null.
    */
   public static String trans(@NonNull String messageKey, @NonNull Object... args) {
-    if (language == null || !LANGUAGE_CACHE.containsKey(language)) {
-      return "<language " + language + " not found>";
+    // check if there is at least one entry for the current language
+    var entries = REGISTERED_ENTRIES.get(I18n.language());
+    if (entries.isEmpty()) {
+      return String.format("<no language entry for %s>", I18n.language());
     }
-    var message = LANGUAGE_CACHE.get(language)
-      .get(messageKey);
-    // check if we know this key
-    if (message == null) {
-      return "<message " + messageKey + " not found in language " + language + ">";
+
+    // use the first entry which is able to translate the given entry
+    for (var entry : entries) {
+      var result = entry.tryTranslate(messageKey, args);
+      if (result != null) {
+        // successful translate
+        return result;
+      }
     }
-    // apply the args to the message
-    return message.format(args);
+
+    // fallthrough if no registered entry can translate the message
+    return String.format("<no entry to translate \"%s\" in language \"%s\">", messageKey, I18n.language());
   }
 
   /**
-   * Add a new language properties, which can resolve with trans() in the configured language.
+   * Get the current language to which each message will be translated.
    *
-   * @param language   the language, which should append
-   * @param properties the properties which will add in the language as parameter
+   * @return the current message of this manager.
    */
-  public static void addLanguageFile(@NonNull String language, @NonNull Properties properties) {
-    var format = ImmutableMap.<String, MessageFormat>builder();
-    for (var key : properties.stringPropertyNames()) {
-      var property = properties.getProperty(key);
-      // store the key & the new MessageFormat for the property
-      format.put(key, new MessageFormat(MESSAGE_FORMAT.matcher(property).replaceAll("{$1}")));
-    }
-    LANGUAGE_CACHE.put(language, format.build());
-    LOGGER.fine("Registering language file %s with %d translations", null, language, properties.size());
-  }
-
-  /**
-   * Add a new language properties, which can resolve with trans() in the configured language.
-   *
-   * @param language the language, which should append
-   * @param file     the properties which will add in the language as parameter
-   */
-  public static void addLanguageFile(@NonNull String language, @NonNull Path file) {
-    try (var inputStream = Files.newInputStream(file)) {
-      addLanguageFile(language, inputStream);
-    } catch (IOException exception) {
-      LOGGER.severe("Exception while reading language file", exception);
-    }
-  }
-
-  /**
-   * Add a new language properties, which can resolve with trans() in the configured language.
-   *
-   * @param language    the language, which should append
-   * @param inputStream the properties which will add in the language as parameter
-   */
-  public static void addLanguageFile(@NonNull String language, @NonNull InputStream inputStream) {
-    try (var reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
-      addLanguageFile(language, reader);
-    } catch (IOException exception) {
-      LOGGER.severe("Exception while reading language file", exception);
-    }
-  }
-
-  /**
-   * Add a new language properties, which can resolve with trans() in the configured language.
-   *
-   * @param language the language, which should append
-   * @param reader   the properties which will be added in the language as parameter
-   */
-  public static void addLanguageFile(@NonNull String language, @NonNull Reader reader) {
-    var properties = new Properties();
-
-    try {
-      properties.load(reader);
-    } catch (IOException exception) {
-      LOGGER.severe("Exception while reading language file", exception);
-    }
-
-    addLanguageFile(language, properties);
-  }
-
   public static @NonNull String language() {
-    return I18n.language;
+    return I18n.CURRENT_LANGUAGE.get();
   }
 
+  /**
+   * Sets the current message to which all messages should get translated. There is no check made if any message is
+   * registered for the given language.
+   *
+   * @param language the language this manager should use.
+   * @throws NullPointerException if the given language is null.
+   */
   public static void language(@NonNull String language) {
-    I18n.language = language;
+    I18n.CURRENT_LANGUAGE.set(language);
+  }
+
+  /**
+   * A registered entry in this registry mapping the loader source and all messages of it.
+   *
+   * @since 4.0
+   */
+  private record Entry(@NonNull ClassLoader source, @NonNull Map<String, MessageFormat> languageEntries) {
+
+    /**
+     * Tries to translate the given key and formats it with the given arguments. If no mapping for the given key is
+     * registered this method simply returns null.
+     *
+     * @param key  the key to translate.
+     * @param args the arguments to use during translation.
+     * @return the translated message for the given key or null if the given key is unknown.
+     * @throws NullPointerException if the given key of argument array is null.
+     */
+    public @Nullable String tryTranslate(@NonNull String key, @NonNull Object... args) {
+      // try to get the associated format with the key
+      var format = this.languageEntries.get(key);
+      return format == null ? null : format.format(args);
+    }
   }
 }

--- a/common/src/test/java/eu/cloudnetservice/cloudnet/common/language/I18nTest.java
+++ b/common/src/test/java/eu/cloudnetservice/cloudnet/common/language/I18nTest.java
@@ -26,12 +26,14 @@ import org.junit.jupiter.api.Test;
 public class I18nTest {
 
   @Test
-  public void test() {
+  void testMessageRegistering() {
+    var loader = I18nTest.class.getClassLoader();
+
     var properties = new Properties();
     properties.put("test_message", "Test_Message");
 
     I18n.language("en");
-    I18n.addLanguageFile("en", properties);
+    I18n.addLanguageFile("en", properties, loader);
 
     Assertions.assertNotNull(I18n.trans("test_message"));
     Assertions.assertEquals("Test_Message", I18n.trans("test_message"));
@@ -41,19 +43,19 @@ public class I18nTest {
       properties.put(StringUtil.generateRandomString(5), StringUtil.generateRandomString(5));
     }
 
-    I18n.addLanguageFile("en", properties);
+    I18n.addLanguageFile("en", properties, loader);
     for (var entry : properties.entrySet()) {
       Assertions.assertEquals(entry.getValue(), I18n.trans(entry.getKey().toString()));
     }
   }
 
   @Test
-  public void testMessageFormatting() {
+  void testMessageFormatting() {
     var directory = Path.of("../node/src/main/resources/lang");
     // walk the lang directory and try to parse all translations to check if there are no unclosed formatting characters
     FileUtil.walkFileTree(
       directory,
-      (root, sub) -> I18n.addLanguageFile("test_TEST", sub),
+      (root, sub) -> I18n.addLanguageFile("test_TEST", sub, I18nTest.class.getClassLoader()),
       true);
   }
 }

--- a/launcher/java17/src/main/resources/launcher.cnl
+++ b/launcher/java17/src/main/resources/launcher.cnl
@@ -43,7 +43,7 @@ var cloudnet.logging.defaultlevel INFO
 # Sets the path of the directory in which all temporary services are saved.
 #var cloudnet.tempDir.services temp/services
 # Sets the language CloudNet uses to print messages. This defaults to english if the given language doesn't exist.
-#var cloudnet.messages.language english
+#var cloudnet.messages.language en_US
 # Sets the directory where the launcher safes it's data to. This includes updater data and libraries.
 #var cloudnet.launcherdir launcher
 # Sets the config file location of the node configuration.

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/BootLogic.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/BootLogic.java
@@ -39,8 +39,8 @@ public final class BootLogic {
 
   public static void main(String[] args) throws Throwable {
     // language management init
-    I18n.loadFromLanguageRegistryFile(BootLogic.class.getClassLoader());
-    I18n.language(System.getProperty("cloudnet.messages.language", "english"));
+    I18n.loadFromLangPath(BootLogic.class);
+    I18n.language(System.getProperty("cloudnet.messages.language", "en_US"));
 
     // init logger and console
     Console console = new JLine3Console();

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/module/NodeModuleProviderHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/module/NodeModuleProviderHandler.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.cloudnet.node.module;
 
+import eu.cloudnetservice.cloudnet.common.language.I18n;
 import eu.cloudnetservice.cloudnet.driver.module.DefaultModuleProviderHandler;
 import eu.cloudnetservice.cloudnet.driver.module.ModuleProviderHandler;
 import eu.cloudnetservice.cloudnet.driver.module.ModuleWrapper;
@@ -55,6 +56,8 @@ public final class NodeModuleProviderHandler extends DefaultModuleProviderHandle
     this.nodeInstance.dataSyncRegistry().unregisterHandler(moduleWrapper.classLoader());
     // unregister all object mappers which are registered
     DefaultObjectMapper.DEFAULT_MAPPER.unregisterBindings(moduleWrapper.classLoader());
+    // unregister all language files
+    I18n.unregisterLanguageFiles(moduleWrapper.classLoader());
   }
 
   private void removeListeners(@NonNull Collection<NetworkChannel> channels, @NonNull ClassLoader loader) {

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/cloudnet/wrapper/Main.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/cloudnet/wrapper/Main.java
@@ -35,8 +35,8 @@ public final class Main {
 
   public static void main(String... args) throws Throwable {
     // language init
-    I18n.loadFromLanguageRegistryFile(Main.class.getClassLoader());
-    I18n.language(System.getProperty("cloudnet.wrapper.messages.language", "english"));
+    I18n.loadFromLangPath(Main.class);
+    I18n.language(System.getProperty("cloudnet.wrapper.messages.language", "en_US"));
     // logger init
     initLogger(LogManager.rootLogger());
     // boot the wrapper


### PR DESCRIPTION
Improves translation handling in a way that allows modules (or other external components) to easily access and register/unregister translation from the registry without the need for any hacking or all translations in one big language file.

Closes #330