### PR TITLE
build: reduce exposed dependencies

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -19,7 +19,6 @@ tasks.withType<Jar> {
 }
 
 dependencies {
-  "api"(libs.gson)
-  "api"(libs.guava)
-  "api"(libs.bundles.unirest)
+  "implementation"(libs.gson)
+  "implementation"(libs.guava)
 }

--- a/driver/build.gradle.kts
+++ b/driver/build.gradle.kts
@@ -43,12 +43,17 @@ dependencies {
   "api"(projects.common)
   "api"(projects.ext.updater)
 
-  "api"(libs.asm)
   "api"(libs.caffeine)
   "api"(libs.reflexion)
-  "implementation"(libs.bundles.netty)
+  "api"(libs.bundles.unirest)
 
-  // native transports
+  // internal libraries
+  "implementation"(libs.asm)
+  "implementation"(libs.gson)
+  "implementation"(libs.guava)
+
+  // netty
+  "implementation"(libs.bundles.netty)
   "implementation"(libs.nettyNativeKqueue)
   "implementation"(variantOf(libs.nettyNativeEpoll) { classifier("linux-x86_64") })
   "implementation"(variantOf(libs.nettyNativeEpoll) { classifier("linux-aarch_64") })

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -40,6 +40,9 @@ subprojects {
   dependencies {
     "compileOnly"(rootProject.projects.node)
     "testImplementation"(rootProject.projects.node)
+
+    // internal dependencies
+    "implementation"(rootProject.libs.guava)
   }
 
   tasks.named<Copy>("processResources") {

--- a/node/build.gradle.kts
+++ b/node/build.gradle.kts
@@ -35,20 +35,21 @@ tasks.withType<Jar> {
 dependencies {
   "api"(projects.driver)
   "api"(projects.ext.updater)
-  // console
-  "api"(libs.jline)
-  "api"(libs.jansi)
-  // javers - diff finder for java objects (used for cluster data sync)
+
+  // dependencies which are available for modules
+  "api"(libs.guava)
   "api"(libs.javers)
-  // default database implementations
-  "api"(libs.h2)
-  "api"(libs.xodus)
-  // just for slf4j to disable the warning message
-  "api"(libs.slf4jNop)
-  // jwt for rest api
-  "api"(libs.bundles.jjwt)
-  // commands
   "api"(libs.bundles.cloud)
+
+  // internal libraries
+  "implementation"(libs.h2)
+  "implementation"(libs.asm)
+  "implementation"(libs.gson)
+  "implementation"(libs.xodus)
+  "implementation"(libs.jline)
+  "implementation"(libs.jansi)
+  "implementation"(libs.slf4jNop)
+  "implementation"(libs.bundles.jjwt)
 }
 
 applyJarMetadata("eu.cloudnetservice.node.BootLogic", "eu.cloudnetservice.node")

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -34,4 +34,8 @@ subprojects {
         .replace("{project.perms.build.version}", projects.modules.cloudperms.version.toString())
     }
   }
+
+  dependencies {
+    "implementation"(rootProject.libs.guava)
+  }
 }

--- a/wrapper-jvm/build.gradle.kts
+++ b/wrapper-jvm/build.gradle.kts
@@ -37,7 +37,7 @@ tasks.withType<ShadowJar> {
   relocate("com.google.common", "eu.cloudnetservice.relocate.guava")
 
   // asm relocation to fix forge discovery:
-  // https://github.com/MinecraftForge/MinecraftForge/blob/1.16.x/src/fmllauncher/java/net/minecraftforge/fml/loading/LibraryFinder.java#L39
+  // https://github.com/MinecraftForge/MinecraftForge/blob/1.16.x/src/fmllauncher/java/net/minecraftforge/fml/loading/LibraryFinder.java#L25-L27
   relocate("org.objectweb.asm.Opcodes", "eu.cloudnetservice.relocate.asm.Opcodes")
 
   // drop unused classes which are making the jar bigger
@@ -53,6 +53,11 @@ tasks.withType<ShadowJar> {
 dependencies {
   "api"(projects.driver)
   "api"(projects.ext.modlauncher)
+
+  // internal libraries
+  "implementation"(libs.asm)
+  "implementation"(libs.gson)
+  "implementation"(libs.guava)
 }
 
 applyJarMetadata(


### PR DESCRIPTION
### Motivation
Right now we are exposing a lot of dependencies to the api users, making it hard for us to upgrade them and (if we shadow them) we cannot reduce the final jar size as all dependency classes must be present. 

### Modification
Expose less dependencies which requires them to be defined explictly where needed rather than being included indirectly.

### Result
Less exposed dependencies and the node (and wrapper) jar file size dropped by about 1.3 MB from 4.8MB to 3.5MB.