### PR TITLE
chore: improve port resolution during service configuration

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/AbstractServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/AbstractServiceFactory.java
@@ -43,13 +43,12 @@ public abstract class AbstractServiceFactory implements CloudServiceFactory {
       configurationBuilder.environment(env);
     }
 
-    // find a free port for the service
-    var port = configuration.port();
-    while (this.isPortInUse(manager, port)) {
-      port++;
-    }
-    // set the port
-    return configurationBuilder.startPort(port).hostAddress(this.resolveHostAddress(configuration)).build();
+    // resolve the host address & port we should use for the service
+    var hostAddress = this.resolveHostAddress(configuration);
+    var hostPort = this.findFreeServicePort(manager, configuration, hostAddress);
+
+    // apply the address to the configuration & finish up
+    return configurationBuilder.startPort(hostPort).hostAddress(hostAddress).build();
   }
 
   protected @NonNull String resolveHostAddress(@NonNull ServiceConfiguration serviceConfiguration) {
@@ -85,14 +84,36 @@ public abstract class AbstractServiceFactory implements CloudServiceFactory {
       hostAddress));
   }
 
-  protected boolean isPortInUse(@NonNull CloudServiceManager manager, int port) {
+  protected int findFreeServicePort(
+    @NonNull CloudServiceManager manager,
+    @NonNull ServiceConfiguration configuration,
+    @NonNull String hostAddress
+  ) {
+    // increase the port number until we found a port
+    var port = configuration.port();
+    while (this.isPortInUse(manager, hostAddress, port)) {
+      port++;
+
+      // stop if the port exceeds the possible port range
+      if (port > 0xFFFF) {
+        throw new IllegalStateException("No free port found for service, started at port: " + configuration.port());
+      }
+    }
+
+    // use the next free, available port
+    return port;
+  }
+
+  protected boolean isPortInUse(@NonNull CloudServiceManager manager, @NonNull String hostAddress, int port) {
     // check if any local service has the port
     for (var cloudService : manager.localCloudServices()) {
-      if (cloudService.serviceConfiguration().port() == port) {
+      var address = cloudService.serviceInfo().address();
+      if (address.host().equals(hostAddress) && address.port() == port) {
         return true;
       }
     }
+
     // validate that the port is free
-    return NetworkUtil.isInUse(port);
+    return NetworkUtil.isInUse(hostAddress, port);
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
@@ -54,10 +54,11 @@ public final class NetworkUtil {
     return LOCAL_ADDRESS;
   }
 
-  public static boolean isInUse(int port) {
+  public static boolean isInUse(@NonNull String hostAddress, int port) {
     try (var serverSocket = new ServerSocket()) {
       // try to bind on the port, if successful the port is free
-      serverSocket.bind(new InetSocketAddress(port));
+      serverSocket.setReuseAddress(true);
+      serverSocket.bind(new InetSocketAddress(hostAddress, port));
       return false;
     } catch (Exception exception) {
       return true;
@@ -67,6 +68,7 @@ public final class NetworkUtil {
   public static boolean checkAssignable(@NonNull HostAndPort hostAndPort) {
     try (var socket = new ServerSocket()) {
       // try to bind on the given address
+      socket.setReuseAddress(true);
       socket.bind(new InetSocketAddress(hostAndPort.host(), 0));
       return true;
     } catch (IOException exception) {


### PR DESCRIPTION
### Motivation
The current service port resolving does not take service bind hosts into account, meaning that binding to the same port on different network interfaces is not possible.

### Modification
Take network interface into account as well when selecting the port for a service.

### Result
Possible to re-use the same port on different network interfaces.