### PR TITLE
chore: add a command to set the runtime of a command

### DIFF
--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServiceFactory.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServiceFactory.java
@@ -64,4 +64,9 @@ public class DockerizedServiceFactory extends AbstractServiceFactory {
       this.dockerClient,
       this.configuration);
   }
+
+  @Override
+  public @NonNull String name() {
+    return this.configuration.factoryName();
+  }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceFactory.java
@@ -16,11 +16,11 @@
 
 package eu.cloudnetservice.node.service;
 
+import eu.cloudnetservice.common.Nameable;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import lombok.NonNull;
 
-@FunctionalInterface
-public interface CloudServiceFactory {
+public interface CloudServiceFactory extends Nameable {
 
   @NonNull CloudService createCloudService(@NonNull CloudServiceManager manager,
     @NonNull ServiceConfiguration configuration);

--- a/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
@@ -25,6 +25,7 @@ import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceTask;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 import lombok.NonNull;
 import org.jetbrains.annotations.ApiStatus;
@@ -35,7 +36,8 @@ import org.jetbrains.annotations.UnmodifiableView;
 
 public interface CloudServiceManager extends CloudServiceProvider {
 
-  @NonNull Collection<CloudServiceFactory> cloudServiceFactories();
+  @NonNull
+  @UnmodifiableView Map<String, CloudServiceFactory> cloudServiceFactories();
 
   @Nullable CloudServiceFactory cloudServiceFactory(@NonNull String runtime);
 

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
@@ -228,8 +228,9 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
   }
 
   @Override
-  public @NonNull Collection<CloudServiceFactory> cloudServiceFactories() {
-    return Collections.unmodifiableCollection(this.cloudServiceFactories.values());
+  @UnmodifiableView
+  public @NonNull Map<String, CloudServiceFactory> cloudServiceFactories() {
+    return Collections.unmodifiableMap(this.cloudServiceFactories);
   }
 
   @Override

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/JVMServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/JVMServiceFactory.java
@@ -46,4 +46,9 @@ public class JVMServiceFactory extends AbstractServiceFactory {
     // create the service
     return new JVMService(config, manager, this.eventManager, this.nodeInstance, preparer);
   }
+
+  @Override
+  public @NonNull String name() {
+    return "jvm";
+  }
 }

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -265,6 +265,7 @@ cloudnet-load-task-unknown-java-version=Could not resolve Java version for {0$ta
 command-tasks-create-task=The empty task was successfully created. Configure it via the command 'tasks' or in the configuration file
 command-tasks-delete-task=The task was successfully deleted
 command-tasks-node-not-found=That node doesn't exist!
+command-tasks-runtime-not-found=The runtime {0$runtime$} does not exist!
 command-tasks-reload-success=The ServiceTasks have been reloaded!
 command-tasks-add-collection-property=The {0$property$} {1$value$} was successfully added to the task {2$task$}
 command-tasks-set-property-success=The {0$property$} of the task {1$name$} was changed to {2$value$}


### PR DESCRIPTION
### Motivation
Setting the runtime of a task got more important by introducing the docker module. Therefore we should have command to set the runtime.

### Modification
Created a new command to set the runtime of a task.

### Result
The runtime can be set using a command and is displayed in the task output.