### PR TITLE
feat: Add command to rename tasks

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -253,7 +253,7 @@ public final class TasksCommand {
     @NonNull @Argument("environment") ServiceEnvironmentType environmentType
   ) {
     if (this.taskProvider().serviceTask(taskName) != null) {
-      source.sendMessage(I18n.trans("command-tasks-task-already-existing"));
+      source.sendMessage(I18n.trans("command-tasks-task-already-existing", taskName));
       return;
     }
 
@@ -295,6 +295,22 @@ public final class TasksCommand {
 
       applyServiceConfigurationDisplay(messages, serviceTask);
       source.sendMessage(messages);
+    }
+  }
+
+  @CommandMethod("tasks rename <name> <new>")
+  public void renameTask(
+    @NonNull CommandSource source,
+    @NonNull @Argument(value = "name") ServiceTask serviceTask,
+    @NonNull @Regex(ServiceTask.NAMING_REGEX) @Argument("new") String newName
+  ) {
+    if (this.taskProvider().serviceTask(newName) != null) {
+      source.sendMessage(I18n.trans("command-tasks-task-already-existing", newName));
+    } else {
+      // create a copy with the new name and remove the old task
+      this.taskProvider().removeServiceTask(serviceTask);
+      this.taskProvider().addServiceTask(ServiceTask.builder(serviceTask).name(newName).build());
+      source.sendMessage(I18n.trans("command-tasks-task-rename-success", serviceTask.name(), newName));
     }
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -298,11 +298,11 @@ public final class TasksCommand {
     }
   }
 
-  @CommandMethod("tasks rename <name> <new>")
+  @CommandMethod("tasks rename <oldName> <newName>")
   public void renameTask(
     @NonNull CommandSource source,
-    @NonNull @Argument(value = "name") ServiceTask serviceTask,
-    @NonNull @Regex(ServiceTask.NAMING_REGEX) @Argument("new") String newName
+    @NonNull @Argument(value = "oldName") ServiceTask serviceTask,
+    @NonNull @Regex(ServiceTask.NAMING_REGEX) @Argument("newName") String newName
   ) {
     if (this.taskProvider().serviceTask(newName) != null) {
       source.sendMessage(I18n.trans("command-tasks-task-already-existing", newName));

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -266,7 +266,7 @@ command-tasks-set-property-success=The {0$property$} of the task {1$name$} was c
 command-tasks-remove-collection-property=The {0$property$} {1$value$} was successfully removed from the task {2$task$}
 command-tasks-clear-property=The {0$property$} for the task {1$task$} were cleared successfully
 command-tasks-task-already-existing=The task {0$task$} already exists!
-command-tasks-task-rename-success=The task {0$task$} was successfully renamed to {1$new$}
+command-tasks-task-rename-success=The task {0$task$} was successfully renamed to {1$new$}. &cKeep in mind that you might need to change the name in other configurations e.g. groups
 command-tasks-task-not-found=That task doesn't exist!
 #
 # Command Tasks (setup)

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -265,7 +265,8 @@ command-tasks-add-collection-property=The {0$property$} {1$value$} was successfu
 command-tasks-set-property-success=The {0$property$} of the task {1$name$} was changed to {2$value$}
 command-tasks-remove-collection-property=The {0$property$} {1$value$} was successfully removed from the task {2$task$}
 command-tasks-clear-property=The {0$property$} for the task {1$task$} were cleared successfully
-command-tasks-task-already-existing=That task already exists!
+command-tasks-task-already-existing=The task {0$task$} already exists!
+command-tasks-task-rename-success=The task {0$task$} was successfully renamed to {1$new$}
 command-tasks-task-not-found=That task doesn't exist!
 #
 # Command Tasks (setup)


### PR DESCRIPTION
### Motivation
Currently renaming a task using a command is not possible. You would have to edit the file and possible restart the cloud too.
### Modification
Created the command `tasks rename <old> <new>` to rename the task without modifiying any files yourself.

### Result
Renaming a task using a command is possible now.