### PR TITLE
[ci skip] chore: remove & disallow usages of jetbrains NotNull annotation

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -52,6 +52,11 @@
       <property name="message" value="Using inner class imports is forbidden."/>
     </module>
     <module name="RegexpSinglelineJava">
+      <property name="format" value="^import (?!lombok).*(NotNull|NonNull|Nonnull);$"/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message" value="Any @NonNull annnotation should be imported from lombok."/>
+    </module>
+    <module name="RegexpSinglelineJava">
       <property name="format" value="System\.(out|err)\..+;"/>
       <property name="ignoreComments" value="true"/>
       <property name="message"

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ApiImplementationGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ApiImplementationGenerator.java
@@ -58,7 +58,6 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import lombok.NonNull;
-import org.jetbrains.annotations.NotNull;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
@@ -337,7 +336,7 @@ public final class ApiImplementationGenerator {
    * @return all methods which need to get implemented.
    * @throws NullPointerException if the given context is null.
    */
-  static @NotNull Collection<Method> collectMethodsToVisit(@NotNull GenerationContext context) {
+  static @NonNull Collection<Method> collectMethodsToVisit(@NonNull GenerationContext context) {
     Map<String, Method> visitedMethods = new HashMap<>();
     // first travel the class we should extend (if given)
     if (context.extendingClass() != null) {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
@@ -33,7 +33,6 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ServerConnectEvent.Reason;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter<ProxiedPlayer> {
@@ -124,7 +123,7 @@ final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
   }
 
   @Override
-  public void sendPluginMessage(@NonNull String key, byte @NotNull [] data) {
+  public void sendPluginMessage(@NonNull String key, byte[] data) {
     this.forEach(player -> player.sendData(key, data));
   }
 

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignManagement.java
@@ -26,7 +26,6 @@ import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
 import eu.cloudnetservice.modules.signs.platform.PlatformSignManagement;
 import lombok.NonNull;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class NukkitSignManagement extends PlatformSignManagement<Player, Location> {
@@ -82,7 +81,7 @@ public class NukkitSignManagement extends PlatformSignManagement<Player, Locatio
   }
 
   @Override
-  public @Nullable WorldPosition convertPosition(@NotNull Location location) {
+  public @Nullable WorldPosition convertPosition(@NonNull Location location) {
     var entry = this.applicableSignConfigurationEntry();
     if (entry == null) {
       return null;

--- a/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
+++ b/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
@@ -18,30 +18,30 @@ package eu.cloudnetservice.plugins.papi;
 
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
 import eu.cloudnetservice.wrapper.Wrapper;
+import lombok.NonNull;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.OfflinePlayer;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class CloudNetPapiExpansion extends PlaceholderExpansion {
 
   @Override
-  public @NotNull String getIdentifier() {
+  public @NonNull String getIdentifier() {
     return "cloudnet";
   }
 
   @Override
-  public @NotNull String getName() {
+  public @NonNull String getName() {
     return "CloudNet";
   }
 
   @Override
-  public @NotNull String getAuthor() {
+  public @NonNull String getAuthor() {
     return "CloudNetService";
   }
 
   @Override
-  public @NotNull String getVersion() {
+  public @NonNull String getVersion() {
     return "{project.build.version}";
   }
 
@@ -51,7 +51,7 @@ public class CloudNetPapiExpansion extends PlaceholderExpansion {
   }
 
   @Override
-  public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
+  public @Nullable String onRequest(OfflinePlayer player, @NonNull String params) {
     // This is a bit tricky - PlaceholderAPI requires us to return "null" if the placeholder is unknown.
     // The bridge will just replace all placeholders in the string with the correct association.
     // We can just return null if the resulting string matches the input string


### PR DESCRIPTION
### Motivation
We are using the lombok.NonNull annotation to verify that an argument is not-null as it generates the code during compile time which pre-checks if a given argument is null or not. IJ automatically uses the jetbrains NotNull annotation, even if the super class or interface uses the correct lombok one, which prevents us from having correct preconditional null checks.

### Modification
I removed all accidentally added NotNull usages and added a checkstyle check which verifies that only the lombok.NonNull import is used.

### Result
There are no more usages of NotNull and all future, accidental usages will lead to a build failure.
