### PR TITLE
feat: Allow a host address on a per task basis

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/HostAndPort.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/HostAndPort.java
@@ -42,7 +42,7 @@ public record HostAndPort(@NonNull String host, int port) {
    * @throws IllegalArgumentException if the given port exceeds the port range.
    */
   public HostAndPort {
-    Preconditions.checkArgument(this.port() >= -1 && this.port() <= 65535, "invalid port given");
+    Preconditions.checkArgument(this.port() >= -1 && this.port() <= 0xFFFF, "invalid port given");
   }
 
   /**

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/DefaultHttpAnnotationParser.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/DefaultHttpAnnotationParser.java
@@ -189,7 +189,7 @@ public final class DefaultHttpAnnotationParser<T extends HttpComponent<T>> imple
 
         // sanatize the supplied arguments
         var supportedPaths = annotation.paths();
-        var boundPort = annotation.port() >= 0 && annotation.port() <= 65535 ? annotation.port() : null;
+        var boundPort = annotation.port() >= 0 && annotation.port() <= 0xFFFF ? annotation.port() : null;
         var supportedMethods = Arrays.stream(annotation.methods()).map(String::toUpperCase).toList();
 
         // validate the arguments

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
@@ -626,9 +626,10 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
 
     /**
      * Sets the host address which all services based on this configuration are bound to. The host address is required
-     * to be assignable on every node a service can start. In order to achieve this a cluster with multiple nodes so
-     * called ip aliases can be used. Define your ip alias in the config of each node and set this host address to the
-     * name of the alias. If null is supplied as host address the fallback address of the node is used.
+     * to be assignable on every node a service can be started on. In order to ensure that the host address is
+     * assignable on every node, ip aliases can be used. Ip aliases can be defined in the config of each node. To use
+     * them set the host address to the name of the alias. If null is supplied the fallback address of the node is
+     * used.
      * <p>
      * Note: if the host address is not assignable or the alias is not resolvable on the node which is picking up the
      * service it will result in an error.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
@@ -121,6 +121,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
 
   protected final int port;
   protected final String runtime;
+  protected final String hostAddress;
   protected final String javaCommand;
 
   protected final boolean autoDeleteOnStop;
@@ -136,6 +137,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
    * @param processConfig         the process configuration of the service which gets created.
    * @param port                  the port of the service to start with, might get increased when already taken.
    * @param runtime               the runtime of the service to create it based on, for example {@code jvm}.
+   * @param hostAddress           the host address the service based on this configuration is bound to.
    * @param javaCommand           the java command to use when starting a service.
    * @param autoDeleteOnStop      if the service should get deleted when stopping.
    * @param staticService         if the service which gets created should be static (no file deletion when stopping).
@@ -152,6 +154,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
     @NonNull ProcessConfiguration processConfig,
     int port,
     @NonNull String runtime,
+    @Nullable String hostAddress,
     @Nullable String javaCommand,
     boolean autoDeleteOnStop,
     boolean staticService,
@@ -167,6 +170,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
     this.serviceId = serviceId;
     this.port = port;
     this.runtime = runtime;
+    this.hostAddress = hostAddress;
     this.javaCommand = javaCommand;
     this.autoDeleteOnStop = autoDeleteOnStop;
     this.staticService = staticService;
@@ -200,6 +204,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
       .taskName(task.name())
 
       .runtime(task.runtime())
+      .hostAddress(task.hostAddress())
       .javaCommand(task.javaCommand())
       .nameSplitter(task.nameSplitter())
 
@@ -236,6 +241,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
     return builder()
       .serviceId(ServiceId.builder(configuration.serviceId()))
       .runtime(configuration.runtime())
+      .hostAddress(configuration.hostAddress())
       .javaCommand(configuration.javaCommand())
       .autoDeleteOnStop(configuration.autoDeleteOnStop())
       .staticService(configuration.staticService())
@@ -310,6 +316,17 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
    */
   public @NonNull String runtime() {
     return this.runtime;
+  }
+
+  /**
+   * Get the host address that all services based on this configuration are bound to. The host address is not required
+   * to be an ip address, it is possible that the host address is just an ip alias which needs to be resolved using the
+   * configuration of the node. The host address might be null, in that case the fallback host of the node is used.
+   *
+   * @return the host address that all services based on this configuration are bound to.
+   */
+  public @Nullable String hostAddress() {
+    return this.hostAddress;
   }
 
   /**
@@ -417,6 +434,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
     protected ProcessConfiguration.Builder processConfig = ProcessConfiguration.builder();
 
     protected String javaCommand;
+    protected String hostAddress;
     protected String runtime = "jvm";
 
     protected boolean staticService;
@@ -607,6 +625,23 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
     }
 
     /**
+     * Sets the host address which all services based on this configuration are bound to. The host address is required
+     * to be assignable on every node a service can start. In order to achieve this a cluster with multiple nodes so
+     * called ip aliases can be used. Define your ip alias in the config of each node and set this host address to the
+     * name of the alias. If null is supplied as host address the fallback address of the node is used.
+     * <p>
+     * Note: if the host address is not assignable or the alias is not resolvable on the node which is picking up the
+     * service it will result in an error.
+     *
+     * @param hostAddress the host address all services based on this configuration should get bound to.
+     * @return the same instance as used to call the method, for chaining.
+     */
+    public @NonNull Builder hostAddress(@Nullable String hostAddress) {
+      this.hostAddress = hostAddress;
+      return this;
+    }
+
+    /**
      * Sets whether services created based on the service configuration should get deleted after being stopped. This
      * does only mean that the service gets unregistered and is no longer available for starting, but does not mean that
      * all service files get deleted when the service is static.
@@ -791,6 +826,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
         this.processConfig.build(),
         this.port,
         this.runtime,
+        this.hostAddress,
         this.javaCommand,
         this.autoDeleteOnStop,
         this.staticService,

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
@@ -369,7 +369,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
    *
    * @return the port number to start the service on, might be counted up when the port is already taken.
    */
-  public @Range(from = 0, to = 65535) int port() {
+  public @Range(from = 0, to = 0xFFFF) int port() {
     return this.port;
   }
 
@@ -797,7 +797,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
      * @param startPort the port to start services upwards from.
      * @return the same instance as used to call the method, for chaining.
      */
-    public @NonNull Builder startPort(@Range(from = 0, to = 65535) int startPort) {
+    public @NonNull Builder startPort(@Range(from = 0, to = 0xFFFF) int startPort) {
       this.port = startPort;
       return this;
     }
@@ -821,7 +821,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
      */
     @Override
     public @NonNull ServiceConfiguration build() {
-      Preconditions.checkArgument(this.port > 0 && this.port <= 65535, "invalid port provided");
+      Preconditions.checkArgument(this.port > 0 && this.port <= 0xFFFF, "invalid port provided");
       return new ServiceConfiguration(
         this.serviceId.build(),
         this.processConfig.build(),

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
@@ -31,6 +31,7 @@ import lombok.NonNull;
 import lombok.ToString;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jetbrains.annotations.UnknownNullability;
 import org.jetbrains.annotations.Unmodifiable;
 
 /**
@@ -322,10 +323,14 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
    * Get the host address that all services based on this configuration are bound to. The host address is not required
    * to be an ip address, it is possible that the host address is just an ip alias which needs to be resolved using the
    * configuration of the node. The host address might be null, in that case the fallback host of the node is used.
+   * <p>
+   * Note: Might be null until the host address was resolved during the preparation of a service based on this
+   * configuration. The resolved host address is not reflected into the original configuration, only into the
+   * configuration which is available through the service information snapshot.
    *
-   * @return the host address that all services based on this configuration are bound to.
+   * @return the host address that all services based on this configuration are bound to, null if not resolved yet.
    */
-  public @Nullable String hostAddress() {
+  public @UnknownNullability String hostAddress() {
     return this.hostAddress;
   }
 

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
@@ -351,7 +351,7 @@ public class ServiceEnvironmentType extends JsonDocPropertyHolder implements Nam
      */
     public @NonNull ServiceEnvironmentType build() {
       Preconditions.checkNotNull(this.name, "no name given");
-      Preconditions.checkArgument(this.defaultServiceStartPort >= 0 && this.defaultServiceStartPort <= 65535,
+      Preconditions.checkArgument(this.defaultServiceStartPort >= 0 && this.defaultServiceStartPort <= 0xFFFF,
         "invalid default port");
 
       return new ServiceEnvironmentType(

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
@@ -436,9 +436,9 @@ public class ServiceTask extends ServiceConfigurationBase implements Cloneable, 
 
     /**
      * Sets the host address which all services of this task are bound to. The host address is required to be assignable
-     * on every node a service can start. In order to achieve this a cluster with multiple nodes so called ip aliases
-     * can be used. Define your ip alias in the config of each node and set this host address to the name of the alias.
-     * If null is supplied as host address the fallback address of the node is used.
+     * on every node a service can be started on. In order to ensure that the host address is assignable on every node, ip
+     * aliases can be used. Ip aliases can be defined in the config of each node. To use them set the host address to
+     * the name of the alias. If null is supplied the fallback address of the node is used.
      * <p>
      * Note: if the host address is not assignable or the alias is not resolvable on the node which is picking up the
      * service it will result in an error.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
@@ -350,7 +350,7 @@ public class ServiceTask extends ServiceConfigurationBase implements Cloneable, 
    *
    * @return the port number to start the service on, might be counted up when the port is already taken.
    */
-  public @Range(from = 1, to = 65535) int startPort() {
+  public @Range(from = 1, to = 0xFFFF) int startPort() {
     return this.startPort;
   }
 
@@ -715,7 +715,7 @@ public class ServiceTask extends ServiceConfigurationBase implements Cloneable, 
     @Override
     public @NonNull ServiceTask build() {
       Preconditions.checkNotNull(this.name, "no name given");
-      Preconditions.checkArgument(this.startPort > 0 && this.startPort <= 65535, "Invalid start port given");
+      Preconditions.checkArgument(this.startPort > 0 && this.startPort <= 0xFFFF, "Invalid start port given");
 
       return new ServiceTask(
         this.name,

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/NetworkTestCase.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/NetworkTestCase.java
@@ -29,7 +29,7 @@ public abstract class NetworkTestCase {
     var port = 1024; // first non restricted (to root user) port
     while (true) {
       // check for out of range port
-      if (port > 65535) {
+      if (port > 0xFFFF) {
         Assertions.fail("No free port found in range 1024 to 65535 which causes tests to break");
       }
       // check if the port is ignored

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/ApplicationBootstrap.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/ApplicationBootstrap.java
@@ -74,7 +74,7 @@ final class ApplicationBootstrap {
     RUNTIME_MX_BEAN.getSystemProperties().forEach((key, value) -> arguments.add("-D" + key + "=" + value));
 
     // enabled the debugger if requested
-    if (debuggerPort >= 0 && debuggerPort <= 65535) {
+    if (debuggerPort >= 0 && debuggerPort <= 0xFFFF) {
       arguments.add(String.format("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:%d", debuggerPort));
     }
 

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
@@ -147,11 +147,10 @@ public final class ClusterCommand {
       throw new ArgumentNotAvailableException(I18n.trans("command-any-host-invalid", address));
     }
     // check if we can assign the parsed host and port
-    if (NetworkUtil.checkAssignable(hostAndPort) == null) {
-      throw new ArgumentNotAvailableException(I18n.trans("command-assignable-host-invalid", address));
+    if (NetworkUtil.checkAssignable(hostAndPort)) {
+      return hostAndPort;
     }
-    // success
-    return hostAndPort;
+    throw new ArgumentNotAvailableException(I18n.trans("command-assignable-host-invalid", address));
   }
 
   @Suggestions("assignableHostAndPort")

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
@@ -161,8 +161,9 @@ public final class ClusterCommand {
   @Parser(name = "anyHost")
   public @NonNull String anyHostParser(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
     var address = input.remove();
-    if (NetworkUtil.parseHostAndPort(address, false) != null) {
-      return address;
+    var hostAndPort = NetworkUtil.parseHostAndPort(address, false);
+    if (hostAndPort != null) {
+      return hostAndPort.host();
     }
 
     throw new ArgumentNotAvailableException(I18n.trans("command-any-host-invalid", address));

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
@@ -24,7 +24,6 @@ import cloud.commandframework.annotations.parsers.Parser;
 import cloud.commandframework.annotations.suggestions.Suggestions;
 import cloud.commandframework.context.CommandContext;
 import com.google.common.collect.Lists;
-import com.google.common.net.InetAddresses;
 import eu.cloudnetservice.common.column.ColumnFormatter;
 import eu.cloudnetservice.common.column.RowBasedFormatter;
 import eu.cloudnetservice.common.io.ZipUtil;
@@ -148,7 +147,7 @@ public final class ClusterCommand {
       throw new ArgumentNotAvailableException(I18n.trans("command-any-host-invalid", address));
     }
     // check if we can assign the parsed host and port
-    if (NetworkUtil.assignableHostAndPort(hostAndPort) == null) {
+    if (NetworkUtil.checkAssignable(hostAndPort) == null) {
       throw new ArgumentNotAvailableException(I18n.trans("command-assignable-host-invalid", address));
     }
     // success
@@ -163,7 +162,7 @@ public final class ClusterCommand {
   @Parser(name = "anyHost")
   public @NonNull String anyHostParser(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
     var address = input.remove();
-    if (InetAddresses.isInetAddress(address)) {
+    if (NetworkUtil.parseHostAndPort(address, false) != null) {
       return address;
     }
 

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
@@ -46,10 +46,10 @@ public final class ConfigCommand {
   @Parser(name = "ipAlias")
   public @NonNull String ipAliasParser(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
     var alias = input.remove();
-
     if (this.nodeConfig().ipAliases().containsKey(alias)) {
       throw new ArgumentNotAvailableException(I18n.trans("command-config-node-ip-alias-already-existing", alias));
     }
+
     return alias;
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
@@ -21,11 +21,12 @@ import cloud.commandframework.annotations.CommandMethod;
 import cloud.commandframework.annotations.CommandPermission;
 import cloud.commandframework.annotations.parsers.Parser;
 import cloud.commandframework.annotations.specifier.Range;
+import cloud.commandframework.annotations.suggestions.Suggestions;
 import cloud.commandframework.context.CommandContext;
-import com.google.common.net.InetAddresses;
 import eu.cloudnetservice.common.JavaVersion;
 import eu.cloudnetservice.common.collection.Pair;
 import eu.cloudnetservice.common.language.I18n;
+import eu.cloudnetservice.driver.network.HostAndPort;
 import eu.cloudnetservice.node.Node;
 import eu.cloudnetservice.node.command.annotation.CommandAlias;
 import eu.cloudnetservice.node.command.annotation.Description;
@@ -33,6 +34,7 @@ import eu.cloudnetservice.node.command.exception.ArgumentNotAvailableException;
 import eu.cloudnetservice.node.command.source.CommandSource;
 import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.config.JsonConfiguration;
+import java.util.List;
 import java.util.Queue;
 import lombok.NonNull;
 
@@ -41,15 +43,19 @@ import lombok.NonNull;
 @Description("Administration of the cloudnet node configuration")
 public final class ConfigCommand {
 
-  @Parser(name = "ip")
-  public @NonNull String ipParser(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
-    var address = input.remove();
+  @Parser(name = "ipAlias")
+  public @NonNull String ipAlias(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
+    var alias = input.remove();
 
-    if (!InetAddresses.isInetAddress(address)) {
-      throw new ArgumentNotAvailableException(I18n.trans("command-config-node-ip-invalid"));
+    if (this.nodeConfig().ipAliases().containsKey(alias)) {
+      throw new ArgumentNotAvailableException(I18n.trans("command-config-node-ip-alias-already-existing", alias));
     }
+    return alias;
+  }
 
-    return address;
+  @Suggestions("ipAlias")
+  public @NonNull List<String> suggestIpAlias(@NonNull CommandContext<?> $, @NonNull String input) {
+    return List.copyOf(this.nodeConfig().ipAliases().keySet());
   }
 
   @CommandMethod("config|cfg reload")
@@ -58,7 +64,7 @@ public final class ConfigCommand {
     Node.instance().serviceTaskProvider().reload();
     Node.instance().groupConfigurationProvider().reload();
     Node.instance().permissionManagement().reload();
-    source.sendMessage(I18n.trans("command-config-node-reload-config"));
+    source.sendMessage(I18n.trans("command-config-reload-config"));
   }
 
   @CommandMethod("config|cfg node reload")
@@ -70,7 +76,7 @@ public final class ConfigCommand {
   @CommandMethod("config|cfg node add ip <ip>")
   public void addIpWhitelist(
     @NonNull CommandSource source,
-    @NonNull @Argument(value = "ip", parserName = "ip") String ip
+    @NonNull @Argument(value = "ip", parserName = "anyHost") String ip
   ) {
     var ipWhitelist = this.nodeConfig().ipWhitelist();
     // check if the collection changes after we add the ip
@@ -96,7 +102,7 @@ public final class ConfigCommand {
   public void setMaxMemory(@NonNull CommandSource source, @Argument("maxMemory") @Range(min = "0") int maxMemory) {
     this.nodeConfig().maxMemory(maxMemory);
     this.nodeConfig().save();
-    source.sendMessage(I18n.trans("command-config-node-max-memory-set", maxMemory));
+    source.sendMessage(I18n.trans("command-config-node-set-max-memory", maxMemory));
   }
 
   @CommandMethod("config|cfg node set javaCommand <executable>")
@@ -109,6 +115,28 @@ public final class ConfigCommand {
     source.sendMessage(I18n.trans("command-config-node-set-java-command",
       executable.first(),
       executable.second().name()));
+  }
+
+  @CommandMethod("config|cfg node add ipalias|ipa <name> <hostAddress>")
+  public void addIpAlias(
+    @NonNull CommandSource source,
+    @NonNull @Argument(value = "name", parserName = "ipAlias") String alias,
+    @NonNull @Argument(value = "hostAddress", parserName = "assignableHostAndPort") HostAndPort hostAddress
+  ) {
+    this.nodeConfig().ipAliases().put(alias, hostAddress.host());
+    this.nodeConfig().save();
+    source.sendMessage(I18n.trans("command-config-node-ip-alias-added", alias, hostAddress));
+  }
+
+  @CommandMethod("config|cfg node remove ipalias|ipa <name>")
+  public void removeIpAlias(
+    @NonNull CommandSource source,
+    @NonNull @Argument(value = "name", suggestions = "ipAlias") String alias
+  ) {
+    if (this.nodeConfig().ipAliases().remove(alias) != null) {
+      this.nodeConfig().save();
+    }
+    source.sendMessage(I18n.trans("command-config-node-ip-alias-remove", alias));
   }
 
   private @NonNull Configuration nodeConfig() {

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
@@ -44,7 +44,7 @@ import lombok.NonNull;
 public final class ConfigCommand {
 
   @Parser(name = "ipAlias")
-  public @NonNull String ipAlias(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
+  public @NonNull String ipAliasParser(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
     var alias = input.remove();
 
     if (this.nodeConfig().ipAliases().containsKey(alias)) {
@@ -54,7 +54,7 @@ public final class ConfigCommand {
   }
 
   @Suggestions("ipAlias")
-  public @NonNull List<String> suggestIpAlias(@NonNull CommandContext<?> $, @NonNull String input) {
+  public @NonNull List<String> ipAliasSuggestions(@NonNull CommandContext<?> $, @NonNull String input) {
     return List.copyOf(this.nodeConfig().ipAliases().keySet());
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
@@ -125,7 +125,7 @@ public final class ConfigCommand {
   ) {
     this.nodeConfig().ipAliases().put(alias, hostAddress.host());
     this.nodeConfig().save();
-    source.sendMessage(I18n.trans("command-config-node-ip-alias-added", alias, hostAddress));
+    source.sendMessage(I18n.trans("command-config-node-ip-alias-added", alias, hostAddress.host()));
   }
 
   @CommandMethod("config|cfg node remove ipalias|ipa <name>")

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -167,17 +167,16 @@ public final class TasksCommand {
   @Parser(suggestions = "ipAliasHostAddress", name = "ipAliasHostAddress")
   public @NonNull String hostAddressParser(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
     var address = input.remove();
-
     var alias = Node.instance().config().ipAliases().get(address);
-
+    // check if we can resolve the host address using our ip alias
     if (alias != null) {
       return address;
     }
-
-    if (NetworkUtil.assignableHostAndPort(address, false) != null) {
+    // check if the host address is parsable and assignable
+    if (NetworkUtil.parseAssignableHostAndPort(address, false) != null) {
       return address;
     }
-
+    // could not parse
     throw new ArgumentNotAvailableException(I18n.trans("command-tasks-unknown-host-address-or-alias", address));
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -173,8 +173,9 @@ public final class TasksCommand {
       return address;
     }
     // check if the host address is parsable and assignable
-    if (NetworkUtil.parseAssignableHostAndPort(address, false) != null) {
-      return address;
+    var hostAndPort = NetworkUtil.parseAssignableHostAndPort(address, false);
+    if (hostAndPort != null) {
+      return hostAndPort.host();
     }
     // could not parse
     throw new ArgumentNotAvailableException(I18n.trans("command-tasks-unknown-host-address-or-alias", address));

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -53,6 +53,7 @@ import eu.cloudnetservice.node.console.Console;
 import eu.cloudnetservice.node.console.animation.setup.ConsoleSetupAnimation;
 import eu.cloudnetservice.node.setup.SpecificTaskSetup;
 import eu.cloudnetservice.node.util.JavaVersionResolver;
+import eu.cloudnetservice.node.util.NetworkUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -161,6 +162,32 @@ public final class TasksCommand {
   @Suggestions("serviceTask")
   public @NonNull List<String> suggestTask(@NonNull CommandContext<?> $, @NonNull String input) {
     return this.taskProvider().serviceTasks().stream().map(Nameable::name).toList();
+  }
+
+  @Parser(suggestions = "ipAliasHostAddress", name = "ipAliasHostAddress")
+  public @NonNull String hostAddressParser(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
+    var address = input.remove();
+
+    var alias = Node.instance().config().ipAliases().get(address);
+
+    if (alias != null) {
+      return address;
+    }
+
+    if (NetworkUtil.assignableHostAndPort(address, false) != null) {
+      return address;
+    }
+
+    throw new ArgumentNotAvailableException(I18n.trans("command-tasks-unknown-host-address-or-alias", address));
+  }
+
+  @Suggestions("ipAliasHostAddress")
+  public @NonNull List<String> suggestHostAddress(@NonNull CommandContext<?> $, @NonNull String input) {
+    // all network addresses
+    var hostAddresses = new ArrayList<>(NetworkUtil.availableIPAddresses());
+    // all ip aliases
+    hostAddresses.addAll(Node.instance().config().ipAliases().keySet());
+    return hostAddresses;
   }
 
   @Parser(suggestions = "serviceTask")
@@ -325,6 +352,21 @@ public final class TasksCommand {
         "minServiceCount",
         task.name(),
         amount));
+    }
+  }
+
+  @CommandMethod("tasks task <name> set hostAddress <hostAddress>")
+  public void setHostAddress(
+    @NonNull CommandSource source,
+    @NonNull @Argument("name") Collection<ServiceTask> serviceTasks,
+    @NonNull @Argument(value = "hostAddress", parserName = "ipAliasHostAddress") String hostAddress
+  ) {
+    for (var task : serviceTasks) {
+      this.updateTask(task, builder -> builder.hostAddress(hostAddress));
+      source.sendMessage(I18n.trans("command-tasks-set-property-success",
+        "hostAddress",
+        task.name(),
+        hostAddress));
     }
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/config/Configuration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/Configuration.java
@@ -22,6 +22,7 @@ import eu.cloudnetservice.driver.network.cluster.NetworkCluster;
 import eu.cloudnetservice.driver.network.cluster.NetworkClusterNode;
 import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
 import java.util.Collection;
+import java.util.Map;
 import lombok.NonNull;
 
 public interface Configuration {
@@ -46,6 +47,10 @@ public interface Configuration {
 
   void connectHostAddress(@NonNull String connectHostAddress);
 
+  @NonNull Map<String, String> ipAliases();
+
+  void ipAliases(@NonNull Map<String, String> alias);
+
   @NonNull NetworkClusterNode identity();
 
   void identity(@NonNull NetworkClusterNode identity);
@@ -54,8 +59,7 @@ public interface Configuration {
 
   void clusterConfig(@NonNull NetworkCluster clusterConfig);
 
-  @NonNull
-  Collection<String> ipWhitelist();
+  @NonNull Collection<String> ipWhitelist();
 
   void ipWhitelist(@NonNull Collection<String> whitelist);
 

--- a/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
@@ -30,7 +30,6 @@ import eu.cloudnetservice.node.setup.DefaultConfigSetup;
 import eu.cloudnetservice.node.util.NetworkUtil;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,10 +60,8 @@ public final class JsonConfiguration implements Configuration {
   };
 
   private static final Function<String, Map<String, String>> MAP_PARSER = value -> {
-    var values = value.split(";;");
     Map<String, String> results = new HashMap<>();
-
-    for (var pair : values) {
+    for (var pair : value.split(";;")) {
       var entry = pair.split(";", 2);
       if (entry.length == 2) {
         results.put(entry[0], entry[1]);
@@ -390,7 +387,7 @@ public final class JsonConfiguration implements Configuration {
 
   @Override
   public @NonNull Collection<String> ipWhitelist() {
-    return this.ipWhitelist != null ? this.ipWhitelist : (this.ipWhitelist = new HashSet<>());
+    return this.ipWhitelist;
   }
 
   @Override
@@ -460,7 +457,7 @@ public final class JsonConfiguration implements Configuration {
 
   @Override
   public @NonNull Collection<HostAndPort> httpListeners() {
-    return this.httpListeners != null ? this.httpListeners : (this.httpListeners = new ArrayList<>());
+    return this.httpListeners;
   }
 
   @Override
@@ -490,7 +487,7 @@ public final class JsonConfiguration implements Configuration {
 
   @Override
   public @NonNull Map<String, String> ipAliases() {
-    return this.ipAliases != null ? this.ipAliases : (this.ipAliases = new HashMap<>());
+    return this.ipAliases;
   }
 
   @Override
@@ -565,6 +562,6 @@ public final class JsonConfiguration implements Configuration {
 
   @Override
   public void properties(@NonNull JsonDocument properties) {
-    this.properties = properties;
+    this.properties = properties.clone();
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
@@ -18,19 +18,15 @@ package eu.cloudnetservice.node.console.animation.setup.answer;
 
 import com.google.common.base.Enums;
 import com.google.common.base.Preconditions;
-import com.google.common.net.InetAddresses;
-import com.google.common.primitives.Ints;
 import eu.cloudnetservice.common.JavaVersion;
 import eu.cloudnetservice.common.collection.Pair;
 import eu.cloudnetservice.driver.network.HostAndPort;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.node.Node;
 import eu.cloudnetservice.node.util.JavaVersionResolver;
+import eu.cloudnetservice.node.util.NetworkUtil;
 import eu.cloudnetservice.node.version.ServiceVersion;
 import eu.cloudnetservice.node.version.ServiceVersionType;
-import java.net.IDN;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -173,62 +169,38 @@ public final class Parsers {
 
   public static @NonNull QuestionAnswerType.Parser<HostAndPort> validatedHostAndPort(boolean withPort) {
     return input -> {
-      // convert the input to an ascii string if needed (for example ☃.net -> xn--n3h.net)
-      var normalizedInput = IDN.toASCII(input).toLowerCase();
-
-      // extract the port from the input if required
-      var port = -1;
-      if (withPort) {
-        var portSeparatorIndex = normalizedInput.lastIndexOf(':');
-        if (portSeparatorIndex == -1) {
-          // missing port
-          throw ParserException.INSTANCE;
-        }
-
-        // extract the port part
-        var portPart = normalizedInput.substring(portSeparatorIndex + 1);
-        if (portPart.isEmpty()) {
-          // missing port
-          throw ParserException.INSTANCE;
-        }
-
-        // try to get the port
-        var possiblePort = Ints.tryParse(portPart);
-        if (possiblePort == null || possiblePort < 0 || possiblePort > 65535) {
-          // invalid port
-          throw ParserException.INSTANCE;
-        }
-
-        // store the port and remove the port part from the input string
-        port = possiblePort;
-        normalizedInput = normalizedInput.substring(0, portSeparatorIndex);
-      }
-
-      // check if the host is wrapped in brackets
-      if (normalizedInput.startsWith("[")) {
-        normalizedInput = normalizedInput.substring(1);
-      }
-
-      // extracting this check allows accidental typos to happen like [2001:db8::1
-      if (normalizedInput.endsWith("]")) {
-        normalizedInput = normalizedInput.substring(0, normalizedInput.length() - 1);
-      }
-
-      try {
-        // try to parse an ipv 4 or 6 address from the input string
-        var address = InetAddresses.forString(normalizedInput);
-        return new HostAndPort(address.getHostAddress(), port);
-      } catch (IllegalArgumentException ignored) {
-      }
-
-      try {
-        // not the end of the world - might still be a domain name
-        var address = InetAddress.getByName(normalizedInput);
-        return new HostAndPort(address.getHostAddress(), port);
-      } catch (UnknownHostException exception) {
-        // okay that's it
+      var host = NetworkUtil.parseHostAndPort(input, withPort);
+      if (host == null) {
         throw ParserException.INSTANCE;
       }
+      return host;
+    };
+  }
+
+  public static @NonNull QuestionAnswerType.Parser<HostAndPort> assignableHostAndPort(boolean withPort) {
+    return input -> {
+      var host = NetworkUtil.assignableHostAndPort(input, withPort);
+      if (host == null) {
+        throw ParserException.INSTANCE;
+      }
+      return host;
+    };
+  }
+
+  public static @NonNull QuestionAnswerType.Parser<String> assignableHostAndPortOrAlias() {
+    return input -> {
+      var ipAlias = Node.instance().config().ipAliases().get(input);
+      // the input is an ip alias
+      if (ipAlias != null) {
+        return ipAlias;
+      }
+      // parse a host and check if it is assignable
+      var host = NetworkUtil.assignableHostAndPort(input, false);
+      // we've found an assignable host
+      if (host != null) {
+        return host.host();
+      }
+      throw ParserException.INSTANCE;
     };
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
@@ -179,7 +179,7 @@ public final class Parsers {
 
   public static @NonNull QuestionAnswerType.Parser<HostAndPort> assignableHostAndPort(boolean withPort) {
     return input -> {
-      var host = NetworkUtil.assignableHostAndPort(input, withPort);
+      var host = NetworkUtil.parseAssignableHostAndPort(input, withPort);
       if (host == null) {
         throw ParserException.INSTANCE;
       }
@@ -195,7 +195,7 @@ public final class Parsers {
         return ipAlias;
       }
       // parse a host and check if it is assignable
-      var host = NetworkUtil.assignableHostAndPort(input, false);
+      var host = NetworkUtil.parseAssignableHostAndPort(input, false);
       // we've found an assignable host
       if (host != null) {
         return host.host();

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
@@ -57,7 +57,6 @@ import eu.cloudnetservice.node.service.CloudService;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import eu.cloudnetservice.node.service.ServiceConfigurationPreparer;
 import eu.cloudnetservice.node.service.ServiceConsoleLogCache;
-import eu.cloudnetservice.node.util.NetworkUtil;
 import java.net.Inet6Address;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -89,7 +88,6 @@ public abstract class AbstractService implements CloudService {
 
   protected final EventManager eventManager;
 
-  protected final String resolvedHostAddress;
   protected final String connectionKey;
   protected final Path serviceDirectory;
   protected final Path pluginDirectory;
@@ -126,7 +124,6 @@ public abstract class AbstractService implements CloudService {
     this.serviceConfiguration = configuration;
     this.serviceConfigurationPreparer = serviceConfigurationPreparer;
 
-    this.resolvedHostAddress = this.resolveHostAddress();
     this.connectionKey = StringUtil.generateRandomString(64);
     this.serviceDirectory = resolveServicePath(configuration.serviceId(), manager, configuration.staticService());
     this.pluginDirectory = this.serviceDirectory
@@ -134,7 +131,7 @@ public abstract class AbstractService implements CloudService {
 
     this.currentServiceInfo = new ServiceInfoSnapshot(
       System.currentTimeMillis(),
-      new HostAndPort(this.resolvedHostAddress, configuration.port()),
+      new HostAndPort(configuration.hostAddress(), configuration.port()),
       new HostAndPort(this.nodeConfiguration().connectHostAddress(), configuration.port()),
       ProcessSnapshot.empty(),
       configuration,
@@ -674,34 +671,6 @@ public abstract class AbstractService implements CloudService {
       configuration.trustCertificatePath() == null ? null : wrapperDir.resolve("trustCertificate"),
       configuration.certificatePath() == null ? null : wrapperDir.resolve("certificate"),
       configuration.privateKeyPath() == null ? null : wrapperDir.resolve("privateKey"));
-  }
-
-  protected @NonNull String resolveHostAddress() {
-    var hostAddress = this.serviceConfiguration.hostAddress();
-    var fallbackHostAddress = this.nodeInstance.config().hostAddress();
-    // if null is supplied use fallback address
-    if (hostAddress == null) {
-      return fallbackHostAddress;
-    }
-    // use the supplied host address if it is an inet address
-    if (NetworkUtil.parseAssignableHostAndPort(hostAddress, false) != null) {
-      return hostAddress;
-    }
-    // retrieve the alias from the node
-    var alias = this.nodeInstance.config().ipAliases().get(hostAddress);
-    // we cant find an alias with this name use fallback
-    if (alias == null) {
-      return fallbackHostAddress;
-    }
-    // check if the alias is a valid inet address
-    if (NetworkUtil.parseAssignableHostAndPort(alias, false) != null) {
-      return alias;
-    }
-    // explode, resolved alias is not an address
-    throw new IllegalArgumentException(String.format(
-      "The host address %s of the alias %s is not a valid inet address.",
-      alias,
-      hostAddress));
   }
 
   protected @NonNull Object[] serviceReplacement() {

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
@@ -684,7 +684,7 @@ public abstract class AbstractService implements CloudService {
       return fallbackHostAddress;
     }
     // use the supplied host address if it is an inet address
-    if (NetworkUtil.assignableHostAndPort(hostAddress, false) != null) {
+    if (NetworkUtil.parseAssignableHostAndPort(hostAddress, false) != null) {
       return hostAddress;
     }
     // retrieve the alias from the node
@@ -694,7 +694,7 @@ public abstract class AbstractService implements CloudService {
       return fallbackHostAddress;
     }
     // check if the alias is a valid inet address
-    if (NetworkUtil.assignableHostAndPort(alias, false) != null) {
+    if (NetworkUtil.parseAssignableHostAndPort(alias, false) != null) {
       return alias;
     }
     // explode, resolved alias is not an address

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
@@ -141,7 +141,7 @@ public class JVMService extends AbstractService {
     arguments.add(String.format("-Dfabric.systemLibraries=%s", wrapperInformation.first().toAbsolutePath()));
 
     // set the used host and port as system property
-    arguments.add("-Dservice.bind.host=" + this.nodeInstance.config().hostAddress());
+    arguments.add("-Dservice.bind.host=" + this.resolvedHostAddress);
     arguments.add("-Dservice.bind.port=" + this.serviceConfiguration().port());
 
     // add the class path and the main class of the wrapper

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
@@ -141,7 +141,7 @@ public class JVMService extends AbstractService {
     arguments.add(String.format("-Dfabric.systemLibraries=%s", wrapperInformation.first().toAbsolutePath()));
 
     // set the used host and port as system property
-    arguments.add("-Dservice.bind.host=" + this.resolvedHostAddress);
+    arguments.add("-Dservice.bind.host=" + this.serviceConfiguration().hostAddress());
     arguments.add("-Dservice.bind.port=" + this.serviceConfiguration().port());
 
     // add the class path and the main class of the wrapper

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
@@ -34,7 +34,7 @@ public class BungeeConfigurationPreparer extends AbstractServiceConfigurationPre
         if (line.trim().startsWith("host:")) {
           line = String.format(
             "    host: %s:%d",
-            cloudService.serviceInfo().address().host(),
+            cloudService.serviceConfiguration().hostAddress(),
             cloudService.serviceConfiguration().port());
         }
         return line;

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
@@ -34,7 +34,7 @@ public class BungeeConfigurationPreparer extends AbstractServiceConfigurationPre
         if (line.trim().startsWith("host:")) {
           line = String.format(
             "    host: %s:%d",
-            nodeInstance.config().hostAddress(),
+            cloudService.serviceInfo().address().host(),
             cloudService.serviceConfiguration().port());
         }
         return line;

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/GlowstoneConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/GlowstoneConfigurationPreparer.java
@@ -32,7 +32,7 @@ public class GlowstoneConfigurationPreparer extends AbstractServiceConfiguration
       // rewrite the configuration file
       this.rewriteFile(configFile, line -> {
         if (line.trim().startsWith("ip:")) {
-          line = String.format("  ip: '%s'", cloudService.serviceInfo().address().host());
+          line = String.format("  ip: '%s'", cloudService.serviceConfiguration().hostAddress());
         } else if (line.trim().startsWith("port:")) {
           line = String.format("  port: %d", cloudService.serviceConfiguration().port());
         }

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/GlowstoneConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/GlowstoneConfigurationPreparer.java
@@ -32,7 +32,7 @@ public class GlowstoneConfigurationPreparer extends AbstractServiceConfiguration
       // rewrite the configuration file
       this.rewriteFile(configFile, line -> {
         if (line.trim().startsWith("ip:")) {
-          line = String.format("  ip: '%s'", nodeInstance.config().hostAddress());
+          line = String.format("  ip: '%s'", cloudService.serviceInfo().address().host());
         } else if (line.trim().startsWith("port:")) {
           line = String.format("  port: %d", cloudService.serviceConfiguration().port());
         }

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/NukkitConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/NukkitConfigurationPreparer.java
@@ -37,7 +37,7 @@ public class NukkitConfigurationPreparer extends AbstractServiceConfigurationPre
       try (var stream = Files.newInputStream(configFile)) {
         properties.load(stream);
         // update the configuration
-        properties.setProperty("server-ip", nodeInstance.config().hostAddress());
+        properties.setProperty("server-ip", cloudService.serviceInfo().address().host());
         properties.setProperty("server-port", String.valueOf(cloudService.serviceConfiguration().port()));
         // store the properties
         try (var out = Files.newOutputStream(configFile)) {

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/NukkitConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/NukkitConfigurationPreparer.java
@@ -37,7 +37,7 @@ public class NukkitConfigurationPreparer extends AbstractServiceConfigurationPre
       try (var stream = Files.newInputStream(configFile)) {
         properties.load(stream);
         // update the configuration
-        properties.setProperty("server-ip", cloudService.serviceInfo().address().host());
+        properties.setProperty("server-ip", cloudService.serviceConfiguration().hostAddress());
         properties.setProperty("server-port", String.valueOf(cloudService.serviceConfiguration().port()));
         // store the properties
         try (var out = Files.newOutputStream(configFile)) {

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VanillaServiceConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VanillaServiceConfigurationPreparer.java
@@ -39,7 +39,7 @@ public class VanillaServiceConfigurationPreparer extends AbstractServiceConfigur
           properties.load(stream);
           // update the configuration
           if (this.shouldRewriteIp(nodeInstance, cloudService)) {
-            properties.setProperty("server-ip", nodeInstance.config().hostAddress());
+            properties.setProperty("server-ip", cloudService.serviceInfo().address().host());
             properties.setProperty("server-port", String.valueOf(cloudService.serviceConfiguration().port()));
           }
           // store the properties

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VanillaServiceConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VanillaServiceConfigurationPreparer.java
@@ -39,7 +39,7 @@ public class VanillaServiceConfigurationPreparer extends AbstractServiceConfigur
           properties.load(stream);
           // update the configuration
           if (this.shouldRewriteIp(nodeInstance, cloudService)) {
-            properties.setProperty("server-ip", cloudService.serviceInfo().address().host());
+            properties.setProperty("server-ip", cloudService.serviceConfiguration().hostAddress());
             properties.setProperty("server-port", String.valueOf(cloudService.serviceConfiguration().port()));
           }
           // store the properties

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VelocityConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VelocityConfigurationPreparer.java
@@ -34,7 +34,7 @@ public class VelocityConfigurationPreparer extends AbstractServiceConfigurationP
         if (line.startsWith("bind =")) {
           line = String.format(
             "bind = \"%s:%d\"",
-            cloudService.serviceInfo().address().host(),
+            cloudService.serviceConfiguration().hostAddress(),
             cloudService.serviceConfiguration().port());
         }
         return line;

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VelocityConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VelocityConfigurationPreparer.java
@@ -34,7 +34,7 @@ public class VelocityConfigurationPreparer extends AbstractServiceConfigurationP
         if (line.startsWith("bind =")) {
           line = String.format(
             "bind = \"%s:%d\"",
-            nodeInstance.config().hostAddress(),
+            cloudService.serviceInfo().address().host(),
             cloudService.serviceConfiguration().port());
         }
         return line;

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/WaterdogPEConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/WaterdogPEConfigurationPreparer.java
@@ -34,7 +34,7 @@ public class WaterdogPEConfigurationPreparer extends AbstractServiceConfiguratio
         if (line.trim().startsWith("host:")) {
           line = String.format(
             "  host: %s:%d",
-            cloudService.serviceInfo().address().host(),
+            cloudService.serviceConfiguration().hostAddress(),
             cloudService.serviceConfiguration().port());
         }
         return line;

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/WaterdogPEConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/WaterdogPEConfigurationPreparer.java
@@ -34,7 +34,7 @@ public class WaterdogPEConfigurationPreparer extends AbstractServiceConfiguratio
         if (line.trim().startsWith("host:")) {
           line = String.format(
             "  host: %s:%d",
-            nodeInstance.config().hostAddress(),
+            cloudService.serviceInfo().address().host(),
             cloudService.serviceConfiguration().port());
         }
         return line;

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
@@ -97,7 +97,7 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
         .answerType(QuestionAnswerType.<HostAndPort>builder()
           .recommendation(NetworkUtil.localAddress() + ":1410")
           .possibleResults(addresses.stream().map(addr -> addr + ":1410").toList())
-          .parser(Parsers.validatedHostAndPort(true)))
+          .parser(Parsers.assignableHostAndPort(true)))
         .build(),
       // web server host
       QuestionListEntry.<HostAndPort>builder()
@@ -106,7 +106,7 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
         .answerType(QuestionAnswerType.<HostAndPort>builder()
           .recommendation(NetworkUtil.localAddress() + ":2812")
           .possibleResults(addresses.stream().map(addr -> addr + ":2812").toList())
-          .parser(Parsers.validatedHostAndPort(true)))
+          .parser(Parsers.assignableHostAndPort(true)))
         .build(),
       // service bind host address
       QuestionListEntry.<HostAndPort>builder()
@@ -115,7 +115,7 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
         .answerType(QuestionAnswerType.<HostAndPort>builder()
           .possibleResults(addresses)
           .recommendation(NetworkUtil.localAddress())
-          .parser(Parsers.validatedHostAndPort(false)))
+          .parser(Parsers.assignableHostAndPort(true)))
         .build(),
       // maximum memory usage
       QuestionListEntry.<Integer>builder()

--- a/node/src/main/java/eu/cloudnetservice/node/setup/SpecificTaskSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/SpecificTaskSetup.java
@@ -98,8 +98,7 @@ public class SpecificTaskSetup extends DefaultTaskSetup implements DefaultSetup 
         .answerType(QuestionAnswerType.<String>builder()
           .recommendation(Node.instance().config().hostAddress())
           .parser(Parsers.assignableHostAndPortOrAlias())
-          .possibleResults(() ->
-            NetworkUtil.availableIPAddresses()
+          .possibleResults(() -> NetworkUtil.availableIPAddresses()
               .stream()
               .collect(Collectors.collectingAndThen(Collectors.toSet(),
                 ips -> {

--- a/node/src/main/java/eu/cloudnetservice/node/setup/SpecificTaskSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/SpecificTaskSetup.java
@@ -28,10 +28,12 @@ import eu.cloudnetservice.node.console.animation.setup.ConsoleSetupAnimation;
 import eu.cloudnetservice.node.console.animation.setup.answer.Parsers;
 import eu.cloudnetservice.node.console.animation.setup.answer.QuestionAnswerType;
 import eu.cloudnetservice.node.console.animation.setup.answer.QuestionListEntry;
+import eu.cloudnetservice.node.util.NetworkUtil;
 import eu.cloudnetservice.node.version.ServiceVersion;
 import eu.cloudnetservice.node.version.ServiceVersionType;
 import eu.cloudnetservice.node.version.information.TemplateVersionInstaller;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 
 public class SpecificTaskSetup extends DefaultTaskSetup implements DefaultSetup {
@@ -90,6 +92,21 @@ public class SpecificTaskSetup extends DefaultTaskSetup implements DefaultSetup 
           .possibleResults("[0, 65535]")
           .recommendation(44955))
         .build(),
+      QuestionListEntry.<String>builder()
+        .key("taskHostAddress")
+        .translatedQuestion("command-tasks-setup-question-host-address")
+        .answerType(QuestionAnswerType.<String>builder()
+          .recommendation(Node.instance().config().hostAddress())
+          .parser(Parsers.assignableHostAndPortOrAlias())
+          .possibleResults(() ->
+            NetworkUtil.availableIPAddresses()
+              .stream()
+              .collect(Collectors.collectingAndThen(Collectors.toSet(),
+                ips -> {
+                  ips.addAll(Node.instance().config().ipAliases().keySet());
+                  return ips;
+                }))))
+        .build(),
       QuestionListEntry.<Pair<String, JavaVersion>>builder()
         .key("taskJavaCommand")
         .translatedQuestion("command-tasks-setup-question-javacommand")
@@ -124,6 +141,7 @@ public class SpecificTaskSetup extends DefaultTaskSetup implements DefaultSetup 
     Pair<ServiceVersionType, ServiceVersion> version = animation.result("taskServiceVersion");
     Pair<String, ?> javaVersion = animation.result("taskJavaCommand");
     var defaultTemplate = ServiceTemplate.builder().prefix(name).name("default").build();
+    String hostAddress = animation.result("taskHostAddress");
 
     var task = ServiceTask.builder()
       .name(name)
@@ -134,6 +152,7 @@ public class SpecificTaskSetup extends DefaultTaskSetup implements DefaultSetup 
       .minServiceCount(animation.result("taskMinServices"))
       .serviceEnvironmentType(environment)
       .startPort(animation.result("taskStartPort"))
+      .hostAddress(hostAddress)
       .javaCommand(javaVersion.first())
       .templates(Set.of(defaultTemplate))
       .nameSplitter(animation.result("taskNameSplitter"))

--- a/node/src/main/java/eu/cloudnetservice/node/setup/SpecificTaskSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/SpecificTaskSetup.java
@@ -88,7 +88,7 @@ public class SpecificTaskSetup extends DefaultTaskSetup implements DefaultSetup 
         .key("taskStartPort")
         .translatedQuestion("command-tasks-setup-question-startport")
         .answerType(QuestionAnswerType.<Integer>builder()
-          .parser(Parsers.ranged(0, 65535))
+          .parser(Parsers.ranged(0, 0xFFFF))
           .possibleResults("[0, 65535]")
           .recommendation(44955))
         .build(),
@@ -99,12 +99,11 @@ public class SpecificTaskSetup extends DefaultTaskSetup implements DefaultSetup 
           .recommendation(Node.instance().config().hostAddress())
           .parser(Parsers.assignableHostAndPortOrAlias())
           .possibleResults(() -> NetworkUtil.availableIPAddresses()
-              .stream()
-              .collect(Collectors.collectingAndThen(Collectors.toSet(),
-                ips -> {
-                  ips.addAll(Node.instance().config().ipAliases().keySet());
-                  return ips;
-                }))))
+            .stream()
+            .collect(Collectors.collectingAndThen(Collectors.toSet(), ips -> {
+              ips.addAll(Node.instance().config().ipAliases().keySet());
+              return ips;
+            }))))
         .build(),
       QuestionListEntry.<Pair<String, JavaVersion>>builder()
         .key("taskJavaCommand")

--- a/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.Set;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 public final class NetworkUtil {
 
@@ -43,6 +44,7 @@ public final class NetworkUtil {
     throw new UnsupportedOperationException();
   }
 
+  @Unmodifiable
   public static @NonNull Set<String> availableIPAddresses() {
     return AVAILABLE_IP_ADDRESSES;
   }

--- a/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
@@ -83,7 +83,7 @@ public final class NetworkUtil {
 
   public static @Nullable HostAndPort parseHostAndPort(@NonNull String input, boolean withPort) {
     // convert the input to an ascii string if needed (for example ☃.net -> xn--n3h.net)
-    var normalizedInput = IDN.toASCII(input).toLowerCase();
+    var normalizedInput = IDN.toASCII(input, IDN.ALLOW_UNASSIGNED).toLowerCase();
 
     // extract the port from the input if required
     var port = -1;

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -237,6 +237,8 @@ command-permissions-user-rename-success=The name of the user {0$name$} was chang
 #
 # Command Config
 #
+command-config-node-ip-alias-already-existing=The ip alias {0$alias$} already exists
+command-config-node-ip-alias-added=The ip alias {0$alias$} and the host address {1$address$} were added
 command-config-node-ip-alias-remove=The ip alias {0$alias$} was removed
 command-config-node-add-ip-whitelist=The ip {0$ip$} was added to the ip whitelist
 command-config-node-remove-ip-whitelist=The ip address {0$ip$} was removed from the ip whitelist

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -138,6 +138,9 @@ missing-command-permission=You are not allowed to execute this sub command
 # General commands
 #
 command-general-group-does-not-exist=That group doesn't exist!
+command-any-host-and-port-invalid=The given input {0$input$} is not a valid host and port
+command-assignable-host-invalid=The given input {0$input$} is not an assignable host
+command-any-host-invalid=The given input {0$input$} is not a valid host address
 #
 # Command help
 #
@@ -234,12 +237,13 @@ command-permissions-user-rename-success=The name of the user {0$name$} was chang
 #
 # Command Config
 #
-command-config-node-reload-config=The node configuration was reloaded. Note: Not all changes are applied without a restart
+command-config-node-ip-alias-remove=The ip alias {0$alias$} was removed
 command-config-node-add-ip-whitelist=The ip {0$ip$} was added to the ip whitelist
-command-config-node-ip-invalid=The ip address {0$ip$} is not valid!
 command-config-node-remove-ip-whitelist=The ip address {0$ip$} was removed from the ip whitelist
-command-config-node-max-memory-set=The maximum memory for the node is now set to {0$memory$}
+command-config-node-set-max-memory=The maximum memory for the node is now set to {0$memory$}
 command-config-node-set-java-command=The default java command for services is now set to {0$path$} using Java version {1$version$}
+command-config-node-reload-config=The node configuration was reloaded. Note: Not all changes are applied without a restart
+command-config-reload-config=Reloaded the node, task, group and permission configurations. Note: Not all changes are applied without a restart
 #
 # Command Groups
 #
@@ -267,6 +271,7 @@ command-tasks-remove-collection-property=The {0$property$} {1$value$} was succes
 command-tasks-clear-property=The {0$property$} for the task {1$task$} were cleared successfully
 command-tasks-task-already-existing=That task already exists!
 command-tasks-task-not-found=That task doesn't exist!
+command-tasks-unknown-host-address-or-alias=The host {0$host$} is not an assignable host or an ip alias of the node.
 #
 # Command Tasks (setup)
 #

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -238,7 +238,7 @@ command-permissions-user-rename-success=The name of the user {0$name$} was chang
 # Command Config
 #
 command-config-node-ip-alias-already-existing=The ip alias {0$alias$} already exists
-command-config-node-ip-alias-added=The host address {1$address$} aliased as {0$alias$} was added
+command-config-node-ip-alias-added=The host address {1$address$} aliased as {0$alias$} was added successfully
 command-config-node-ip-alias-remove=The ip alias {0$alias$} was removed
 command-config-node-add-ip-whitelist=The ip {0$ip$} was added to the ip whitelist
 command-config-node-remove-ip-whitelist=The ip address {0$ip$} was removed from the ip whitelist

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -238,7 +238,7 @@ command-permissions-user-rename-success=The name of the user {0$name$} was chang
 # Command Config
 #
 command-config-node-ip-alias-already-existing=The ip alias {0$alias$} already exists
-command-config-node-ip-alias-added=The ip alias {0$alias$} and the host address {1$address$} were added
+command-config-node-ip-alias-added=The host address {1$address$} aliased as {0$alias$} was added
 command-config-node-ip-alias-remove=The ip alias {0$alias$} was removed
 command-config-node-add-ip-whitelist=The ip {0$ip$} was added to the ip whitelist
 command-config-node-remove-ip-whitelist=The ip address {0$ip$} was removed from the ip whitelist
@@ -273,12 +273,12 @@ command-tasks-remove-collection-property=The {0$property$} {1$value$} was succes
 command-tasks-clear-property=The {0$property$} for the task {1$task$} were cleared successfully
 command-tasks-task-already-existing=That task already exists!
 command-tasks-task-not-found=That task doesn't exist!
-command-tasks-unknown-host-address-or-alias=The host {0$host$} is not an assignable host or an ip alias of the node.
+command-tasks-unknown-host-address-or-alias=The host {0$host$} is neither an assignable host nor an ip alias of the node.
 #
 # Command Tasks (setup)
 #
 command-tasks-setup-create-success=The new task {0$name$} has been successfully created!
-command-tasks-setup-question-application=Which service version should be ran on services of this task?
+command-tasks-setup-question-application=Which service version should run on services of this task?
 command-tasks-setup-question-environment=What should be the environment of this task?
 command-tasks-setup-question-javacommand-invalid=The provided executable is not a valid java installation path
 command-tasks-setup-question-javacommand=What is the path to the Java executable?


### PR DESCRIPTION
### Motivation
Currently every service is started on the same host address provided in the node configuration. The problem with this is that there is no way to use different hosts for different tasks like a Proxy and a Lobby.
### Modification
Created a new host address option for tasks which is used to bind the services of the task to. In order to make this feature available in the cluster too (different ips on different host systems), an ip alias system was implemented. The ip aliases are configured on each node and are resolved when starting the service. If somebody wants to use the same ip for each task supplying null as host address will use the fallback host, which is the old approach of using the host address provided by the node.

### Result
All tasks can have different host addresses and bind their services to that host address.