### PR TITLE
Add some docker-based integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import org.cadixdev.gradle.licenser.LicenseExtension
-import org.gradle.internal.impldep.com.google.common.collect.Maps
 
 plugins {
   id("cloudnet.parent-build-logic")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,7 @@ subprojects {
     // testing
     "testImplementation"(rootProject.libs.bundles.junit)
     "testImplementation"(rootProject.libs.bundles.mockito)
+    "testImplementation"(rootProject.libs.bundles.testContainers)
   }
 
   tasks.withType<Jar> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import org.cadixdev.gradle.licenser.LicenseExtension
+import org.gradle.internal.impldep.com.google.common.collect.Maps
 
 plugins {
   id("cloudnet.parent-build-logic")
@@ -81,6 +82,8 @@ subprojects {
     testLogging {
       events("started", "passed", "skipped", "failed")
     }
+    // always pass down all given system properties
+    systemProperties(System.getProperties().mapKeys { it.key.toString() })
   }
 
   tasks.withType<JavaCompile> {

--- a/common/src/test/java/eu/cloudnetservice/cloudnet/common/io/ZipUtilTest.java
+++ b/common/src/test/java/eu/cloudnetservice/cloudnet/common/io/ZipUtilTest.java
@@ -43,7 +43,7 @@ public final class ZipUtilTest {
 
   @Test
   void testZipUtils() throws Exception {
-    var zipFilePath = TEST_DIR.resolve("test.zip");
+    var zipFilePath = TEST_DIR.resolve("test.zip").toAbsolutePath();
 
     try (
       var out = Files.newOutputStream(zipFilePath);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ junit = "5.8.2"
 mockito = "4.4.0"
 tyrusClient = "2.0.2"
 minaSshdServer = "2.8.0"
+testcontainers = "1.16.3"
 
 # compile time processing
 lombok = "1.18.22"
@@ -104,6 +105,10 @@ mockito = { group = "org.mockito", name = "mockito-junit-jupiter", version.ref =
 minaSshdServer = { group = "org.apache.sshd", name = "sshd-sftp", version.ref = "minaSshdServer" }
 tyrus = { group = "org.glassfish.tyrus.bundles", name = "tyrus-standalone-client", version.ref = "tyrusClient" }
 
+# testcontainers
+testContainers = { group = "org.testcontainers", name = "testcontainers", version.ref = "testcontainers" }
+testContainersJunit = { group = "org.testcontainers", name = "junit-jupiter", version.ref = "testcontainers" }
+
 # unirest
 unirest = { group = "com.konghq", name = "unirest-java", version.ref = "unirest" }
 unirestGson = { group = "com.konghq", name = "unirest-object-mappers-gson", version.ref = "unirest" }
@@ -171,6 +176,7 @@ netty = ["nettyHandler", "nettyCodecHttp"]
 jjwt = ["jjwtApi", "jjwtImpl", "jjwtGson"]
 junit = ["junitApi", "junitParams", "junitEngine"]
 dockerJava = ["dockerJavaApi", "dockerJavaHttpclient5"]
+testContainers = ["testContainers", "testContainersJunit"]
 adventure = ["adventureApi", "adventureSerializerGson", "adventureSerializerLegacy"]
 
 serverPlatform = ["spigot", "sponge", "nukkitX"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ guava = "31.1-jre"
 junit = "5.8.2"
 mockito = "4.4.0"
 tyrusClient = "2.0.2"
-minaSshdServer = "2.8.0"
 testcontainers = "1.16.3"
 
 # compile time processing
@@ -102,7 +101,6 @@ junitEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", vers
 # general testing
 mockitoInline = { group = "org.mockito", name = "mockito-inline", version.ref = "mockito" }
 mockito = { group = "org.mockito", name = "mockito-junit-jupiter", version.ref = "mockito" }
-minaSshdServer = { group = "org.apache.sshd", name = "sshd-sftp", version.ref = "minaSshdServer" }
 tyrus = { group = "org.glassfish.tyrus.bundles", name = "tyrus-standalone-client", version.ref = "tyrusClient" }
 
 # testcontainers

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -23,6 +23,10 @@ subprojects {
   apply(plugin = "net.kyori.blossom")
   apply(plugin = "eu.cloudnetservice.juppiter")
 
+  configurations {
+    getByName("testImplementation").extendsFrom(getByName("moduleLibrary"))
+  }
+
   repositories {
     maven("https://jitpack.io/")
     maven("https://repo.md-5.net/repository/releases/")

--- a/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabase.java
+++ b/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabase.java
@@ -105,10 +105,13 @@ public class MongoDBDatabase extends AbstractDatabase {
 
   @Override
   public @NonNull List<JsonDocument> get(@NonNull JsonDocument filters) {
+    // the easiest way to prevent issues with json-to-json conversion is to use the in-build document of mongodb and
+    // then reconvert the values as we need them
     Collection<Bson> bsonFilters = new ArrayList<>();
-    for (var filter : filters) {
-      var value = filters.get(filter);
-      bsonFilters.add(this.valueEq(filter, value));
+    var document = Document.parse(filters.toString());
+    // easy part: convert each key of the document in a way that it matches the actual values written to the database
+    for (var entry : document.entrySet()) {
+      bsonFilters.add(this.valueEq(entry.getKey(), entry.getValue()));
     }
 
     List<JsonDocument> documents = new ArrayList<>();

--- a/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
+++ b/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
@@ -23,11 +23,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
+@EnabledIfSystemProperty(named = "cn.runDockerizedTests", matches = "true")
 class MongoDBDatabaseTest {
 
   @Container

--- a/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
+++ b/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.modules.mongodb;
+
+import eu.cloudnetservice.cloudnet.common.document.gson.JsonDocument;
+import eu.cloudnetservice.modules.mongodb.config.MongoDBConnectionConfig;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class MongoDBDatabaseTest {
+
+  @Container
+  private final GenericContainer<?> mongoContainer = new GenericContainer<>("mongo:latest").withExposedPorts(27017);
+
+  private MongoDBDatabaseProvider databaseProvider;
+
+  @BeforeEach
+  void setup() throws Exception {
+    this.databaseProvider = new MongoDBDatabaseProvider(new MongoDBConnectionConfig(
+      "mongo",
+      this.mongoContainer.getHost(),
+      this.mongoContainer.getFirstMappedPort(),
+      "",
+      "",
+      "",
+      "cn_db",
+      null));
+    this.databaseProvider.init();
+  }
+
+  @Test
+  void testAccessCreatesDatabase() {
+    Assertions.assertNotNull(this.databaseProvider.database("hello_world"));
+    Assertions.assertNotNull(this.databaseProvider.database("hello2_world"));
+
+    var names = this.databaseProvider.databaseNames();
+    Assertions.assertTrue(names.contains("hello_world"));
+    Assertions.assertTrue(names.contains("hello2_world"));
+  }
+
+  @Test
+  void testDatabaseDeletion() {
+    Assertions.assertNotNull(this.databaseProvider.database("hello_world"));
+    Assertions.assertNotNull(this.databaseProvider.database("hello2_world"));
+
+    var names = this.databaseProvider.databaseNames();
+    Assertions.assertTrue(names.contains("hello_world"));
+    Assertions.assertTrue(names.contains("hello2_world"));
+
+    Assertions.assertTrue(this.databaseProvider.deleteDatabase("hello_world"));
+    Assertions.assertTrue(this.databaseProvider.deleteDatabase("hello2_world"));
+
+    Assertions.assertTrue(this.databaseProvider.databaseNames().isEmpty());
+  }
+
+  @Test
+  void testBasicDatabaseOperations() {
+    var database = this.databaseProvider.database("test");
+    Assertions.assertNotNull(database);
+
+    Assertions.assertTrue(database.insert("1234", JsonDocument.newDocument("hello", "world")));
+    Assertions.assertTrue(database.insert("12234", JsonDocument.newDocument("hello", "world2")));
+
+    Assertions.assertTrue(database.contains("1234"));
+    Assertions.assertTrue(database.contains("12234"));
+
+    Assertions.assertEquals(2, database.documentCount());
+
+    var keys = database.keys();
+    Assertions.assertEquals(2, keys.size());
+    Assertions.assertTrue(keys.contains("1234"));
+    Assertions.assertTrue(keys.contains("12234"));
+
+    var entry = database.get("1234");
+    Assertions.assertNotNull(entry);
+    Assertions.assertEquals("world", entry.getString("hello"));
+
+    var entry2 = database.get("12234");
+    Assertions.assertNotNull(entry2);
+    Assertions.assertEquals("world2", entry2.getString("hello"));
+
+    var entry3 = database.get("122334");
+    Assertions.assertNull(entry3);
+
+    var entry4 = database.get("hello", "world");
+    Assertions.assertEquals(1, entry4.size());
+    Assertions.assertEquals("world", entry4.iterator().next().getString("hello"));
+
+    var entry5 = database.get(JsonDocument.newDocument("hello", "world2"));
+    Assertions.assertEquals(1, entry5.size());
+    Assertions.assertEquals("world2", entry5.iterator().next().getString("hello"));
+
+    var entries = database.entries();
+    Assertions.assertEquals(2, entries.size());
+    Assertions.assertEquals("world", entries.get("1234").getString("hello"));
+    Assertions.assertEquals("world2", entries.get("12234").getString("hello"));
+
+    var documents = database.documents();
+    Assertions.assertEquals(2, documents.size());
+
+    var filtered = database.filter((key, value) -> key.equals("1234"));
+    Assertions.assertEquals(1, filtered.size());
+    Assertions.assertNotNull(filtered.get("1234"));
+    Assertions.assertEquals("world", filtered.get("1234").getString("hello"));
+
+    Assertions.assertTrue(database.delete("12234"));
+    Assertions.assertEquals(1, database.documentCount());
+
+    database.clear();
+    Assertions.assertEquals(0, database.documentCount());
+
+    Assertions.assertFalse(database.delete("1234"));
+  }
+
+  @Test
+  void testChunkedDataRead() {
+    var database = this.databaseProvider.database("test");
+    Assertions.assertNotNull(database);
+
+    // fill in some data
+    var entries = 1235;
+    var expectedReadCounts = (int) Math.ceil(entries / 50D);
+
+    for (int i = 0; i < entries; i++) {
+      database.insert(UUID.randomUUID().toString(), JsonDocument.newDocument("this_is", "a_world_test"));
+    }
+
+    Assertions.assertEquals(entries, database.documentCount());
+
+    var index = 0;
+    var readsCalled = 0;
+
+    Map<String, JsonDocument> currentChunk;
+    while ((currentChunk = database.readChunk(index, 50)) != null) {
+      index += 50;
+      readsCalled++;
+
+      Assertions.assertFalse(currentChunk.size() > 50);
+    }
+
+    Assertions.assertEquals(expectedReadCounts, readsCalled);
+  }
+}

--- a/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
+++ b/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
@@ -23,13 +23,11 @@ import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
-@EnabledIfSystemProperty(named = "cn.runDockerizedTests", matches = "true")
+@Testcontainers(disabledWithoutDocker = true)
 class MongoDBDatabaseTest {
 
   @Container

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
@@ -49,8 +49,6 @@ public final class MySQLDatabase extends SQLDatabase {
         }
 
         return result.isEmpty() ? null : result;
-      },
-      null,
-      TABLE_COLUMN_KEY, chunkSize, beginIndex);
+      }, null, TABLE_COLUMN_KEY, chunkSize, beginIndex);
   }
 }

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
@@ -39,12 +39,7 @@ public final class MySQLDatabase extends SQLDatabase {
   @Override
   public @Nullable Map<String, JsonDocument> readChunk(long beginIndex, int chunkSize) {
     return this.databaseProvider.executeQuery(
-      String.format(
-        "SELECT * FROM `%s` ORDER BY %s LIMIT %d OFFSET %d;",
-        this.name,
-        TABLE_COLUMN_KEY,
-        chunkSize,
-        beginIndex),
+      String.format("SELECT * FROM `%s` ORDER BY ? LIMIT ? OFFSET ?;", this.name),
       resultSet -> {
         Map<String, JsonDocument> result = new HashMap<>();
         while (resultSet.next()) {
@@ -54,6 +49,8 @@ public final class MySQLDatabase extends SQLDatabase {
         }
 
         return result.isEmpty() ? null : result;
-      }, null);
+      },
+      null,
+      TABLE_COLUMN_KEY, chunkSize, beginIndex);
   }
 }

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
@@ -39,19 +39,21 @@ public final class MySQLDatabase extends SQLDatabase {
   @Override
   public @Nullable Map<String, JsonDocument> readChunk(long beginIndex, int chunkSize) {
     return this.databaseProvider.executeQuery(
-      String.format("SELECT * FROM `%s` WHERE ROW_NUMBER() BETWEEN ? AND ?;", this.name),
+      String.format(
+        "SELECT * FROM `%s` ORDER BY %s LIMIT %d OFFSET %d;",
+        this.name,
+        TABLE_COLUMN_KEY,
+        chunkSize,
+        beginIndex),
       resultSet -> {
         Map<String, JsonDocument> result = new HashMap<>();
         while (resultSet.next()) {
           var key = resultSet.getString(TABLE_COLUMN_KEY);
-          var document = JsonDocument.newDocument(resultSet.getString(TABLE_COLUMN_VAL));
+          var document = JsonDocument.fromJsonString(resultSet.getString(TABLE_COLUMN_VAL));
           result.put(key, document);
         }
 
         return result.isEmpty() ? null : result;
-      },
-      null,
-      beginIndex, beginIndex + chunkSize
-    );
+      }, null);
   }
 }

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseProvider.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseProvider.java
@@ -94,16 +94,18 @@ public final class MySQLDatabaseProvider extends SQLDatabaseProvider {
 
   @Override
   public @NonNull Collection<String> databaseNames() {
-    return this.executeQuery(
-      "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='PUBLIC'",
-      resultSet -> {
-        Collection<String> collection = new ArrayList<>();
-        while (resultSet.next()) {
-          collection.add(resultSet.getString("table_name"));
-        }
-
-        return collection;
-      }, Set.of());
+    try (var connection = this.hikariDataSource.getConnection();
+      var meta = connection.getMetaData().getTables(null, null, null, new String[]{"TABLE"})) {
+      // now we just need to extract the name from of the tables from the result set
+      Collection<String> names = new ArrayList<>();
+      while (meta.next()) {
+        names.add(meta.getString("table_name"));
+      }
+      return names;
+    } catch (SQLException exception) {
+      LOGGER.severe("Exception listing tables", exception);
+      return Set.of();
+    }
   }
 
   @Override

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseProvider.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseProvider.java
@@ -95,7 +95,7 @@ public final class MySQLDatabaseProvider extends SQLDatabaseProvider {
   @Override
   public @NonNull Collection<String> databaseNames() {
     try (var connection = this.hikariDataSource.getConnection();
-      var meta = connection.getMetaData().getTables(null, null, null, new String[]{"TABLE"})) {
+      var meta = connection.getMetaData().getTables(null, null, null, TABLE_TYPE)) {
       // now we just need to extract the name from of the tables from the result set
       Collection<String> names = new ArrayList<>();
       while (meta.next()) {

--- a/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
+++ b/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.modules.mysql;
+
+import eu.cloudnetservice.cloudnet.common.document.gson.JsonDocument;
+import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
+import eu.cloudnetservice.cloudnet.node.database.DatabaseHandler;
+import eu.cloudnetservice.modules.mysql.config.MySQLConfiguration;
+import eu.cloudnetservice.modules.mysql.config.MySQLConnectionEndpoint;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class MySQLDatabaseTest {
+
+  @Container
+  private final GenericContainer<?> mysqlContainer = new GenericContainer<>("mariadb:latest")
+    .withExposedPorts(3306)
+    .withEnv("MYSQL_USER", "test")
+    .withEnv("MYSQL_PASSWORD", "test")
+    .withEnv("MYSQL_ROOT_PASSWORD", "test")
+    .withEnv("MYSQL_DATABASE", "cn_testing");
+
+  private MySQLDatabaseProvider databaseProvider;
+
+  @BeforeEach
+  void setup() {
+    this.databaseProvider = new MySQLDatabaseProvider(new MySQLConfiguration(
+      "test",
+      "test",
+      "mysql",
+      List.of(new MySQLConnectionEndpoint(
+        false,
+        "cn_testing",
+        new HostAndPort(this.mysqlContainer.getHost(), this.mysqlContainer.getFirstMappedPort())))),
+      null);
+    this.databaseProvider.init();
+    this.databaseProvider.databaseHandler(Mockito.mock(DatabaseHandler.class));
+  }
+
+  @Test
+  void testAccessCreatesDatabase() {
+    Assertions.assertNotNull(this.databaseProvider.database("hello_world"));
+    Assertions.assertNotNull(this.databaseProvider.database("hello2_world"));
+
+    var names = this.databaseProvider.databaseNames();
+    Assertions.assertTrue(names.contains("hello_world"));
+    Assertions.assertTrue(names.contains("hello2_world"));
+  }
+
+  @Test
+  void testDatabaseDeletion() {
+    Assertions.assertNotNull(this.databaseProvider.database("hello_world"));
+    Assertions.assertNotNull(this.databaseProvider.database("hello2_world"));
+
+    var names = this.databaseProvider.databaseNames();
+    Assertions.assertTrue(names.contains("hello_world"));
+    Assertions.assertTrue(names.contains("hello2_world"));
+
+    Assertions.assertTrue(this.databaseProvider.deleteDatabase("hello_world"));
+    Assertions.assertTrue(this.databaseProvider.deleteDatabase("hello2_world"));
+
+    Assertions.assertTrue(this.databaseProvider.databaseNames().isEmpty());
+  }
+
+  @Test
+  void testBasicDatabaseOperations() {
+    var database = this.databaseProvider.database("test");
+    Assertions.assertNotNull(database);
+
+    Assertions.assertTrue(database.insert("1234", JsonDocument.newDocument("hello", "world")));
+    Assertions.assertTrue(database.insert("12234", JsonDocument.newDocument("hello", "world2")));
+
+    Assertions.assertTrue(database.contains("1234"));
+    Assertions.assertTrue(database.contains("12234"));
+
+    Assertions.assertEquals(2, database.documentCount());
+
+    var keys = database.keys();
+    Assertions.assertEquals(2, keys.size());
+    Assertions.assertTrue(keys.contains("1234"));
+    Assertions.assertTrue(keys.contains("12234"));
+
+    var entry = database.get("1234");
+    Assertions.assertNotNull(entry);
+    Assertions.assertEquals("world", entry.getString("hello"));
+
+    var entry2 = database.get("12234");
+    Assertions.assertNotNull(entry2);
+    Assertions.assertEquals("world2", entry2.getString("hello"));
+
+    var entry3 = database.get("122334");
+    Assertions.assertNull(entry3);
+
+    var entry4 = database.get("hello", "world");
+    Assertions.assertEquals(1, entry4.size());
+    Assertions.assertEquals("world", entry4.iterator().next().getString("hello"));
+
+    var entry5 = database.get(JsonDocument.newDocument("hello", "world2"));
+    Assertions.assertEquals(1, entry5.size());
+    Assertions.assertEquals("world2", entry5.iterator().next().getString("hello"));
+
+    var entries = database.entries();
+    Assertions.assertEquals(2, entries.size());
+    Assertions.assertEquals("world", entries.get("1234").getString("hello"));
+    Assertions.assertEquals("world2", entries.get("12234").getString("hello"));
+
+    var documents = database.documents();
+    Assertions.assertEquals(2, documents.size());
+
+    var filtered = database.filter((key, value) -> key.equals("1234"));
+    Assertions.assertEquals(1, filtered.size());
+    Assertions.assertNotNull(filtered.get("1234"));
+    Assertions.assertEquals("world", filtered.get("1234").getString("hello"));
+
+    Assertions.assertTrue(database.delete("12234"));
+    Assertions.assertEquals(1, database.documentCount());
+
+    database.clear();
+    Assertions.assertEquals(0, database.documentCount());
+
+    Assertions.assertFalse(database.delete("1234"));
+  }
+
+  @Test
+  void testChunkedDataRead() {
+    var database = this.databaseProvider.database("test");
+    Assertions.assertNotNull(database);
+
+    // fill in some data
+    var entries = 1235;
+    var expectedReadCounts = (int) Math.ceil(entries / 50D);
+
+    for (int i = 0; i < entries; i++) {
+      database.insert(UUID.randomUUID().toString(), JsonDocument.newDocument("this_is", "a_world_test"));
+    }
+
+    Assertions.assertEquals(entries, database.documentCount());
+
+    var index = 0;
+    var readsCalled = 0;
+
+    Map<String, JsonDocument> currentChunk;
+    while ((currentChunk = database.readChunk(index, 50)) != null) {
+      index += 50;
+      readsCalled++;
+
+      Assertions.assertFalse(currentChunk.size() > 50);
+    }
+
+    Assertions.assertEquals(expectedReadCounts, readsCalled);
+  }
+}

--- a/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
+++ b/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
@@ -27,12 +27,14 @@ import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockito.Mockito;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
+@EnabledIfSystemProperty(named = "cn.runDockerizedTests", matches = "true")
 class MySQLDatabaseTest {
 
   @Container

--- a/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
+++ b/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
@@ -27,14 +27,12 @@ import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockito.Mockito;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
-@EnabledIfSystemProperty(named = "cn.runDockerizedTests", matches = "true")
+@Testcontainers(disabledWithoutDocker = true)
 class MySQLDatabaseTest {
 
   @Container

--- a/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorage.java
+++ b/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorage.java
@@ -297,7 +297,7 @@ public class S3TemplateStorage implements TemplateStorage {
   public boolean createFile(@NonNull ServiceTemplate template, @NonNull String path) {
     try {
       var request = PutObjectRequest.builder()
-        .bucket(this.getBucketPath(template, path))
+        .bucket(this.config().bucket())
         .key(this.getBucketPath(template, path))
         .contentLength(0L)
         .contentType("text/plain")

--- a/modules/storage-s3/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
+++ b/modules/storage-s3/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockito.Mockito;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -37,6 +38,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @TestMethodOrder(OrderAnnotation.class)
+@EnabledIfSystemProperty(named = "cn.runDockerizedTests", matches = "true")
 class S3TemplateStorageTest {
 
   // default localstack port, maps all services to that port

--- a/modules/storage-s3/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
+++ b/modules/storage-s3/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
@@ -29,16 +29,14 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockito.Mockito;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @TestMethodOrder(OrderAnnotation.class)
-@EnabledIfSystemProperty(named = "cn.runDockerizedTests", matches = "true")
+@Testcontainers(disabledWithoutDocker = true)
 class S3TemplateStorageTest {
 
   // default localstack port, maps all services to that port

--- a/modules/storage-sftp/build.gradle.kts
+++ b/modules/storage-sftp/build.gradle.kts
@@ -20,9 +20,6 @@ tasks.withType<Jar> {
 
 dependencies {
   "moduleLibrary"(libs.sshj)
-
-  "testImplementation"(libs.sshj)
-  "testImplementation"(libs.minaSshdServer)
 }
 
 moduleJson {

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -165,8 +165,13 @@ public class SFTPTemplateStorage implements TemplateStorage {
   @Override
   public boolean delete(@NonNull ServiceTemplate template) {
     return this.executeWithClient(client -> {
-      if (client.statExistence(this.constructRemotePath(template)) != null) {
-        this.deleteDir(client, this.constructRemotePath(template));
+      var templatePath = this.constructRemotePath(template);
+      var attributes = client.statExistence(templatePath);
+      // checks if the remote directory actually exists
+      if (attributes != null && attributes.getType() == Type.DIRECTORY) {
+        // now we are sure that the template exists and can remove it
+        this.deleteDir(client, templatePath);
+        client.rmdir(templatePath);
         return true;
       } else {
         return false;

--- a/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
+++ b/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
@@ -30,14 +30,12 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @TestMethodOrder(OrderAnnotation.class)
-@EnabledIfSystemProperty(named = "cn.runDockerizedTests", matches = "true")
+@Testcontainers(disabledWithoutDocker = true)
 public final class SFTPTemplateStorageTest {
 
   private static final ServiceTemplate TEMPLATE = ServiceTemplate.builder()

--- a/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
+++ b/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
@@ -16,14 +16,12 @@
 
 package eu.cloudnetservice.modules.sftp;
 
-import eu.cloudnetservice.cloudnet.common.io.FileUtil;
 import eu.cloudnetservice.cloudnet.driver.network.HostAndPort;
 import eu.cloudnetservice.cloudnet.driver.service.ServiceTemplate;
 import eu.cloudnetservice.cloudnet.driver.template.FileInfo;
 import eu.cloudnetservice.modules.sftp.config.SFTPTemplateStorageConfig;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.Arrays;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -40,7 +38,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @TestMethodOrder(OrderAnnotation.class)
 public final class SFTPTemplateStorageTest {
 
-  private static final Path HOME_PATH = Path.of("build", "tmp", "sftp");
   private static final ServiceTemplate TEMPLATE = ServiceTemplate.builder()
     .prefix("global")
     .name("proxy")
@@ -56,7 +53,6 @@ public final class SFTPTemplateStorageTest {
 
   @BeforeAll
   static void setupStorage() {
-    FileUtil.createDirectory(HOME_PATH);
     storage = new SFTPTemplateStorage(new SFTPTemplateStorageConfig(
       new HostAndPort(SFTP.getHost(), SFTP.getFirstMappedPort()),
       "sftp",

--- a/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
+++ b/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
@@ -30,12 +30,14 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @TestMethodOrder(OrderAnnotation.class)
+@EnabledIfSystemProperty(named = "cn.runDockerizedTests", matches = "true")
 public final class SFTPTemplateStorageTest {
 
   private static final ServiceTemplate TEMPLATE = ServiceTemplate.builder()

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/database/sql/SQLDatabase.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/database/sql/SQLDatabase.java
@@ -103,7 +103,7 @@ public abstract class SQLDatabase extends AbstractDatabase {
     return this.databaseProvider.executeUpdate(
       String.format("DELETE FROM `%s` WHERE %s = ?", this.name, TABLE_COLUMN_KEY),
       key
-    ) != -1;
+    ) > 0;
   }
 
   @Override

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/database/sql/SQLDatabaseProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/database/sql/SQLDatabaseProvider.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.UnknownNullability;
 
 public abstract class SQLDatabaseProvider extends AbstractDatabaseProvider {
 
+  protected static final String[] TABLE_TYPE = new String[]{"TABLE"};
   protected static final Logger LOGGER = LogManager.logger(SQLDatabaseProvider.class);
 
   protected final ExecutorService executorService;

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/template/LocalTemplateStorage.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/template/LocalTemplateStorage.java
@@ -222,9 +222,9 @@ public class LocalTemplateStorage implements TemplateStorage {
     boolean deep
   ) {
     List<FileInfo> out = new ArrayList<>();
-    var root = this.getTemplatePath(template).resolve(dir);
+    var root = this.getTemplatePath(template);
     // walk over all files
-    FileUtil.walkFileTree(root, (parent, file) -> {
+    FileUtil.walkFileTree(root.resolve(dir), (parent, file) -> {
       try {
         out.add(FileInfo.of(file, root.relativize(file)));
       } catch (IOException ignored) {

--- a/node/src/test/java/eu/cloudnetservice/cloudnet/node/database/h2/H2DatabaseTest.java
+++ b/node/src/test/java/eu/cloudnetservice/cloudnet/node/database/h2/H2DatabaseTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.cloudnet.node.database.h2;
+
+import eu.cloudnetservice.cloudnet.common.document.gson.JsonDocument;
+import eu.cloudnetservice.cloudnet.common.io.FileUtil;
+import eu.cloudnetservice.cloudnet.node.database.DatabaseHandler;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class H2DatabaseTest {
+
+  private H2DatabaseProvider databaseProvider;
+
+  @BeforeEach
+  void setup() throws Exception {
+    var baseDirectory = Path.of("build", "tmp", "h2");
+    FileUtil.delete(baseDirectory);
+
+    this.databaseProvider = new H2DatabaseProvider(baseDirectory.resolve("db").toString(), null);
+    this.databaseProvider.databaseHandler(Mockito.mock(DatabaseHandler.class));
+    this.databaseProvider.init();
+  }
+
+  @AfterEach
+  void closeEnvironment() throws Exception {
+    this.databaseProvider.close();
+  }
+
+  @Test
+  void testAccessCreatesDatabase() {
+    Assertions.assertNotNull(this.databaseProvider.database("hello_world"));
+    Assertions.assertNotNull(this.databaseProvider.database("hello2_world"));
+
+    var names = this.databaseProvider.databaseNames();
+    Assertions.assertTrue(names.contains("hello_world"));
+    Assertions.assertTrue(names.contains("hello2_world"));
+  }
+
+  @Test
+  void testDatabaseDeletion() {
+    Assertions.assertNotNull(this.databaseProvider.database("hello_world"));
+    Assertions.assertNotNull(this.databaseProvider.database("hello2_world"));
+
+    var names = this.databaseProvider.databaseNames();
+    Assertions.assertTrue(names.contains("hello_world"));
+    Assertions.assertTrue(names.contains("hello2_world"));
+
+    Assertions.assertTrue(this.databaseProvider.deleteDatabase("hello_world"));
+    Assertions.assertTrue(this.databaseProvider.deleteDatabase("hello2_world"));
+
+    Assertions.assertTrue(this.databaseProvider.databaseNames().isEmpty());
+  }
+
+  @Test
+  void testBasicDatabaseOperations() {
+    var database = this.databaseProvider.database("test");
+    Assertions.assertNotNull(database);
+
+    Assertions.assertTrue(database.insert("1234", JsonDocument.newDocument("hello", "world")));
+    Assertions.assertTrue(database.insert("12234", JsonDocument.newDocument("hello", "world2")));
+
+    Assertions.assertTrue(database.contains("1234"));
+    Assertions.assertTrue(database.contains("12234"));
+
+    Assertions.assertEquals(2, database.documentCount());
+
+    var keys = database.keys();
+    Assertions.assertEquals(2, keys.size());
+    Assertions.assertTrue(keys.contains("1234"));
+    Assertions.assertTrue(keys.contains("12234"));
+
+    var entry = database.get("1234");
+    Assertions.assertNotNull(entry);
+    Assertions.assertEquals("world", entry.getString("hello"));
+
+    var entry2 = database.get("12234");
+    Assertions.assertNotNull(entry2);
+    Assertions.assertEquals("world2", entry2.getString("hello"));
+
+    var entry3 = database.get("122334");
+    Assertions.assertNull(entry3);
+
+    var entry4 = database.get("hello", "world");
+    Assertions.assertEquals(1, entry4.size());
+    Assertions.assertEquals("world", entry4.iterator().next().getString("hello"));
+
+    var entry5 = database.get(JsonDocument.newDocument("hello", "world2"));
+    Assertions.assertEquals(1, entry5.size());
+    Assertions.assertEquals("world2", entry5.iterator().next().getString("hello"));
+
+    var entries = database.entries();
+    Assertions.assertEquals(2, entries.size());
+    Assertions.assertEquals("world", entries.get("1234").getString("hello"));
+    Assertions.assertEquals("world2", entries.get("12234").getString("hello"));
+
+    var documents = database.documents();
+    Assertions.assertEquals(2, documents.size());
+
+    var filtered = database.filter((key, value) -> key.equals("1234"));
+    Assertions.assertEquals(1, filtered.size());
+    Assertions.assertNotNull(filtered.get("1234"));
+    Assertions.assertEquals("world", filtered.get("1234").getString("hello"));
+
+    Assertions.assertTrue(database.delete("12234"));
+    Assertions.assertEquals(1, database.documentCount());
+
+    database.clear();
+    Assertions.assertEquals(0, database.documentCount());
+
+    Assertions.assertFalse(database.delete("1234"));
+  }
+
+  @Test
+  void testChunkedDataRead() {
+    var database = this.databaseProvider.database("test");
+    Assertions.assertNotNull(database);
+
+    // fill in some data
+    var entries = 1235;
+    var expectedReadCounts = (int) Math.ceil(entries / 50D);
+
+    for (int i = 0; i < entries; i++) {
+      database.insert(UUID.randomUUID().toString(), JsonDocument.newDocument("this_is", "a_world_test"));
+    }
+
+    Assertions.assertEquals(entries, database.documentCount());
+
+    var index = 0;
+    var readsCalled = 0;
+
+    Map<String, JsonDocument> currentChunk;
+    while ((currentChunk = database.readChunk(index, 50)) != null) {
+      index += 50;
+      readsCalled++;
+
+      Assertions.assertFalse(currentChunk.size() > 50);
+    }
+
+    Assertions.assertEquals(expectedReadCounts, readsCalled);
+  }
+}

--- a/node/src/test/java/eu/cloudnetservice/cloudnet/node/database/xodus/XodusDatabaseTest.java
+++ b/node/src/test/java/eu/cloudnetservice/cloudnet/node/database/xodus/XodusDatabaseTest.java
@@ -30,14 +30,12 @@ import org.mockito.Mockito;
 
 class XodusDatabaseTest {
 
+  private static final Path BASE_DIRECTORY = Path.of("build", "tmp", "xodus").toAbsolutePath();
   private XodusDatabaseProvider databaseProvider;
 
   @BeforeEach
   void setup() {
-    var baseDirectory = Path.of("build", "tmp", "xodus");
-    FileUtil.delete(baseDirectory);
-
-    this.databaseProvider = new XodusDatabaseProvider(baseDirectory.toFile(), false, null);
+    this.databaseProvider = new XodusDatabaseProvider(BASE_DIRECTORY.toFile(), false, null);
     this.databaseProvider.databaseHandler(Mockito.mock(DatabaseHandler.class));
     this.databaseProvider.init();
   }
@@ -45,6 +43,7 @@ class XodusDatabaseTest {
   @AfterEach
   void closeEnvironment() throws Exception {
     this.databaseProvider.close();
+    FileUtil.delete(BASE_DIRECTORY);
   }
 
   @Test

--- a/node/src/test/java/eu/cloudnetservice/cloudnet/node/database/xodus/XodusDatabaseTest.java
+++ b/node/src/test/java/eu/cloudnetservice/cloudnet/node/database/xodus/XodusDatabaseTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.cloudnet.node.database.xodus;
+
+import eu.cloudnetservice.cloudnet.common.document.gson.JsonDocument;
+import eu.cloudnetservice.cloudnet.common.io.FileUtil;
+import eu.cloudnetservice.cloudnet.node.database.DatabaseHandler;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class XodusDatabaseTest {
+
+  private XodusDatabaseProvider databaseProvider;
+
+  @BeforeEach
+  void setup() {
+    var baseDirectory = Path.of("build", "tmp", "xodus");
+    FileUtil.delete(baseDirectory);
+
+    this.databaseProvider = new XodusDatabaseProvider(baseDirectory.toFile(), false, null);
+    this.databaseProvider.databaseHandler(Mockito.mock(DatabaseHandler.class));
+    this.databaseProvider.init();
+  }
+
+  @AfterEach
+  void closeEnvironment() throws Exception {
+    this.databaseProvider.close();
+  }
+
+  @Test
+  void testAccessCreatesDatabase() {
+    Assertions.assertNotNull(this.databaseProvider.database("hello_world"));
+    Assertions.assertNotNull(this.databaseProvider.database("hello2_world"));
+
+    var names = this.databaseProvider.databaseNames();
+    Assertions.assertTrue(names.contains("hello_world"));
+    Assertions.assertTrue(names.contains("hello2_world"));
+  }
+
+  @Test
+  void testDatabaseDeletion() {
+    Assertions.assertNotNull(this.databaseProvider.database("hello_world"));
+    Assertions.assertNotNull(this.databaseProvider.database("hello2_world"));
+
+    var names = this.databaseProvider.databaseNames();
+    Assertions.assertTrue(names.contains("hello_world"));
+    Assertions.assertTrue(names.contains("hello2_world"));
+
+    Assertions.assertTrue(this.databaseProvider.deleteDatabase("hello_world"));
+    Assertions.assertTrue(this.databaseProvider.deleteDatabase("hello2_world"));
+
+    Assertions.assertTrue(this.databaseProvider.databaseNames().isEmpty());
+  }
+
+  @Test
+  void testBasicDatabaseOperations() {
+    var database = this.databaseProvider.database("test");
+    Assertions.assertNotNull(database);
+
+    Assertions.assertTrue(database.insert("1234", JsonDocument.newDocument("hello", "world")));
+    Assertions.assertTrue(database.insert("12234", JsonDocument.newDocument("hello", "world2")));
+
+    Assertions.assertTrue(database.contains("1234"));
+    Assertions.assertTrue(database.contains("12234"));
+
+    Assertions.assertEquals(2, database.documentCount());
+
+    var keys = database.keys();
+    Assertions.assertEquals(2, keys.size());
+    Assertions.assertTrue(keys.contains("1234"));
+    Assertions.assertTrue(keys.contains("12234"));
+
+    var entry = database.get("1234");
+    Assertions.assertNotNull(entry);
+    Assertions.assertEquals("world", entry.getString("hello"));
+
+    var entry2 = database.get("12234");
+    Assertions.assertNotNull(entry2);
+    Assertions.assertEquals("world2", entry2.getString("hello"));
+
+    var entry3 = database.get("122334");
+    Assertions.assertNull(entry3);
+
+    var entry4 = database.get("hello", "world");
+    Assertions.assertEquals(1, entry4.size());
+    Assertions.assertEquals("world", entry4.iterator().next().getString("hello"));
+
+    var entry5 = database.get(JsonDocument.newDocument("hello", "world2"));
+    Assertions.assertEquals(1, entry5.size());
+    Assertions.assertEquals("world2", entry5.iterator().next().getString("hello"));
+
+    var entries = database.entries();
+    Assertions.assertEquals(2, entries.size());
+    Assertions.assertEquals("world", entries.get("1234").getString("hello"));
+    Assertions.assertEquals("world2", entries.get("12234").getString("hello"));
+
+    var documents = database.documents();
+    Assertions.assertEquals(2, documents.size());
+
+    var filtered = database.filter((key, value) -> key.equals("1234"));
+    Assertions.assertEquals(1, filtered.size());
+    Assertions.assertNotNull(filtered.get("1234"));
+    Assertions.assertEquals("world", filtered.get("1234").getString("hello"));
+
+    Assertions.assertTrue(database.delete("12234"));
+    Assertions.assertEquals(1, database.documentCount());
+
+    database.clear();
+    Assertions.assertEquals(0, database.documentCount());
+
+    Assertions.assertFalse(database.delete("1234"));
+  }
+
+  @Test
+  void testChunkedDataRead() {
+    var database = this.databaseProvider.database("test");
+    Assertions.assertNotNull(database);
+
+    // fill in some data
+    var entries = 1235;
+    var expectedReadCounts = (int) Math.ceil(entries / 50D);
+
+    for (int i = 0; i < entries; i++) {
+      database.insert(UUID.randomUUID().toString(), JsonDocument.newDocument("this_is", "a_world_test"));
+    }
+
+    Assertions.assertEquals(entries, database.documentCount());
+
+    var index = 0;
+    var readsCalled = 0;
+
+    Map<String, JsonDocument> currentChunk;
+    while ((currentChunk = database.readChunk(index, 50)) != null) {
+      index += 50;
+      readsCalled++;
+
+      Assertions.assertFalse(currentChunk.size() > 50);
+    }
+
+    Assertions.assertEquals(expectedReadCounts, readsCalled);
+  }
+}


### PR DESCRIPTION
This pull requests adds some integration tests based on docker. Currently I need to find a way to run the tests based on a conditional - running through `gradlew` will not pass down the given system properties, so I think I will switch to environment based variables (opinion on that @0utplay ?)

The tests are failing on our CI as no docker seems to be available, I think the best way is to disable them (as we want to remove Jenkins anyway).

Current todo:
 - [x] Caching the docker images on GH actions
 - [x] Finding a way to enable the integration tests (disabled by default)