### PR TITLE
chore: update to netty 5.0.0-Alpha3

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
@@ -202,7 +202,7 @@ public final class NettyUtil {
   public static @NonNull <T> Future<T> awaitFuture(@NonNull Future<T> future) {
     try {
       // await the future and rethrow exceptions if any occur
-      return future.asStage().await().future();
+      return future.asStage().sync().future();
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt(); // not much we can do
       throw new IllegalThreadStateException();

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
@@ -202,7 +202,7 @@ public final class NettyUtil {
   public static @NonNull <T> Future<T> awaitFuture(@NonNull Future<T> future) {
     try {
       // await the future and rethrow exceptions if any occur
-      return future.sync();
+      return future.asStage().await().future();
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt(); // not much we can do
       throw new IllegalThreadStateException();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ dockerJava = "3.2.13"
 unirest = "4.0.0-RC2"
 annotations = "23.0.0"
 influxClient = "6.3.0"
-netty = "5.0.0.Alpha3-SNAPSHOT"
+netty = "5.0.0.Alpha3"
 
 # platform api versions
 sponge = "9.0.0"


### PR DESCRIPTION
### Motivation
Netty has released [the next alpha version of netty 5](https://netty.io/news/2022/07/08/5-0-0-Alpha3.html). While we were using snapshot versions previously, we now want to stay in the release channel of netty to prevent accidental pulls of breaking changes.

### Modification
Bump netty to 5.0.0-Alpha3 and fix an issue with a breaking change.

### Result
We are now using the latest release version of netty 5.