### PR TITLE
Include Bedwars as a game mode for the default distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ atlassian-ide-plugin.xml
 
 # delombok
 */src/main/lombok
+
+# Bedwars
+Bedwars


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

<!-- A brief description of the changes done in this pull request. -->
This pull request adds the popular game mode "Bedwars" to the default distribution of CloudNet.

### Documentation of test results:

<!-- Add test results before and after applying your changes. -->
On first startup, a new server group is created that automatically hosts the most popular game mode "Bedwars".

### Related issues/discussions:

<!-- Add any related issues here by mentioning them (e.g. Fixes #1). -->  
See discord: https://discord.com/channels/325362837184577536/325366515178274818/962370430109368350