### PR TITLE
chore: improve host address extraction when used

### DIFF
--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/CloudNetCloudflareModule.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/CloudNetCloudflareModule.java
@@ -28,6 +28,7 @@ import eu.cloudnetservice.modules.cloudflare.dns.DNSType;
 import eu.cloudnetservice.modules.cloudflare.dns.DefaultDNSRecord;
 import eu.cloudnetservice.modules.cloudflare.listener.CloudflareStartAndStopListener;
 import eu.cloudnetservice.node.Node;
+import eu.cloudnetservice.node.util.NetworkUtil;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -60,7 +61,7 @@ public final class CloudNetCloudflareModule extends DriverModule {
           new CloudflareConfigurationEntry(
             false,
             CloudflareConfigurationEntry.AuthenticationMethod.GLOBAL_KEY,
-            this.initialHostAddress(),
+            NetworkUtil.localAddress(),
             "user@example.com",
             "api_token_string",
             "zoneId",
@@ -122,14 +123,6 @@ public final class CloudNetCloudflareModule extends DriverModule {
   @ModuleTask(order = 64, event = ModuleLifeCycle.STOPPED)
   public void removeRecordsOnDelete() {
     this.cloudFlareAPI.close();
-  }
-
-  private String initialHostAddress() {
-    try {
-      return InetAddress.getLocalHost().getHostAddress();
-    } catch (Exception ex) {
-      return "0.0.0.0";
-    }
   }
 
   public @NonNull CloudflareConfiguration cloudFlareConfiguration() {

--- a/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
@@ -127,14 +127,14 @@ public final class NetworkUtil {
     try {
       // try to parse an ipv 4 or 6 address from the input string
       var address = InetAddresses.forString(normalizedInput);
-      return new HostAndPort(address.getHostAddress(), port);
+      return new HostAndPort(extractHostAddress(address), port);
     } catch (IllegalArgumentException ignored) {
     }
 
     try {
       // not the end of the world - might still be a domain name
       var address = InetAddress.getByName(normalizedInput);
-      return new HostAndPort(address.getHostAddress(), port);
+      return new HostAndPort(extractHostAddress(address), port);
     } catch (UnknownHostException exception) {
       // okay that's it
       return null;
@@ -143,13 +143,13 @@ public final class NetworkUtil {
 
   private static @NonNull String findLocalAddress() {
     try {
-      return hostAddress(InetAddress.getLocalHost());
+      return extractHostAddress(InetAddress.getLocalHost());
     } catch (UnknownHostException exception) {
       return "127.0.0.1";
     }
   }
 
-  private static @NonNull String hostAddress(@NonNull InetAddress address) {
+  private static @NonNull String extractHostAddress(@NonNull InetAddress address) {
     if (address instanceof Inet6Address) {
       // get the host address of the inet address
       var hostAddress = address.getHostAddress();
@@ -176,7 +176,7 @@ public final class NetworkUtil {
         // get all addresses of the interface
         var inetAddresses = networkInterfaces.nextElement().getInetAddresses();
         while (inetAddresses.hasMoreElements()) {
-          addresses.add(hostAddress(inetAddresses.nextElement()));
+          addresses.add(extractHostAddress(inetAddresses.nextElement()));
         }
       }
       // return the located addresses


### PR DESCRIPTION
### Motivation
The current calls to `getHostAddress` are not taking into account that the network interface might be appended by java to the result (if the address is an ipv6 address), this might look something like: `2001:db8:3c4d:15::1a2f:1a2b%eth2`.

### Modification
Use the `extractHostAddress` method from the node networtk util to remove the network interface information which are appended to the address.

### Result
No more network interface information after the host address.