### PR TITLE
[ci skip] chore: require console sender for service screen command

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
@@ -48,6 +48,7 @@ import eu.cloudnetservice.node.command.annotation.CommandAlias;
 import eu.cloudnetservice.node.command.annotation.Description;
 import eu.cloudnetservice.node.command.exception.ArgumentNotAvailableException;
 import eu.cloudnetservice.node.command.source.CommandSource;
+import eu.cloudnetservice.node.command.source.ConsoleCommandSource;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -247,7 +248,7 @@ public final class ServiceCommand {
     }
   }
 
-  @CommandMethod("service|ser <name> toggle")
+  @CommandMethod(value = "service|ser <name> toggle", requiredSender = ConsoleCommandSource.class)
   public void toggleScreens(
     @NonNull CommandSource source,
     @NonNull @Argument("name") Collection<ServiceInfoSnapshot> matchedServices


### PR DESCRIPTION
### Motivation
The screen commands should not be available from the driver (or ingame) as the messages will not be send to the user who executed the command.

### Modification
The `service <name|uuid> toggle` annotation now has the required sender set to the console sender.

### Result
The `service <name|uuid> toggle` command is now only available from the node console.
