### PR TITLE
fix: Replace Set.copyOf with ImmutableSet.copyOf to preserve order

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/service/GroupConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/GroupConfiguration.java
@@ -17,6 +17,7 @@
 package eu.cloudnetservice.driver.service;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import eu.cloudnetservice.common.Nameable;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import java.util.Collection;
@@ -227,8 +228,8 @@ public class GroupConfiguration extends ServiceConfigurationBase implements Clon
       Preconditions.checkNotNull(this.name, "no name given");
       return new GroupConfiguration(
         this.name,
-        Set.copyOf(this.jvmOptions),
-        Set.copyOf(this.processParameters),
+        ImmutableSet.copyOf(this.jvmOptions),
+        ImmutableSet.copyOf(this.processParameters),
         Set.copyOf(this.targetEnvironments),
         Set.copyOf(this.templates),
         Set.copyOf(this.deployments),

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
@@ -17,8 +17,10 @@
 package eu.cloudnetservice.driver.service;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 import lombok.NonNull;
@@ -89,8 +91,8 @@ public record ProcessConfiguration(
     protected String environment;
     protected int maxHeapMemorySize = 512;
 
-    protected Set<String> jvmOptions = new HashSet<>();
-    protected Set<String> processParameters = new HashSet<>();
+    protected Set<String> jvmOptions = new LinkedHashSet<>();
+    protected Set<String> processParameters = new LinkedHashSet<>();
 
     /**
      * Sets the maximum amount of heap memory (in mb) the service is allowed to use. The given heap memory size must be
@@ -212,8 +214,8 @@ public record ProcessConfiguration(
       return new ProcessConfiguration(
         this.environment,
         this.maxHeapMemorySize,
-        Set.copyOf(this.jvmOptions),
-        Set.copyOf(this.processParameters));
+        ImmutableSet.copyOf(this.jvmOptions),
+        ImmutableSet.copyOf(this.processParameters));
     }
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfigurationBase.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfigurationBase.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.common.document.property.JsonDocPropertyHolder;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 import lombok.EqualsAndHashCode;
@@ -128,8 +129,8 @@ public abstract class ServiceConfigurationBase extends JsonDocPropertyHolder {
   public abstract static class Builder<T extends ServiceConfigurationBase, B extends Builder<T, B>> {
 
     protected JsonDocument properties = JsonDocument.newDocument();
-    protected Set<String> jvmOptions = new HashSet<>();
-    protected Set<String> processParameters = new HashSet<>();
+    protected Set<String> jvmOptions = new LinkedHashSet<>();
+    protected Set<String> processParameters = new LinkedHashSet<>();
     protected Set<ServiceTemplate> templates = new HashSet<>();
     protected Set<ServiceDeployment> deployments = new HashSet<>();
     protected Set<ServiceRemoteInclusion> includes = new HashSet<>();

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
@@ -17,6 +17,7 @@
 package eu.cloudnetservice.driver.service;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import eu.cloudnetservice.common.Nameable;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.common.document.property.DocProperty;
@@ -24,6 +25,7 @@ import eu.cloudnetservice.common.document.property.FunctionalDocProperty;
 import eu.cloudnetservice.common.document.property.JsonDocPropertyHolder;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 import lombok.EqualsAndHashCode;
@@ -262,7 +264,7 @@ public class ServiceEnvironmentType extends JsonDocPropertyHolder implements Nam
     private String name;
     private int defaultServiceStartPort = 44955;
     private JsonDocument properties = JsonDocument.newDocument();
-    private Set<String> defaultProcessArguments = new HashSet<>();
+    private Set<String> defaultProcessArguments = new LinkedHashSet<>();
 
     /**
      * Sets the name of the service environment type.
@@ -347,7 +349,7 @@ public class ServiceEnvironmentType extends JsonDocPropertyHolder implements Nam
       return new ServiceEnvironmentType(
         this.name,
         this.defaultServiceStartPort,
-        this.defaultProcessArguments,
+        ImmutableSet.copyOf(this.defaultProcessArguments),
         this.properties);
     }
   }


### PR DESCRIPTION
### Motivation
Some jvm options require a strict option order. Creating copies using `Set.copyOf` would not keep the set in any order and therefore the jvm might crash.
### Modification
Replaced any HashSets with LinkedHashSets that need to be in order and replaced `Set.copyOf` with `ImmutableSet.copyOf`

### Result
The order of the options is preserved.