### PR TITLE
[ci skip] fix: either use new or old constructor of ServerListPingEvent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ defaultTasks 'build', 'checkLicenses', 'test', 'jar'
 
 allprojects {
 
-  def major = 3, minor = 4, patch = 4, versionType = "RELEASE"
+  def major = 3, minor = 4, patch = 5, versionType = "SNAPSHOT"
 
   group 'de.dytanic.cloudnet'
   version "$major.$minor.$patch-$versionType"

--- a/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetBridgePlugin.java
+++ b/cloudnet-modules/cloudnet-bridge/src/main/java/de/dytanic/cloudnet/ext/bridge/bukkit/BukkitCloudNetBridgePlugin.java
@@ -25,13 +25,22 @@ import de.dytanic.cloudnet.ext.bridge.listener.BridgeCustomChannelMessageListene
 import de.dytanic.cloudnet.ext.bridge.player.IPlayerManager;
 import de.dytanic.cloudnet.ext.bridge.server.BridgeServerHelper;
 import de.dytanic.cloudnet.wrapper.Wrapper;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.function.Supplier;
+import java.util.logging.Level;
 import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Nullable;
 
 public final class BukkitCloudNetBridgePlugin extends JavaPlugin {
+
+  private Supplier<ServerListPingEvent> serverListPingEventConstructor;
 
   @Override
   public synchronized void onEnable() {
@@ -70,14 +79,12 @@ public final class BukkitCloudNetBridgePlugin extends JavaPlugin {
       boolean value = false;
 
       try {
-        ServerListPingEvent serverListPingEvent = new ServerListPingEvent(
-          new InetSocketAddress("127.0.0.1", 53345).getAddress(),
-          BridgeServerHelper.getMotd(),
-          Bukkit.getOnlinePlayers().size(),
-          BridgeServerHelper.getMaxPlayers()
-        );
-        Bukkit.getPluginManager().callEvent(serverListPingEvent);
+        ServerListPingEvent serverListPingEvent = this.constructServerListPingEvent();
+        if (serverListPingEvent == null) {
+          return;
+        }
 
+        Bukkit.getPluginManager().callEvent(serverListPingEvent);
         if (!serverListPingEvent.getMotd().equalsIgnoreCase(BridgeServerHelper.getMotd())) {
           hasToUpdate = true;
           BridgeServerHelper.setMotd(serverListPingEvent.getMotd());
@@ -105,5 +112,49 @@ public final class BukkitCloudNetBridgePlugin extends JavaPlugin {
         exception.printStackTrace();
       }
     }, 0, 10);
+  }
+
+  private @Nullable ServerListPingEvent constructServerListPingEvent() {
+    if (this.serverListPingEventConstructor == null) {
+      try {
+        // new method in 1.19 and above
+        MethodHandle constructor = MethodHandles.publicLookup().findConstructor(
+          ServerListPingEvent.class,
+          MethodType.methodType(void.class, InetAddress.class, String.class, boolean.class, int.class, int.class));
+        this.serverListPingEventConstructor = () -> {
+          try {
+            return (ServerListPingEvent) constructor.invokeExact(
+              new InetSocketAddress("127.0.0.1", 53345).getAddress(),
+              BridgeServerHelper.getMotd(),
+              false,
+              Bukkit.getOnlinePlayers().size(),
+              BridgeServerHelper.getMaxPlayers());
+          } catch (Throwable throwable) {
+            // wait what
+            this.getLogger().log(
+              Level.SEVERE,
+              "Unable to construct ServerListPingEvent using modern constructor; disabling event calling",
+              throwable);
+            this.serverListPingEventConstructor = () -> null;
+            return null;
+          }
+        };
+      } catch (IllegalAccessException exception) {
+        // wait what
+        this.serverListPingEventConstructor = () -> null;
+        this.getLogger().log(
+          Level.SEVERE,
+          "Unable to access modern constructor of ServerListPingEvent; disabling event calling",
+          exception);
+      } catch (NoSuchMethodException exception) {
+        // old method before 1.18
+        this.serverListPingEventConstructor = () -> new ServerListPingEvent(
+          new InetSocketAddress("127.0.0.1", 53345).getAddress(),
+          BridgeServerHelper.getMotd(),
+          Bukkit.getOnlinePlayers().size(),
+          BridgeServerHelper.getMaxPlayers());
+      }
+    }
+    return this.serverListPingEventConstructor.get();
   }
 }


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:
The ServerListPingEvent is now called using the newly introduced constructor with the `previewsChat` option and the old constructor if running in an older environment.

### Documentation of test results:
Waiting for @0utplay to test this ;)

### Related issues/discussions:
Discord Bug report, see https://canary.discord.com/channels/325362837184577536/536594898321670154/988692256326311946
