### PR TITLE
chore: improve bridge localized message handling

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitPlayerManagementListener.java
@@ -20,7 +20,6 @@ import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.helper.ServerPlatformHelper;
 import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
 import eu.cloudnetservice.wrapper.Wrapper;
-import java.util.Locale;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -53,7 +52,7 @@ public final class BukkitPlayerManagementListener implements Listener {
       if (task.maintenance() && !event.getPlayer().hasPermission("cloudnet.bridge.maintenance")) {
         event.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
         event.setKickMessage(this.management.configuration().message(
-          Locale.forLanguageTag(BukkitUtil.playerLocale(event.getPlayer())),
+          BukkitUtil.playerLocale(event.getPlayer()),
           "server-join-cancel-because-maintenance"));
         return;
       }
@@ -62,7 +61,7 @@ public final class BukkitPlayerManagementListener implements Listener {
       if (permission != null && !event.getPlayer().hasPermission(permission)) {
         event.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
         event.setKickMessage(this.management.configuration().message(
-          Locale.forLanguageTag(BukkitUtil.playerLocale(event.getPlayer())),
+          BukkitUtil.playerLocale(event.getPlayer()),
           "server-join-cancel-because-permission"));
       }
     }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitUtil.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitUtil.java
@@ -18,13 +18,18 @@ package eu.cloudnetservice.modules.bridge.platform.bukkit;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 import lombok.NonNull;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 final class BukkitUtil {
 
   private static final Function<Player, String> LOCALE_GETTER;
+  private static final Map<String, Locale> LOCALE_CACHE = new HashMap<>();
 
   static {
     Function<Player, String> localeGetter;
@@ -57,7 +62,14 @@ final class BukkitUtil {
     throw new UnsupportedOperationException();
   }
 
-  public static @NonNull String playerLocale(@NonNull Player player) {
-    return LOCALE_GETTER.apply(player);
+  public static @Nullable Locale playerLocale(@NonNull Player player) {
+    // resolve the language using the getter, do nothing if we were not able to resolve the language for some reason
+    var localeTag = LOCALE_GETTER.apply(player);
+    if (localeTag == null) {
+      return null;
+    }
+
+    // resolve the locale tag from the cache, put it in if missing
+    return LOCALE_CACHE.computeIfAbsent(localeTag, tag -> Locale.forLanguageTag(tag.replace('_', '-')));
   }
 }


### PR DESCRIPTION
### Motivation
The bridge module supports localized messages but they can be handled much better to make it easier for end users to configure them.

### Modification
There are three modifications:
 1. Parse the language tag of the bukkit `getLocale` method correctly, currently parsing would always result in the root locale because the supplied language tags are invalid (`forLanguageTag` is the correct method, but only accepts `-` not `_`)
 2. Allow users to specifically override the messages for a specific locale (like `en_US`) and a language (like `en`).
 3. Correctly fall back to the default messages when we were unable to load the localized or default messages from the bridge configuration (this would currently result in an exception rather than a message load from the default messages).

### Result
Improved & fixed localized message handling for the bridge module.