### PR TITLE
chore: remove the connect host address

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceInfoSnapshot.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceInfoSnapshot.java
@@ -46,7 +46,6 @@ public class ServiceInfoSnapshot extends JsonDocPropertyHolder
   protected final long creationTime;
 
   protected final HostAndPort address;
-  protected final HostAndPort connectAddress;
 
   protected final ProcessSnapshot processSnapshot;
   protected final ServiceConfiguration configuration;
@@ -60,7 +59,6 @@ public class ServiceInfoSnapshot extends JsonDocPropertyHolder
    *
    * @param creationTime    the unix timestamp of the snapshot creation time.
    * @param address         the address to which the service was bound if started.
-   * @param connectAddress  the address to use when trying to connect to the service if started.
    * @param processSnapshot the current snapshot of the process resource usage.
    * @param configuration   the configuration base used to create the service.
    * @param connectedTime   the time when the service connected to the node, -1 if not yet connected.
@@ -72,7 +70,6 @@ public class ServiceInfoSnapshot extends JsonDocPropertyHolder
   public ServiceInfoSnapshot(
     long creationTime,
     @NonNull HostAndPort address,
-    @NonNull HostAndPort connectAddress,
     @NonNull ProcessSnapshot processSnapshot,
     @NonNull ServiceConfiguration configuration,
     long connectedTime,
@@ -83,7 +80,6 @@ public class ServiceInfoSnapshot extends JsonDocPropertyHolder
     this.creationTime = creationTime;
     this.connectedTime = connectedTime;
     this.address = address;
-    this.connectAddress = connectAddress;
     this.lifeCycle = lifeCycle;
     this.processSnapshot = processSnapshot;
     this.configuration = configuration;
@@ -115,15 +111,6 @@ public class ServiceInfoSnapshot extends JsonDocPropertyHolder
    */
   public @NonNull HostAndPort address() {
     return this.address;
-  }
-
-  /**
-   * Get the connect-address of the service which will be used to connect players to the wrapped service.
-   *
-   * @return the connect-address of the wrapped service.
-   */
-  public @NonNull HostAndPort connectAddress() {
-    return this.connectAddress;
   }
 
   /**

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/object/DefaultObjectMapperTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/object/DefaultObjectMapperTest.java
@@ -124,7 +124,6 @@ public class DefaultObjectMapperTest {
       Arguments.of(new ServiceInfoSnapshot(
         System.currentTimeMillis(),
         new HostAndPort("127.0.1.1", 99),
-        new HostAndPort("127.0.1.1", 45678),
         ProcessSnapshot.self(),
         ServiceConfiguration.builder()
           .taskName("Lobby")

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordHelper.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordHelper.java
@@ -93,7 +93,7 @@ public final class BungeeCordHelper {
   private static @NonNull ServerInfo constructServerInfo(@NonNull ServiceInfoSnapshot snapshot) {
     return ProxyServer.getInstance().constructServerInfo(
       snapshot.name(),
-      new InetSocketAddress(snapshot.connectAddress().host(), snapshot.connectAddress().port()),
+      new InetSocketAddress(snapshot.address().host(), snapshot.address().port()),
       "Just another CloudNet provided service info",
       false);
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgeManagement.java
@@ -67,7 +67,7 @@ final class VelocityBridgeManagement extends PlatformBridgeManagement<Player, Ne
     // register each service matching the service cache tester
     this.cacheRegisterListener = service -> proxyServer.registerServer(new ServerInfo(
       service.name(),
-      new InetSocketAddress(service.connectAddress().host(), service.connectAddress().port())));
+      new InetSocketAddress(service.address().host(), service.address().port())));
     // unregister each service matching the service cache tester
     this.cacheUnregisterListener = service -> proxyServer.getServer(service.name())
       .map(RegisteredServer::getServerInfo)

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgeManagement.java
@@ -64,8 +64,8 @@ final class WaterDogPEBridgeManagement extends PlatformBridgeManagement<ProxiedP
       service.name(),
       new BedrockServerInfo(
         service.name(),
-        new InetSocketAddress(service.connectAddress().host(), service.connectAddress().port()),
-        new InetSocketAddress(service.connectAddress().host(), service.connectAddress().port())));
+        new InetSocketAddress(service.address().host(), service.address().port()),
+        new InetSocketAddress(service.address().host(), service.address().port())));
     // unregister each service matching the service cache tester
     this.cacheUnregisterListener = service -> ProxyServer.getInstance().getServerInfoMap().remove(service.name());
   }

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/util/NodeServerUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/util/NodeServerUtil.java
@@ -49,7 +49,6 @@ public final class NodeServerUtil {
         var newSnapshot = new ServiceInfoSnapshot(
           System.currentTimeMillis(),
           snapshot.address(),
-          snapshot.connectAddress(),
           ProcessSnapshot.empty(),
           snapshot.configuration(),
           -1,

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
@@ -131,7 +131,7 @@ public final class ClusterCommand {
   public @NonNull HostAndPort defaultHostAndPortParser(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
     var address = input.remove();
     var hostAndPort = NetworkUtil.parseHostAndPort(address, true);
-    if (hostAndPort == null) {
+    if (hostAndPort == null || NetworkUtil.checkWildcard(hostAndPort)) {
       throw new ArgumentNotAvailableException(I18n.trans("command-any-host-and-port-invalid", address));
     }
 
@@ -147,9 +147,10 @@ public final class ClusterCommand {
       throw new ArgumentNotAvailableException(I18n.trans("command-any-host-invalid", address));
     }
     // check if we can assign the parsed host and port
-    if (NetworkUtil.checkAssignable(hostAndPort)) {
+    if (NetworkUtil.checkAssignable(hostAndPort) && !NetworkUtil.checkWildcard(hostAndPort)) {
       return hostAndPort;
     }
+
     throw new ArgumentNotAvailableException(I18n.trans("command-assignable-host-invalid", address));
   }
 
@@ -162,11 +163,11 @@ public final class ClusterCommand {
   public @NonNull String anyHostParser(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
     var address = input.remove();
     var hostAndPort = NetworkUtil.parseHostAndPort(address, false);
-    if (hostAndPort != null) {
-      return hostAndPort.host();
+    if (hostAndPort == null || NetworkUtil.checkWildcard(hostAndPort)) {
+      throw new ArgumentNotAvailableException(I18n.trans("command-any-host-invalid", address));
     }
 
-    throw new ArgumentNotAvailableException(I18n.trans("command-any-host-invalid", address));
+    return hostAndPort.host();
   }
 
   @Parser(name = "noNodeId", suggestions = "clusterNode")

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
@@ -370,11 +370,6 @@ public final class ServiceCommand {
       "* Address: " + service.address().host() + ":" + service.address().port()
     ));
 
-    if (!service.address().host().equals(service.connectAddress().host())) {
-      list.add("* Address for connections: " + service.connectAddress().host() + ":" + service
-        .connectAddress().port());
-    }
-
     if (service.connected()) {
       list.add("* Connected: " + DATE_FORMAT.format(service.connectedTime()));
     } else {

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -174,11 +174,12 @@ public final class TasksCommand {
     }
     // check if the host address is parsable and assignable
     var hostAndPort = NetworkUtil.parseAssignableHostAndPort(address, false);
-    if (hostAndPort != null) {
-      return hostAndPort.host();
+    if (hostAndPort == null || NetworkUtil.checkWildcard(hostAndPort)) {
+      // could not parse
+      throw new ArgumentNotAvailableException(I18n.trans("command-tasks-unknown-host-address-or-alias", address));
     }
-    // could not parse
-    throw new ArgumentNotAvailableException(I18n.trans("command-tasks-unknown-host-address-or-alias", address));
+
+    return hostAndPort.host();
   }
 
   @Suggestions("ipAliasHostAddress")

--- a/node/src/main/java/eu/cloudnetservice/node/config/Configuration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/Configuration.java
@@ -43,10 +43,6 @@ public interface Configuration {
 
   void hostAddress(@NonNull String hostAddress);
 
-  @NonNull String connectHostAddress();
-
-  void connectHostAddress(@NonNull String connectHostAddress);
-
   @NonNull Map<String, String> ipAliases();
 
   void ipAliases(@NonNull Map<String, String> alias);

--- a/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
@@ -347,7 +347,6 @@ public final class JsonConfiguration implements Configuration {
 
     this.jvmCommand = configuration.javaCommand();
     this.hostAddress = configuration.hostAddress();
-    this.connectHostAddress = configuration.connectHostAddress();
 
     this.ipAliases = configuration.ipAliases();
 
@@ -473,16 +472,6 @@ public final class JsonConfiguration implements Configuration {
   @Override
   public void restConfiguration(@NonNull RestConfiguration configuration) {
     this.restConfiguration = configuration;
-  }
-
-  @Override
-  public @NonNull String connectHostAddress() {
-    return this.connectHostAddress;
-  }
-
-  @Override
-  public void connectHostAddress(@NonNull String connectHostAddress) {
-    this.connectHostAddress = connectHostAddress;
   }
 
   @Override

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
@@ -188,6 +188,19 @@ public final class Parsers {
     };
   }
 
+  public static @NonNull QuestionAnswerType.Parser<HostAndPort> nonWildcardHost(
+    @NonNull QuestionAnswerType.Parser<HostAndPort> parser
+  ) {
+    return input -> {
+      var hostAndPort = parser.parse(input);
+      if (hostAndPort == null || NetworkUtil.checkWildcard(hostAndPort)) {
+        throw ParserException.INSTANCE;
+      }
+
+      return hostAndPort;
+    };
+  }
+
   public static @NonNull QuestionAnswerType.Parser<String> assignableHostAndPortOrAlias() {
     return input -> {
       var ipAlias = Node.instance().config().ipAliases().get(input);

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
@@ -133,7 +133,6 @@ public abstract class AbstractService implements CloudService {
     this.currentServiceInfo = new ServiceInfoSnapshot(
       System.currentTimeMillis(),
       new HostAndPort(configuration.hostAddress(), configuration.port()),
-      new HostAndPort(this.nodeConfiguration().connectHostAddress(), configuration.port()),
       ProcessSnapshot.empty(),
       configuration,
       -1,
@@ -574,7 +573,6 @@ public abstract class AbstractService implements CloudService {
     this.currentServiceInfo = new ServiceInfoSnapshot(
       this.lastServiceInfo.creationTime(),
       this.lastServiceInfo.address(),
-      this.lastServiceInfo.connectAddress(),
       this.alive() ? this.lastServiceInfo.processSnapshot() : ProcessSnapshot.empty(),
       this.lastServiceInfo.configuration(),
       this.connectionTimestamp,

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
@@ -95,7 +95,7 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
         .answerType(QuestionAnswerType.<HostAndPort>builder()
           .recommendation(NetworkUtil.localAddress() + ":1410")
           .possibleResults(addresses.stream().map(addr -> addr + ":1410").toList())
-          .parser(Parsers.nonWildcardHost(Parsers.assignableHostAndPort(true))))
+          .parser(Parsers.assignableHostAndPort(true)))
         .build(),
       // web server host
       QuestionListEntry.<HostAndPort>builder()
@@ -104,7 +104,7 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
         .answerType(QuestionAnswerType.<HostAndPort>builder()
           .recommendation(NetworkUtil.localAddress() + ":2812")
           .possibleResults(addresses.stream().map(addr -> addr + ":2812").toList())
-          .parser(Parsers.nonWildcardHost(Parsers.assignableHostAndPort(true))))
+          .parser(Parsers.assignableHostAndPort(true)))
         .build(),
       // service bind host address
       QuestionListEntry.<HostAndPort>builder()

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.node.setup;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.net.InetAddresses;
 import eu.cloudnetservice.common.io.FileUtil;
 import eu.cloudnetservice.common.language.I18n;
 import eu.cloudnetservice.driver.module.DefaultModuleProvider;
@@ -34,7 +33,6 @@ import eu.cloudnetservice.node.console.animation.setup.answer.QuestionAnswerType
 import eu.cloudnetservice.node.console.animation.setup.answer.QuestionListEntry;
 import eu.cloudnetservice.node.module.ModuleEntry;
 import eu.cloudnetservice.node.util.NetworkUtil;
-import java.net.Inet6Address;
 import java.nio.file.StandardCopyOption;
 import java.util.Collection;
 import java.util.HashSet;
@@ -97,7 +95,7 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
         .answerType(QuestionAnswerType.<HostAndPort>builder()
           .recommendation(NetworkUtil.localAddress() + ":1410")
           .possibleResults(addresses.stream().map(addr -> addr + ":1410").toList())
-          .parser(Parsers.assignableHostAndPort(true)))
+          .parser(Parsers.nonWildcardHost(Parsers.assignableHostAndPort(true))))
         .build(),
       // web server host
       QuestionListEntry.<HostAndPort>builder()
@@ -106,7 +104,7 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
         .answerType(QuestionAnswerType.<HostAndPort>builder()
           .recommendation(NetworkUtil.localAddress() + ":2812")
           .possibleResults(addresses.stream().map(addr -> addr + ":2812").toList())
-          .parser(Parsers.assignableHostAndPort(true)))
+          .parser(Parsers.nonWildcardHost(Parsers.assignableHostAndPort(true))))
         .build(),
       // service bind host address
       QuestionListEntry.<HostAndPort>builder()
@@ -115,7 +113,7 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
         .answerType(QuestionAnswerType.<HostAndPort>builder()
           .possibleResults(addresses)
           .recommendation(NetworkUtil.localAddress())
-          .parser(Parsers.assignableHostAndPort(true)))
+          .parser(Parsers.nonWildcardHost(Parsers.assignableHostAndPort(true))))
         .build(),
       // maximum memory usage
       QuestionListEntry.<Integer>builder()
@@ -204,16 +202,6 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
     // init the host address
     HostAndPort hostAddress = animation.result("hostAddress");
     config.hostAddress(hostAddress.host());
-
-    // if the host address is a wildcard address we need to specify a loopback address as connect host address
-    // this is because the connect address should be used by a proxy to connect a player to a downstream service
-    var address = InetAddresses.forString(hostAddress.host());
-    if (address.isAnyLocalAddress()) {
-      // keep ipv6 address types
-      config.connectHostAddress(address instanceof Inet6Address ? "::1" : "127.0.0.1");
-    } else {
-      config.connectHostAddress(hostAddress.host());
-    }
 
     // init the web host address
     config.httpListeners().clear();

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
@@ -113,7 +113,7 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
         .answerType(QuestionAnswerType.<HostAndPort>builder()
           .possibleResults(addresses)
           .recommendation(NetworkUtil.localAddress())
-          .parser(Parsers.nonWildcardHost(Parsers.assignableHostAndPort(true))))
+          .parser(Parsers.nonWildcardHost(Parsers.assignableHostAndPort(false))))
         .build(),
       // maximum memory usage
       QuestionListEntry.<Integer>builder()

--- a/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
@@ -64,6 +64,10 @@ public final class NetworkUtil {
     }
   }
 
+  public static boolean checkWildcard(@NonNull HostAndPort hostAndPort) {
+    return InetAddresses.forString(hostAndPort.host()).isAnyLocalAddress();
+  }
+
   public static boolean checkAssignable(@NonNull HostAndPort hostAndPort) {
     try (var socket = new ServerSocket()) {
       // try to bind on the given address

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -22,8 +22,8 @@ cloudnet-init-setup-cluster-cluster-id=What is the id of your cluster? (you can 
 cloudnet-init-setup-cluster-install=Is this node part of a cluster? (MultiRoot)
 cloudnet-init-setup-cluster-list-nodes=What are the names of your already existing nodes? (separated by ";")
 cloudnet-init-setup-cluster-node-host=What is the host and port of the node "{0$node$}"? (you can find it in the config.json at "listeners")
-cloudnet-init-setup-host-address=On which host should the services be started on?
-cloudnet-init-setup-internal-host=On which host and port should CloudNet run on? (This is NOT your proxy host/port)
+cloudnet-init-setup-host-address=On which host should the services be started on? Note: Wildcard addresses (like 0.0.0.0) are not allowed
+cloudnet-init-setup-internal-host=On which host and port should CloudNet run on? (This is NOT your proxy host/port) Note: Wildcard addresses (like 0.0.0.0) are not allowed
 cloudnet-init-setup-memory=How much memory (in MB) can the services running on this CloudNet node use?
 cloudnet-init-setup-node-id=What should the name of this CloudNet node be?
 cloudnet-init-setup-tasks-javacommand=What is the path to the Java executable?
@@ -33,7 +33,7 @@ cloudnet-init-setup-tasks-server-environment=What should be the environment of t
 cloudnet-init-setup-tasks-server-version=Which ServiceVersion should be used on the services?
 cloudnet-init-setup-tasks-should-install-proxy=Should a default proxy be created?
 cloudnet-init-setup-tasks-should-install-server=Should a default lobby be created?
-cloudnet-init-setup-web-host=On which host and port should CloudNet's WebServer run?
+cloudnet-init-setup-web-host=On which host and port should CloudNet's WebServer run? Note: Wildcard addresses (like 0.0.0.0) are not allowed
 cloudnet-init-default-modules=Which default modules should be installed? (separated by a space)
 #
 # Console animations
@@ -138,9 +138,9 @@ missing-command-permission=You are not allowed to execute this sub command
 # General commands
 #
 command-general-group-does-not-exist=That group doesn't exist!
-command-any-host-and-port-invalid=The given input {0$input$} is not a valid host and port
-command-assignable-host-invalid=The given input {0$input$} is not an assignable host
-command-any-host-invalid=The given input {0$input$} is not a valid host address
+command-any-host-and-port-invalid=The given input {0$input$} is not a valid host and port. Note: Wildcard addresses (like 0.0.0.0) are not allowed
+command-assignable-host-invalid=The given input {0$input$} is not an assignable host. Note: Wildcard addresses (like 0.0.0.0) are not allowed
+command-any-host-invalid=The given input {0$input$} is not a valid host address. Note: Wildcard addresses (like 0.0.0.0) are not allowed
 #
 # Command help
 #
@@ -150,7 +150,6 @@ command-help-docs-no-url=The {0$command$} command has no documentation url
 # Command Cluster
 #
 command-cluster-add-node-success=Registered the new node ({0$name$}) to the cluster configuration
-command-cluster-invalid-host=The provided host name is invalid
 command-cluster-node-not-found=That node doesn't exist
 command-cluster-node-set-drain=Draining is now {0, choice, 0#disabled|1#enabled$drain$} for node {1$node$}
 command-cluster-push-static-service-failed=Failed to deploy the static service to the cluster
@@ -274,7 +273,7 @@ command-tasks-clear-property=The {0$property$} for the task {1$task$} were clear
 command-tasks-task-already-existing=The task {0$task$} already exists!
 command-tasks-task-rename-success=The task {0$task$} was successfully renamed to {1$new$}. &cKeep in mind that you might need to change the name in other configurations e.g. groups
 command-tasks-task-not-found=That task doesn't exist!
-command-tasks-unknown-host-address-or-alias=The host {0$host$} is neither an assignable host nor an ip alias of the node.
+command-tasks-unknown-host-address-or-alias=The host {0$host$} is neither an assignable host nor an ip alias of the node. Note: Wildcard addresses (like 0.0.0.0) are not allowed
 #
 # Command Tasks (setup)
 #

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -23,7 +23,7 @@ cloudnet-init-setup-cluster-install=Is this node part of a cluster? (MultiRoot)
 cloudnet-init-setup-cluster-list-nodes=What are the names of your already existing nodes? (separated by ";")
 cloudnet-init-setup-cluster-node-host=What is the host and port of the node "{0$node$}"? (you can find it in the config.json at "listeners")
 cloudnet-init-setup-host-address=On which host should the services be started on? Note: Wildcard addresses (like 0.0.0.0) are not allowed
-cloudnet-init-setup-internal-host=On which host and port should CloudNet run on? (This is NOT your proxy host/port) Note: Wildcard addresses (like 0.0.0.0) are not allowed
+cloudnet-init-setup-internal-host=On which host and port should CloudNet run on? (This is NOT your proxy host/port)
 cloudnet-init-setup-memory=How much memory (in MB) can the services running on this CloudNet node use?
 cloudnet-init-setup-node-id=What should the name of this CloudNet node be?
 cloudnet-init-setup-tasks-javacommand=What is the path to the Java executable?
@@ -33,7 +33,7 @@ cloudnet-init-setup-tasks-server-environment=What should be the environment of t
 cloudnet-init-setup-tasks-server-version=Which ServiceVersion should be used on the services?
 cloudnet-init-setup-tasks-should-install-proxy=Should a default proxy be created?
 cloudnet-init-setup-tasks-should-install-server=Should a default lobby be created?
-cloudnet-init-setup-web-host=On which host and port should CloudNet's WebServer run? Note: Wildcard addresses (like 0.0.0.0) are not allowed
+cloudnet-init-setup-web-host=On which host and port should CloudNet's WebServer run?
 cloudnet-init-default-modules=Which default modules should be installed? (separated by a space)
 #
 # Console animations

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
@@ -276,7 +276,6 @@ public class Wrapper extends CloudNetDriver {
     return new ServiceInfoSnapshot(
       System.currentTimeMillis(),
       this.currentServiceInfoSnapshot.address(),
-      this.currentServiceInfoSnapshot.connectAddress(),
       ProcessSnapshot.self(),
       this.serviceConfiguration(),
       this.currentServiceInfoSnapshot.connectedTime(),
@@ -405,7 +404,6 @@ public class Wrapper extends CloudNetDriver {
       this.currentServiceInfoSnapshot = new ServiceInfoSnapshot(
         System.currentTimeMillis(),
         this.currentServiceInfoSnapshot.address(),
-        this.currentServiceInfoSnapshot.connectAddress(),
         ProcessSnapshot.self(),
         this.serviceConfiguration(),
         System.currentTimeMillis(),


### PR DESCRIPTION
### Motivation
After introducing host addresses on a per task basis the connect host address became useless. Therefore we don't need it anymore.

### Modification
Removed the connect host address at all places. Furthermore some parsers were tightend in order to disallow wildcard addresses.

### Result
The connect host address option and all usages were removed