### PR TITLE
chore: increase timeouts when resolving dependencies

### DIFF
--- a/build-extensions/src/main/kotlin/extensions.kt
+++ b/build-extensions/src/main/kotlin/extensions.kt
@@ -118,8 +118,9 @@ private fun resolveRepository(
     val url = URL(it.url.toURL(), testUrlPath)
     with(url.openConnection() as HttpURLConnection) {
       useCaches = false
-      readTimeout = 5000
-      connectTimeout = 5000
+      readTimeout = 30000
+      connectTimeout = 30000
+      instanceFollowRedirects = true
 
       setRequestProperty(
         "User-Agent",


### PR DESCRIPTION
### Motivation
Some builds are failing from time to time as the dependency resolution times out for some reason.

### Modification
Increased the dependency resolve timeout from 5 seconds to 30 seconds to prevent timeouts.

### Result
(Hoipefully) less build failures because of connection/read timeouts.

##### Other context
After this pull request the changes will be applied to the juppiter plugin as well.