### PR TITLE
chore: allow updates of service properties

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/EmptySpecificCloudServiceProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/EmptySpecificCloudServiceProvider.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.node.service.defaults.provider;
 
+import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.channel.ChannelMessageSender;
 import eu.cloudnetservice.driver.provider.SpecificCloudServiceProvider;
 import eu.cloudnetservice.driver.service.ServiceDeployment;
@@ -99,5 +100,9 @@ public final class EmptySpecificCloudServiceProvider implements SpecificCloudSer
 
   @Override
   public void deployResources(boolean removeDeployments) {
+  }
+
+  @Override
+  public void updateProperties(@NonNull JsonDocument properties) {
   }
 }

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
@@ -17,6 +17,7 @@
 package eu.cloudnetservice.wrapper;
 
 import com.google.common.collect.Lists;
+import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
 import eu.cloudnetservice.driver.CloudNetDriver;
@@ -252,6 +253,10 @@ public class Wrapper extends CloudNetDriver {
    * @return the new ServiceInfoSnapshot instance
    */
   public @NonNull ServiceInfoSnapshot createServiceInfoSnapshot() {
+    return this.createServiceInfoSnapshot(this.currentServiceInfoSnapshot.properties());
+  }
+
+  public @NonNull ServiceInfoSnapshot createServiceInfoSnapshot(@NonNull JsonDocument properties) {
     return new ServiceInfoSnapshot(
       System.currentTimeMillis(),
       this.currentServiceInfoSnapshot.address(),
@@ -260,7 +265,7 @@ public class Wrapper extends CloudNetDriver {
       this.serviceConfiguration(),
       this.currentServiceInfoSnapshot.connectedTime(),
       ServiceLifeCycle.RUNNING,
-      this.currentServiceInfoSnapshot.properties());
+      properties);
   }
 
   @ApiStatus.Internal

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/ServiceChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/ServiceChannelMessageListener.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.wrapper.network.listener.message;
 
+import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.event.EventListener;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.event.events.channel.ChannelMessageReceiveEvent;
@@ -59,6 +60,15 @@ public final class ServiceChannelMessageListener {
         // force update request of the service info
         case "request_update_service_information" -> event.binaryResponse(DataBuf.empty()
           .writeObject(Wrapper.instance().configureServiceInfoSnapshot()));
+
+        // force update request of the service information with new properties
+        case "request_update_service_information_with_new_properties" -> {
+          var properties = event.content().readObject(JsonDocument.class);
+          var snapshot = Wrapper.instance().createServiceInfoSnapshot(properties);
+
+          // publish the new service info
+          Wrapper.instance().publishServiceInfoUpdate(snapshot);
+        }
 
         // call the event for a new line in the log of the service
         case "screen_new_line" -> {


### PR DESCRIPTION
### Motivation
Some plugins might set custom properties into a service info snapshot and then update the snapshot safely to all services in the network. There is currently no way to do that, aside from the service to which the snapshot belongs.

### Modification
Added a `updateProperties` method to the SpecificCloudServiceProvider which allows safely updating the service properties by requesting a snapshot with the changes applied of the plugins running on the target service. The plugins are also responsible to decide if they want to override the properties or keep them.

### Result
An easy and safe way to update service properties.