### PR TITLE
chore: update for new cloud command framework version

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCaptionVariableReplacementHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCaptionVariableReplacementHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.node.command.defaults;
+
+import cloud.commandframework.captions.Caption;
+import cloud.commandframework.captions.CaptionVariableReplacementHandler;
+import eu.cloudnetservice.common.language.I18n;
+import lombok.NonNull;
+
+final class DefaultCaptionVariableReplacementHandler implements CaptionVariableReplacementHandler {
+
+  @Override
+  public @NonNull String replaceVariables(@NonNull Caption caption, @NonNull Object... variables) {
+    return I18n.trans(caption.getKey().replace('.', '-'), variables);
+  }
+}

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandProvider.java
@@ -97,8 +97,7 @@ public class DefaultCommandProvider implements CommandProvider {
   public DefaultCommandProvider(@NonNull Console console, @NonNull EventManager eventManager) {
     this.console = console;
     this.commandManager = new DefaultCommandManager();
-    this.commandManager.captionVariableReplacementHandler(
-      (caption, variables) -> I18n.trans(caption.getKey(), variables));
+    this.commandManager.captionVariableReplacementHandler(new DefaultCaptionVariableReplacementHandler());
     this.annotationParser = new AnnotationParser<>(this.commandManager, CommandSource.class,
       parameters -> SimpleCommandMeta.empty());
     this.registeredCommands = Multimaps.newSetMultimap(new ConcurrentHashMap<>(), ConcurrentHashMap::newKeySet);
@@ -122,7 +121,7 @@ public class DefaultCommandProvider implements CommandProvider {
     // register pre- and post-processor to call our events
     this.commandManager.registerCommandPreProcessor(new DefaultCommandPreProcessor());
     this.commandManager.registerCommandPostProcessor(new DefaultCommandPostProcessor());
-    this.commandManager.setCommandSuggestionProcessor(new DefaultSuggestionProcessor(this));
+    this.commandManager.commandSuggestionProcessor(new DefaultSuggestionProcessor(this));
     // register the command confirmation handling
     this.registerCommandConfirmation();
     this.exceptionHandler = new CommandExceptionHandler(this, eventManager);
@@ -291,14 +290,14 @@ public class DefaultCommandProvider implements CommandProvider {
    */
   protected @NonNull List<String> commandUsageOfRoot(@NonNull String root) {
     List<String> commandUsage = new ArrayList<>();
-    for (var command : this.commandManager.getCommands()) {
+    for (var command : this.commandManager.commands()) {
       var arguments = command.getArguments();
       // the first argument is the root, check if it matches
       if (arguments.isEmpty() || !arguments.get(0).getName().equalsIgnoreCase(root)) {
         continue;
       }
 
-      commandUsage.add(this.commandManager.getCommandSyntaxFormatter().apply(arguments, null));
+      commandUsage.add(this.commandManager.commandSyntaxFormatter().apply(arguments, null));
     }
 
     Collections.sort(commandUsage);

--- a/node/src/main/java/eu/cloudnetservice/node/command/exception/CommandExceptionHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/exception/CommandExceptionHandler.java
@@ -19,9 +19,9 @@ package eu.cloudnetservice.node.command.exception;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.compound.FlagArgument;
 import cloud.commandframework.exceptions.ArgumentParseException;
-import cloud.commandframework.exceptions.CommandException;
 import cloud.commandframework.exceptions.InvalidSyntaxException;
 import cloud.commandframework.exceptions.NoSuchCommandException;
+import eu.cloudnetservice.CaptionedCommandException;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
 import eu.cloudnetservice.driver.command.CommandInfo;
@@ -73,7 +73,7 @@ public class CommandExceptionHandler {
     }
 
     // determine the cause type and apply the specific handler
-    if (cause instanceof CommandException) {
+    if (cause instanceof CaptionedCommandException) {
       if (cause instanceof InvalidSyntaxException invalidSyntaxException) {
         // build the full command tree for the given input
         var commandTree = this.collectCommandHelp(invalidSyntaxException.getCurrentChain());
@@ -104,7 +104,7 @@ public class CommandExceptionHandler {
       var deepCause = cause.getCause();
       if (deepCause instanceof ArgumentNotAvailableException) {
         source.sendMessage(deepCause.getMessage());
-      } else if (deepCause instanceof CommandException) {
+      } else if (deepCause instanceof CaptionedCommandException) {
         // we need to handle this exception extra
         if (deepCause instanceof FlagArgument.FlagParseException flagParseException) {
           // if no flag is supplied we should reply with the command tree


### PR DESCRIPTION
### Motivation
Our cloud command framework fork and the original cloud framework have released some breaking updates which we should pull in.

### Modification
Replace invalid imports, create new caption replacement handler class (as the old one is no longer a functional interface) and replace deprecated api usages.

### Result
Everything compiles again with the new cloud dependency version.