### PR TITLE
chore: improve host and port parsing during setups

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
@@ -204,6 +204,16 @@ public final class Parsers {
         normalizedInput = normalizedInput.substring(0, portSeparatorIndex);
       }
 
+      // check if the host is wrapped in brackets
+      if (normalizedInput.startsWith("[")) {
+        normalizedInput = normalizedInput.substring(1);
+      }
+
+      // extracting this check allows accidental typos to happen like [2001:db8::1
+      if (normalizedInput.endsWith("]")) {
+        normalizedInput = normalizedInput.substring(0, normalizedInput.length() - 1);
+      }
+
       try {
         // try to parse an ipv 4 or 6 address from the input string
         var address = InetAddresses.forString(normalizedInput);


### PR DESCRIPTION
### Motivation
Currently host and port inputs must be in an uri format to be parsed correctly from our host and port parser. This makes the setup process much harder for users.

### Modification
Remove the need for the uri-syntax and assume the formatting of the input based on the `withPort` argument passed into the parser. The parser will still accept uri formatted input like: `[2001:db8::1]:80`. We are now also normalizing non-ascii input like `☃.net` to an ascii format (in this example case `xn--n3h.net`).

### Result
Much better parsing of host and ports during setups, making the process much easier.