### PR TITLE
Add Available Servers and Max Servers in CloudNet NPC Module

### DIFF
--- a/cloudnet-modules/cloudnet-npcs/src/main/java/eu/cloudnetservice/cloudnet/ext/npcs/AbstractNPCManagement.java
+++ b/cloudnet-modules/cloudnet-npcs/src/main/java/eu/cloudnetservice/cloudnet/ext/npcs/AbstractNPCManagement.java
@@ -18,11 +18,13 @@ package eu.cloudnetservice.cloudnet.ext.npcs;
 
 import de.dytanic.cloudnet.common.collection.Pair;
 import de.dytanic.cloudnet.common.document.gson.JsonDocument;
+import de.dytanic.cloudnet.driver.CloudNetDriver;
 import de.dytanic.cloudnet.driver.channel.ChannelMessage;
 import de.dytanic.cloudnet.driver.event.EventListener;
 import de.dytanic.cloudnet.driver.event.events.channel.ChannelMessageReceiveEvent;
 import de.dytanic.cloudnet.driver.service.ServiceEnvironmentType;
 import de.dytanic.cloudnet.driver.service.ServiceInfoSnapshot;
+import de.dytanic.cloudnet.driver.service.ServiceTask;
 import de.dytanic.cloudnet.ext.bridge.ServiceInfoStateWatcher;
 import de.dytanic.cloudnet.wrapper.Wrapper;
 import eu.cloudnetservice.cloudnet.ext.npcs.configuration.NPCConfiguration;
@@ -242,4 +244,16 @@ public abstract class AbstractNPCManagement extends ServiceInfoStateWatcher {
     return new HashSet<>(this.cloudNPCS);
   }
 
+  /**
+   * Get the max services from target group
+   *
+   * @return the max service count
+   */
+  public int getMaxServices(@NotNull CloudNPC cloudNPC) {
+    ServiceTask serviceTask = CloudNetDriver.getInstance()
+      .getServiceTaskProvider().getServiceTask(cloudNPC.getTargetGroup());
+
+    if (serviceTask == null) return 0;
+    return serviceTask.getProperties().getDocument("smartConfig").getInt("maxServiceCount");
+  }
 }

--- a/cloudnet-modules/cloudnet-npcs/src/main/java/eu/cloudnetservice/cloudnet/ext/npcs/bukkit/BukkitNPCManagement.java
+++ b/cloudnet-modules/cloudnet-npcs/src/main/java/eu/cloudnetservice/cloudnet/ext/npcs/bukkit/BukkitNPCManagement.java
@@ -269,7 +269,7 @@ public class BukkitNPCManagement extends AbstractNPCManagement {
         .replace("%online_players%", onlinePlayers).replace("%o_p%", onlinePlayers)
         .replace("%max_players%", maxPlayers).replace("%m_p%", maxPlayers)
         .replace("%online_servers%", onlineServers).replace("%o_s%", onlineServers)
-        .replace("%available_servers%", availableServers).replace("%a_s", availableServers)
+        .replace("%available_servers%", availableServers).replace("%a_s%", availableServers)
         .replace("%max_servers%", maxServers).replace("%m_s%", maxServers);
 
       // update the stand

--- a/cloudnet-modules/cloudnet-npcs/src/main/java/eu/cloudnetservice/cloudnet/ext/npcs/bukkit/BukkitNPCManagement.java
+++ b/cloudnet-modules/cloudnet-npcs/src/main/java/eu/cloudnetservice/cloudnet/ext/npcs/bukkit/BukkitNPCManagement.java
@@ -260,13 +260,17 @@ public class BukkitNPCManagement extends AbstractNPCManagement {
         .mapToInt(service -> service.getProperty(BridgeServiceProperty.MAX_PLAYERS).orElse(0))
         .sum());
       String onlineServers = String.valueOf(services.size());
+      String availableServers = String.valueOf(filterNPCServices(cloudNPC).size());
+      String maxServers = String.valueOf(getMaxServices(cloudNPC));
 
       // assemble the info line
       String infoLine = cloudNPC.getInfoLine()
         .replace("%group%", cloudNPC.getTargetGroup()).replace("%g%", cloudNPC.getTargetGroup())
         .replace("%online_players%", onlinePlayers).replace("%o_p%", onlinePlayers)
         .replace("%max_players%", maxPlayers).replace("%m_p%", maxPlayers)
-        .replace("%online_servers%", onlineServers).replace("%o_s%", onlineServers);
+        .replace("%online_servers%", onlineServers).replace("%o_s%", onlineServers)
+        .replace("%available_servers%", availableServers).replace("%a_s", availableServers)
+        .replace("%max_servers%", maxServers).replace("%m_s%", maxServers);
 
       // update the stand
       stand.setCustomName(infoLine);


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Gives you the possibility to use Available Servers and Max Servers in the Info Line. Available Server = a_s and Max Servers = m_s. I think the feature is actually quite practical, but I didn't find enough time to calculate the Max Services and therefore I take the data directly from the SmartConfig. But feel free to change it if there is a better way.

### Documentation of test results:

There are no errors or warnings. I've tested it directly on my server. 
![TestonServer](https://cdn.discordapp.com/attachments/725320649387540532/939594486676348928/unknown.png)

### Related issues/discussions:

I didn't think so :thinking: 
