### PR TITLE
[ci skip] chore: validate target branch when opening a pull request

### DIFF
--- a/.github/workflows/prbranch.yml
+++ b/.github/workflows/prbranch.yml
@@ -1,0 +1,16 @@
+name: Validate target PR branch
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Vankka/pr-target-branch-action@v2
+        with:
+          target: release
+          exclude: nightly

--- a/.github/workflows/prbranch.yml
+++ b/.github/workflows/prbranch.yml
@@ -2,9 +2,7 @@ name: Validate target PR branch
 
 on:
   pull_request:
-    types:
-      - opened
-      - edited
+    types: [ opened, edited ]
 
 jobs:
   check-branch:


### PR DESCRIPTION
### Motivation
There were already occurrences of accidental pull request merges into wrong branches.

### Modification
Add an action that will fail when the target branch is not "nightly"

### Result
Less more likely to accidentaly merge a pull request into the wrong branch.