### PR TITLE
fix: Suggest whitelisted ips when removing them

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
@@ -54,7 +54,7 @@ public final class ConfigCommand {
     return address;
   }
 
-  @Suggestions("whitelistIps")
+  @Suggestions("whitelistedIps")
   public @NonNull List<String> suggestWhitelistIps(@NonNull CommandContext<?> $, @NonNull String input) {
     return List.copyOf(this.nodeConfig().ipWhitelist());
   }
@@ -91,7 +91,7 @@ public final class ConfigCommand {
   @CommandMethod("config|cfg node remove ip <ip>")
   public void removeIpWhitelist(
     @NonNull CommandSource source,
-    @NonNull @Argument(value = "ip", suggestions = "whitelistIps") String ip
+    @NonNull @Argument(value = "ip", suggestions = "whitelistedIps") String ip
   ) {
     var ipWhitelist = this.nodeConfig().ipWhitelist();
     // check if the collection changes after we remove the given ip

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
@@ -21,6 +21,7 @@ import cloud.commandframework.annotations.CommandMethod;
 import cloud.commandframework.annotations.CommandPermission;
 import cloud.commandframework.annotations.parsers.Parser;
 import cloud.commandframework.annotations.specifier.Range;
+import cloud.commandframework.annotations.suggestions.Suggestions;
 import cloud.commandframework.context.CommandContext;
 import com.google.common.net.InetAddresses;
 import eu.cloudnetservice.common.JavaVersion;
@@ -33,6 +34,7 @@ import eu.cloudnetservice.node.command.exception.ArgumentNotAvailableException;
 import eu.cloudnetservice.node.command.source.CommandSource;
 import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.config.JsonConfiguration;
+import java.util.List;
 import java.util.Queue;
 import lombok.NonNull;
 
@@ -50,6 +52,11 @@ public final class ConfigCommand {
     }
 
     return address;
+  }
+
+  @Suggestions("whitelistIps")
+  public @NonNull List<String> suggestWhitelistIps(@NonNull CommandContext<?> $, @NonNull String input) {
+    return List.copyOf(this.nodeConfig().ipWhitelist());
   }
 
   @CommandMethod("config|cfg reload")
@@ -82,7 +89,10 @@ public final class ConfigCommand {
   }
 
   @CommandMethod("config|cfg node remove ip <ip>")
-  public void removeIpWhitelist(@NonNull CommandSource source, @NonNull @Argument(value = "ip") String ip) {
+  public void removeIpWhitelist(
+    @NonNull CommandSource source,
+    @NonNull @Argument(value = "ip", suggestions = "whitelistIps") String ip
+  ) {
     var ipWhitelist = this.nodeConfig().ipWhitelist();
     // check if the collection changes after we remove the given ip
     if (ipWhitelist.remove(ip)) {


### PR DESCRIPTION
### Motivation
Currently there aren't any suggestions when trying to remove a whitelisted ip using the command.

### Modification
Created a new suggestion supplier for whitelisted ips and applied it to the remove command.

### Result
All whitelisted ips are suggested when trying to remove an ip.