### PR TITLE
fix: prevent runtime reloading of critical information

### DIFF
--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerNode.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerNode.java
@@ -164,7 +164,7 @@ public class V2HttpHandlerNode extends WebSocketAbleV2HttpHandler {
   }
 
   protected void reloadConfig() {
-    this.node().config(this.node().config().load());
+    this.node().reloadConfigFrom(JsonConfiguration.loadFromFile(this.node()));
     this.node().serviceTaskProvider().reload();
     this.node().groupConfigurationProvider().reload();
     this.node().permissionManagement().reload();

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/CloudNet.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/CloudNet.java
@@ -112,6 +112,7 @@ public class CloudNet extends CloudNetDriver {
   private final DefaultNodeServerProvider nodeServerProvider;
   private final ServiceVersionProvider serviceVersionProvider;
 
+  private final Configuration configuration;
   private final ModulesHolder modulesHolder;
   private final UpdaterRegistry<ModuleUpdaterContext, ModulesHolder> moduleUpdaterRegistry;
 
@@ -121,7 +122,6 @@ public class CloudNet extends CloudNetDriver {
   private final DataSyncRegistry dataSyncRegistry = new DefaultDataSyncRegistry();
   private final QueuedConsoleLogHandler logHandler = new QueuedConsoleLogHandler();
 
-  private volatile Configuration configuration;
   private volatile AbstractDatabaseProvider databaseProvider;
 
   protected CloudNet(@NonNull String[] args, @NonNull Console console, @NonNull Logger rootLogger) {
@@ -431,8 +431,8 @@ public class CloudNet extends CloudNetDriver {
     return this.configuration;
   }
 
-  public void config(@NonNull Configuration configuration) {
-    this.configuration = configuration;
+  public void reloadConfigFrom(@NonNull Configuration configuration) {
+    this.configuration.reloadFrom(configuration.save());
   }
 
   public @NonNull DefaultNodeServerProvider nodeServerProvider() {

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/command/sub/CommandConfig.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/command/sub/CommandConfig.java
@@ -52,7 +52,7 @@ public final class CommandConfig {
 
   @CommandMethod("config reload")
   public void reloadConfigs(@NonNull CommandSource source) {
-    CloudNet.instance().config(JsonConfiguration.loadFromFile(CloudNet.instance()));
+    CloudNet.instance().reloadConfigFrom(JsonConfiguration.loadFromFile(CloudNet.instance()));
     CloudNet.instance().serviceTaskProvider().reload();
     CloudNet.instance().groupConfigurationProvider().reload();
     CloudNet.instance().permissionManagement().reload();
@@ -61,7 +61,7 @@ public final class CommandConfig {
 
   @CommandMethod("config node reload")
   public void reloadNodeConfig(@NonNull CommandSource source) {
-    CloudNet.instance().config(JsonConfiguration.loadFromFile(CloudNet.instance()));
+    CloudNet.instance().reloadConfigFrom(JsonConfiguration.loadFromFile(CloudNet.instance()));
     source.sendMessage(I18n.trans("command-config-node-reload-config"));
   }
 

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/config/Configuration.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/config/Configuration.java
@@ -32,6 +32,8 @@ public interface Configuration {
 
   @NonNull Configuration save();
 
+  void reloadFrom(@NonNull Configuration configuration);
+
   @NonNull String hostAddress();
 
   void hostAddress(@NonNull String hostAddress);

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/config/JsonConfiguration.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/config/JsonConfiguration.java
@@ -291,6 +291,39 @@ public final class JsonConfiguration implements Configuration {
   }
 
   @Override
+  public void reloadFrom(@NonNull Configuration configuration) {
+    // supported identity changes
+    this.identity.properties().append(configuration.properties());
+
+    // collection configurations
+    this.identity.listeners().clear();
+    this.identity.listeners().addAll(configuration.identity().listeners());
+
+    this.ipWhitelist.clear();
+    this.ipWhitelist.addAll(configuration.ipWhitelist());
+
+    this.clusterConfig.nodes().clear();
+    this.clusterConfig.nodes().addAll(configuration.clusterConfig().nodes());
+
+    // general configuration
+    this.maxMemory = configuration.maxMemory();
+    this.maxCPUUsageToStartServices = configuration.maxCPUUsageToStartServices();
+    this.maxServiceConsoleLogCacheSize = configuration.maxServiceConsoleLogCacheSize();
+    this.processTerminationTimeoutSeconds = configuration.processTerminationTimeoutSeconds();
+
+    this.forceInitialClusterDataSync = configuration.forceInitialClusterDataSync();
+    this.printErrorStreamLinesFromServices = configuration.printErrorStreamLinesFromServices();
+    this.runBlockedServiceStartTryLaterAutomatic = configuration.runBlockedServiceStartTryLaterAutomatic();
+
+    this.jvmCommand = configuration.javaCommand();
+    this.hostAddress = configuration.hostAddress();
+    this.connectHostAddress = configuration.connectHostAddress();
+
+    this.properties = configuration.properties();
+    this.accessControlConfiguration = configuration.accessControlConfig();
+  }
+
+  @Override
   public @NonNull NetworkClusterNode identity() {
     return this.identity;
   }

--- a/node/src/main/java/eu/cloudnetservice/cloudnet/node/config/JsonConfiguration.java
+++ b/node/src/main/java/eu/cloudnetservice/cloudnet/node/config/JsonConfiguration.java
@@ -293,7 +293,7 @@ public final class JsonConfiguration implements Configuration {
   @Override
   public void reloadFrom(@NonNull Configuration configuration) {
     // supported identity changes
-    this.identity.properties().append(configuration.properties());
+    this.identity.properties().append(configuration.identity().properties());
 
     // collection configurations
     this.identity.listeners().clear();


### PR DESCRIPTION
This for example prevents changing the node unique id by reloading the current node config which breaks the whole cluster completely. All API methods are still present and useable to do that anyway, but it's then up to the developers to ensure that nothing goes wrong when doing that.