### PR TITLE
chore: allow retrieval of http body via annotation

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestBody.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestBody.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.http.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Injects the request body into the annotated parameter. The type of the parameter must be one of: {@code String},
+ * {@code byte[]}, {@code InputStream} or {@code JsonDocument}. Json documents will be decoded by reading the request
+ * body from the input stream.
+ *
+ * @since 4.0
+ */
+@Documented
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestBody {
+
+}


### PR DESCRIPTION
### Motivation
There is currently no annotation to get the request body from a http request directly injected into a handler method parameter.

### Modification
Add a `@RequestBody` annotation which allows the injection of the body into a paramater with the type `String`, `byte[]`, `InputStream` or `JsonDocument`.

### Result
Easier injection of request body via annotation.

##### Other context
Tests are currently failing as #703 is not present in this branch (passing locally).