### PR TITLE
chore: expand annotation node http authentication api

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpHandleException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpHandleException.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.http;
+
+import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An exception which can be thrown by a handler to set the status and body of the response for the current http
+ * request. Throwing this exception will not prevent other handlers from processing the request as well.
+ *
+ * @since 4.0
+ */
+public class HttpHandleException extends RuntimeException {
+
+  private final byte[] responseBody;
+  private final HttpResponseCode responseCode;
+
+  /**
+   * Constructs a new HttpHandleException instance.
+   *
+   * @param responseCode the http status code to set in the response.
+   * @param responseBody the response body to set, null to reset the body.
+   * @param message      the detail message why the exception occurred, for debugging only.
+   * @throws NullPointerException if the given response code or message is null.
+   */
+  public HttpHandleException(@NonNull HttpResponseCode responseCode, byte[] responseBody, @NonNull String message) {
+    super(message);
+    this.responseBody = responseBody;
+    this.responseCode = responseCode;
+  }
+
+  /**
+   * Get the body to set in the response, null to reset the body.
+   *
+   * @return the body to set in the response to the current processing request.
+   */
+  public byte[] responseBody() {
+    return this.responseBody;
+  }
+
+  /**
+   * Get the status code to set in the response to the current processing request.
+   *
+   * @return the status code to set in the response.
+   */
+  public @NonNull HttpResponseCode responseCode() {
+    return this.responseCode;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull Throwable fillInStackTrace() {
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull Throwable initCause(@Nullable Throwable cause) {
+    return this;
+  }
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/AnnotationHttpHandleException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/AnnotationHttpHandleException.java
@@ -16,15 +16,16 @@
 
 package eu.cloudnetservice.driver.network.http.annotation.parser;
 
+import eu.cloudnetservice.driver.network.http.HttpHandleException;
+import eu.cloudnetservice.driver.network.http.HttpResponseCode;
 import lombok.NonNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * A stackless exception which can be thrown when processing a http handler annotation.
  *
  * @since 4.0
  */
-public final class AnnotationHttpHandleException extends IllegalArgumentException {
+public final class AnnotationHttpHandleException extends HttpHandleException {
 
   /**
    * Constructs a new AnnotationHttpHandleException instance.
@@ -34,22 +35,24 @@ public final class AnnotationHttpHandleException extends IllegalArgumentExceptio
    * @throws NullPointerException if the given path or reason is null.
    */
   public AnnotationHttpHandleException(@NonNull String path, @NonNull String reason) {
-    super(String.format("Unable to handle http request on path \"%s\": %s", path, reason));
+    this(path, reason, HttpResponseCode.BAD_REQUEST, null);
   }
 
   /**
-   * {@inheritDoc}
+   * Constructs a new AnnotationHttpHandleException instance.
+   *
+   * @param path         the path to which the request was sent during which the handling error occurred.
+   * @param reason       the reason why the error occurred.
+   * @param responseCode the http status code to set in the response.
+   * @param responseBody the response body to set.
+   * @throws NullPointerException if the given path, reason or status is null.
    */
-  @Override
-  public @NonNull Throwable fillInStackTrace() {
-    return this;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public @NonNull Throwable initCause(@Nullable Throwable cause) {
-    return this;
+  public AnnotationHttpHandleException(
+    @NonNull String path,
+    @NonNull String reason,
+    @NonNull HttpResponseCode responseCode,
+    byte[] responseBody
+  ) {
+    super(responseCode, responseBody, String.format("Unable to handle http request on path \"%s\": %s", path, reason));
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/http/annotation/BearerAuth.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/annotation/BearerAuth.java
@@ -24,13 +24,14 @@ import java.lang.annotation.Target;
 
 /**
  * Tries to authenticate a permission user based on the required bearer token in the request and passes the associated
- * session instance for the annotated method parameter.
+ * session instance for the annotated method parameter. Annotating a handler method will ensure that the requesting user
+ * exists, but will not pass into any parameter.
  *
  * @since 4.0
  */
 @Documented
-@Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.METHOD})
 public @interface BearerAuth {
 
 }

--- a/node/src/main/java/eu/cloudnetservice/node/http/annotation/HandlerPermission.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/annotation/HandlerPermission.java
@@ -21,17 +21,25 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import lombok.NonNull;
 
 /**
- * Tries to authenticate a permission user based on the required basic credentials in the request and passes the user
- * instance for the annotated method parameter. Annotating a handler method will ensure that the requesting user exists,
- * but will not pass into any parameter.
+ * Enforces a permission for the annotated http handler. If this annotation is present on class and method level, then
+ * the annotation on method level is used.
+ * <p>
+ * This annotation must be used in combination with {@code @BasicAuth} or {@code @BearerAuth} to have any effect.
  *
  * @since 4.0
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.PARAMETER, ElementType.METHOD})
-public @interface BasicAuth {
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface HandlerPermission {
 
+  /**
+   * Get the permission that the user must have in order to send a request to the handler(s).
+   *
+   * @return the required permission for the http handler(s).
+   */
+  @NonNull String value();
 }

--- a/node/src/main/java/eu/cloudnetservice/node/http/annotation/SecurityAnnotationExtensions.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/annotation/SecurityAnnotationExtensions.java
@@ -16,16 +16,26 @@
 
 package eu.cloudnetservice.node.http.annotation;
 
+import eu.cloudnetservice.common.document.gson.JsonDocument;
+import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.network.http.HttpContext;
 import eu.cloudnetservice.driver.network.http.HttpContextPreprocessor;
+import eu.cloudnetservice.driver.network.http.HttpResponseCode;
 import eu.cloudnetservice.driver.network.http.annotation.Optional;
 import eu.cloudnetservice.driver.network.http.annotation.parser.AnnotationHttpHandleException;
 import eu.cloudnetservice.driver.network.http.annotation.parser.DefaultHttpAnnotationParser;
 import eu.cloudnetservice.driver.network.http.annotation.parser.HttpAnnotationParser;
 import eu.cloudnetservice.driver.network.http.annotation.parser.HttpAnnotationProcessor;
 import eu.cloudnetservice.driver.network.http.annotation.parser.HttpAnnotationProcessorUtil;
+import eu.cloudnetservice.driver.permission.Permission;
+import eu.cloudnetservice.driver.permission.PermissionUser;
+import eu.cloudnetservice.node.http.HttpSession;
 import eu.cloudnetservice.node.http.V2HttpAuthentication;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
 import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class SecurityAnnotationExtensions {
 
@@ -39,10 +49,62 @@ public final class SecurityAnnotationExtensions {
       .registerAnnotationProcessor(new BearerAuthProcessor(auth));
   }
 
+  private static @Nullable <T> HttpContext handleAuthResult(
+    @NonNull HttpContext context,
+    @NonNull V2HttpAuthentication.LoginResult<T> result,
+    @NonNull Function<T, PermissionUser> userExtractor,
+    @Nullable HandlerPermission permission
+  ) {
+    // if the auth succeeded check if the user has the required permission
+    if (result.succeeded()) {
+      var user = userExtractor.apply(result.result());
+      if (validatePermission(user, permission)) {
+        // the user has no permission for the handler
+        context
+          .cancelNext(true)
+          .closeAfter(true)
+          .response()
+          .status(HttpResponseCode.UNAUTHORIZED)
+          .body(buildErrorResponse("Required permission is not set"));
+        return null;
+      }
+
+      // all fine
+      return context;
+    }
+
+    // auth failed - set that in the context and drop the request
+    context
+      .cancelNext(true)
+      .closeAfter(true)
+      .response()
+      .status(HttpResponseCode.UNAUTHORIZED)
+      .body(buildErrorResponse(result.errorMessage()));
+    return null;
+  }
+
+  private static boolean validatePermission(@NonNull PermissionUser user, @Nullable HandlerPermission permission) {
+    var permissionManagement = CloudNetDriver.instance().permissionManagement();
+    return permission == null || permissionManagement.hasPermission(user, Permission.of(permission.value()));
+  }
+
+  private static @Nullable HandlerPermission resolvePermissionAnnotation(@NonNull Method method) {
+    var permission = method.getAnnotation(HandlerPermission.class);
+    return permission == null ? method.getDeclaringClass().getAnnotation(HandlerPermission.class) : permission;
+  }
+
+  private static byte[] buildErrorResponse(@NonNull String reason) {
+    return JsonDocument.newDocument("success", false)
+      .append("reason", reason)
+      .toString()
+      .getBytes(StandardCharsets.UTF_8);
+  }
+
   private record BasicAuthProcessor(@NonNull V2HttpAuthentication authentication) implements HttpAnnotationProcessor {
 
     @Override
-    public @NonNull HttpContextPreprocessor buildPreprocessor(@NonNull Method method, @NonNull Object handler) {
+    public @Nullable HttpContextPreprocessor buildPreprocessor(@NonNull Method method, @NonNull Object handler) {
+      var permission = resolvePermissionAnnotation(method);
       var hints = HttpAnnotationProcessorUtil.mapParameters(
         method,
         BasicAuth.class,
@@ -50,20 +112,48 @@ public final class SecurityAnnotationExtensions {
           // try to authenticate the user; throw an exception if that failed and the parameter is required
           var authResult = this.authentication.handleBasicLoginRequest(context.request());
           if (!param.isAnnotationPresent(Optional.class) && authResult.failed()) {
-            throw new AnnotationHttpHandleException(path, "Unable to authenticate user: " + authResult.errorMessage());
+            throw new AnnotationHttpHandleException(
+              path,
+              "Unable to authenticate user: " + authResult.errorMessage(),
+              HttpResponseCode.UNAUTHORIZED,
+              buildErrorResponse("Unable to authenticate user"));
           }
 
-          // put the user into the context
-          return authResult.result();
+          // put the user into the context if he has the required permission
+          if (validatePermission(authResult.result(), permission)) {
+            return authResult.result();
+          }
+
+          throw new AnnotationHttpHandleException(
+            path,
+            "User has not the required permission to send a request",
+            HttpResponseCode.FORBIDDEN,
+            buildErrorResponse("Missing required permission"));
         });
-      return (path, ctx) -> ctx.addInvocationHints(DefaultHttpAnnotationParser.PARAM_INVOCATION_HINT_KEY, hints);
+      // check if we got any hints
+      if (!hints.isEmpty()) {
+        return (path, ctx) -> ctx.addInvocationHints(DefaultHttpAnnotationParser.PARAM_INVOCATION_HINT_KEY, hints);
+      }
+
+      // check if the annotation is present on method level
+      if (method.isAnnotationPresent(BasicAuth.class)) {
+        return (path, ctx) -> {
+          // drop the request if the authentication failed
+          var authResult = this.authentication.handleBasicLoginRequest(ctx.request());
+          return handleAuthResult(ctx, authResult, Function.identity(), permission);
+        };
+      }
+
+      // ok, nothing to do
+      return null;
     }
   }
 
   private record BearerAuthProcessor(@NonNull V2HttpAuthentication authentication) implements HttpAnnotationProcessor {
 
     @Override
-    public @NonNull HttpContextPreprocessor buildPreprocessor(@NonNull Method method, @NonNull Object handler) {
+    public @Nullable HttpContextPreprocessor buildPreprocessor(@NonNull Method method, @NonNull Object handler) {
+      var permission = resolvePermissionAnnotation(method);
       var hints = HttpAnnotationProcessorUtil.mapParameters(
         method,
         BearerAuth.class,
@@ -71,13 +161,40 @@ public final class SecurityAnnotationExtensions {
           // try to authenticate the user; throw an exception if that failed and the parameter is required
           var authResult = this.authentication.handleBearerLoginRequest(context.request());
           if (!param.isAnnotationPresent(Optional.class) && authResult.failed()) {
-            throw new AnnotationHttpHandleException(path, "Unable to authenticate user: " + authResult.errorMessage());
+            throw new AnnotationHttpHandleException(
+              path,
+              "Unable to authenticate user: " + authResult.errorMessage(),
+              HttpResponseCode.UNAUTHORIZED,
+              buildErrorResponse("Unable to authenticate user"));
           }
 
-          // put the session into the context
-          return authResult.result();
+          // put the user into the context if he has the required permission
+          if (validatePermission(authResult.result().user(), permission)) {
+            return authResult.result();
+          }
+
+          throw new AnnotationHttpHandleException(
+            path,
+            "User has not the required permission to send a request",
+            HttpResponseCode.FORBIDDEN,
+            buildErrorResponse("Missing required permission"));
         });
-      return (path, ctx) -> ctx.addInvocationHints(DefaultHttpAnnotationParser.PARAM_INVOCATION_HINT_KEY, hints);
+      // check if we got any hints
+      if (!hints.isEmpty()) {
+        return (path, ctx) -> ctx.addInvocationHints(DefaultHttpAnnotationParser.PARAM_INVOCATION_HINT_KEY, hints);
+      }
+
+      // check if the annotation is present on method level
+      if (method.isAnnotationPresent(BearerAuth.class)) {
+        return (path, ctx) -> {
+          // drop the request if the authentication failed
+          var authResult = this.authentication.handleBearerLoginRequest(ctx.request());
+          return handleAuthResult(ctx, authResult, HttpSession::user, permission);
+        };
+      }
+
+      // ok, nothing to do
+      return null;
     }
   }
 }


### PR DESCRIPTION
### Motivation
Expand the previously introduced annotation system to easier and more percise authenticate a user using annotations.

### Modification
Expanded the `@BasicAuth` and `@BearerAuth` annotation to be also respected when present on method level. Added a new `@HandlerPermission` annotation to control the required permission for a http handler on class or method level (only works in combination with an authentication permission).

### Result
Easier authentication of users using the http annotation api.