### PR TITLE
fix: use new cloud failure reason getter

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/exception/CommandExceptionHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/exception/CommandExceptionHandler.java
@@ -108,7 +108,7 @@ public class CommandExceptionHandler {
         // we need to handle this exception extra
         if (deepCause instanceof FlagArgument.FlagParseException flagParseException) {
           // if no flag is supplied we should reply with the command tree
-          if (flagParseException.getFailureReason() == FlagArgument.FailureReason.NO_FLAG_STARTED) {
+          if (flagParseException.failureReason() == FlagArgument.FailureReason.NO_FLAG_STARTED) {
             source.sendMessage(this.collectCommandHelp(parseException.getCurrentChain()));
             return;
           }


### PR DESCRIPTION
### Motivation
In our fork of cloud we've exposed the failure reason when a flag parse exception is raised. That changed was later pr-ed to the upstream repository, but they use flow style for all new methods, so after updating our fork we now need to change this as well.

### Modification
Use new `FlagParseException#failureReason()` instead of `FlagParseException#getFailureReason()`.

### Result
The cloud update is completed and we can use the new, updated version of cloud.