### PR TITLE
chore: add support for compressed http responses

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerInitializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerInitializer.java
@@ -19,6 +19,7 @@ package eu.cloudnetservice.driver.network.netty.http;
 import eu.cloudnetservice.driver.network.HostAndPort;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelInitializer;
+import io.netty5.handler.codec.http.HttpContentCompressor;
 import io.netty5.handler.codec.http.HttpObjectAggregator;
 import io.netty5.handler.codec.http.HttpRequestDecoder;
 import io.netty5.handler.codec.http.HttpResponseEncoder;
@@ -63,6 +64,7 @@ final class NettyHttpServerInitializer extends ChannelInitializer<Channel> {
       .addLast("http-request-decoder", new HttpRequestDecoder())
       .addLast("http-object-aggregator", new HttpObjectAggregator<>(Short.MAX_VALUE))
       .addLast("http-response-encoder", new HttpResponseEncoder())
+      .addLast("http-response-compressor", new HttpContentCompressor())
       .addLast("http-chunk-handler", new ChunkedWriteHandler())
       .addLast("http-server-handler", new NettyHttpServerHandler(this.nettyHttpServer, this.hostAndPort));
   }


### PR DESCRIPTION
### Motivation
Clients can send an `accept-encoding` http header to request a specific encoding of the response, some of them require the server to compress the response (especially useful when trying to f. ex. download files).

### Modification
Add the content compressor handler of netty into the pipeline which automatically compresses the response when requested. (Supported compressions are `gzip`, `deflate`. `zstd` & `br`). 

### Result
We are now compressing http responses when requested.