### PR TITLE
fix: correctly specify asm dependency for report module

### DIFF
--- a/modules/report/build.gradle.kts
+++ b/modules/report/build.gradle.kts
@@ -19,6 +19,7 @@ tasks.withType<Jar> {
 }
 
 dependencies {
+  "compileOnly"(libs.asm)
   "moduleLibrary"(libs.oshi)
 }
 


### PR DESCRIPTION
### Motivation
Due to a conflict between pull request #692 and #705 the compilation currently fails because the asm dependency is no longer exported to consumers, but required by the report module.

### Modification
Specifically specifiy the asm dependency for the report module.

### Result
The compile process runs as expected again.