### PR TITLE
Fix that java executable parsing fails

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/exception/CommandExceptionHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/exception/CommandExceptionHandler.java
@@ -75,11 +75,17 @@ public class CommandExceptionHandler {
     // determine the cause type and apply the specific handler
     if (cause instanceof CommandException) {
       if (cause instanceof InvalidSyntaxException invalidSyntaxException) {
+        // build the full command tree for the given input
+        var commandTree = this.collectCommandHelp(invalidSyntaxException.getCurrentChain());
         // call the event to allow an own response
         var event = this.eventManager.callEvent(new CommandInvalidSyntaxEvent(
           source,
           invalidSyntaxException.getCorrectSyntax(),
-          this.collectCommandHelp(invalidSyntaxException.getCurrentChain())));
+          commandTree,
+          // by default, we display the whole tree if we just have one argument
+          invalidSyntaxException.getCurrentChain().size() <= 1
+            ? commandTree
+            : List.of(invalidSyntaxException.getMessage())));
         // send the response of the event
         source.sendMessage(event.response());
       } else if (cause instanceof NoSuchCommandException noSuchCommandException) {

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -192,7 +192,7 @@ public final class TasksCommand {
         I18n.trans("command-tasks-setup-question-javacommand-invalid"));
     }
 
-    return new Pair<>(command.replace("\"", ""), version);
+    return new Pair<>(command, version);
   }
 
   @Parser(name = "nodeId", suggestions = "clusterNode")

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -183,13 +183,16 @@ public final class TasksCommand {
     @NonNull Queue<String> input
   ) {
     var command = String.join(" ", input);
+    // we have to clear the queue as we consumed the input using String.join
+    input.clear();
+
     var version = JavaVersionResolver.resolveFromJavaExecutable(command);
     if (version == null) {
       throw new ArgumentNotAvailableException(
         I18n.trans("command-tasks-setup-question-javacommand-invalid"));
     }
 
-    return new Pair<>(command, version);
+    return new Pair<>(command.replace("\"", ""), version);
   }
 
   @Parser(name = "nodeId", suggestions = "clusterNode")
@@ -410,7 +413,7 @@ public final class TasksCommand {
   public void setJavaCommand(
     @NonNull CommandSource source,
     @NonNull @Argument("name") Collection<ServiceTask> serviceTasks,
-    @NonNull @Argument(value = "executable", parserName = "javaCommand") @Quoted Pair<String, JavaVersion> executable
+    @NonNull @Argument(value = "executable", parserName = "javaCommand") Pair<String, JavaVersion> executable
   ) {
     for (var task : serviceTasks) {
       this.updateTask(task, builder -> builder.javaCommand(executable.first()));

--- a/node/src/main/java/eu/cloudnetservice/node/event/command/CommandInvalidSyntaxEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/command/CommandInvalidSyntaxEvent.java
@@ -25,15 +25,18 @@ public class CommandInvalidSyntaxEvent extends Event {
 
   private final CommandSource source;
   private final String correctSyntax;
+  private final List<String> fullCommandTree;
   private List<String> response;
 
   public CommandInvalidSyntaxEvent(
     @NonNull CommandSource source,
     @NonNull String correctSyntax,
+    @NonNull List<String> fullCommandTree,
     @NonNull List<String> response
   ) {
     this.source = source;
     this.correctSyntax = correctSyntax;
+    this.fullCommandTree = fullCommandTree;
     this.response = response;
   }
 
@@ -49,6 +52,15 @@ public class CommandInvalidSyntaxEvent extends Event {
    */
   public @NonNull String correctSyntax() {
     return this.correctSyntax;
+  }
+
+  /**
+   * Gets the full command tree for the input that lead to this event.
+   *
+   * @return the command tree.
+   */
+  public @NonNull List<String> fullCommandTree() {
+    return this.fullCommandTree;
   }
 
   /**

--- a/node/src/main/java/eu/cloudnetservice/node/util/JavaVersionResolver.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/JavaVersionResolver.java
@@ -18,6 +18,8 @@ package eu.cloudnetservice.node.util;
 
 import com.google.common.io.CharStreams;
 import eu.cloudnetservice.common.JavaVersion;
+import eu.cloudnetservice.common.log.LogManager;
+import eu.cloudnetservice.common.log.Logger;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -28,6 +30,8 @@ import org.jetbrains.annotations.Nullable;
  * An util class for resolving the java version for a given path.
  */
 public final class JavaVersionResolver {
+
+  private static final Logger LOGGER = LogManager.logger(JavaVersionResolver.class);
 
   // https://regex101.com/r/6Z4jZT/1
   private static final Pattern JAVA_REGEX = Pattern.compile("^.* version \"(\\d+)\\.?(\\d+)?\\.?([\\d_]+)?\".*",
@@ -66,7 +70,8 @@ public final class JavaVersionResolver {
       } finally {
         process.destroyForcibly();
       }
-    } catch (IOException ignored) {
+    } catch (IOException exception) {
+      LOGGER.warning("Unable to read input from process", exception);
     }
 
     return null;


### PR DESCRIPTION
This pr addresses an issue where the parsing of java executables fails due to the fact that cloud expects us to remove every argument that was parsed successfully.

Now the queue is cleared after we joined all remaining arguments to one command.