### PR TITLE
[ci skip] build: improve generated javadocs

### DIFF
--- a/build-extensions/src/main/kotlin/publishing-extensions.kt
+++ b/build-extensions/src/main/kotlin/publishing-extensions.kt
@@ -18,6 +18,8 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.external.javadoc.JavadocMemberLevel
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.Sign
@@ -96,4 +98,18 @@ fun Project.configurePublishing(publishedComponent: String, withJavadocAndSource
       !rootProject.version.toString().endsWith("-SNAPSHOT")
     }
   }
+}
+
+fun applyDefaultJavadocOptions(options: StandardJavadocDocletOptions) {
+  options.use()
+  options.encoding = "UTF-8"
+  options.memberLevel = JavadocMemberLevel.PRIVATE
+  options.addBooleanOption("Xdoclint:-missing", true)
+  options.links(
+    "https://projectlombok.org/api/",
+    "https://jd.adventure.kyori.net/api/4.11.0/",
+    "https://javadoc.io/doc/com.konghq/unirest-java/latest/",
+    "https://javadoc.io/doc/org.jetbrains/annotations/latest/",
+    "https://javadoc.io/doc/cloud.commandframework/cloud-core/latest/"
+  )
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,12 +127,7 @@ subprojects {
 
   tasks.withType<Javadoc> {
     val options = options as? StandardJavadocDocletOptions ?: return@withType
-
-    // options
-    options.encoding = "UTF-8"
-    options.memberLevel = JavadocMemberLevel.PRIVATE
-    options.addStringOption("-html5")
-    options.addBooleanOption("Xdoclint:-missing", true)
+    applyDefaultJavadocOptions(options)
   }
 
   // all these projects are publishing their java artifacts
@@ -145,11 +140,8 @@ tasks.register("globalJavaDoc", Javadoc::class) {
   title = "CloudNet JavaDocs"
   setDestinationDir(buildDir.resolve("javadocs"))
   // options
-  options.encoding = "UTF-8"
+  applyDefaultJavadocOptions(options)
   options.windowTitle = "CloudNet JavaDocs"
-  options.memberLevel = JavadocMemberLevel.PRIVATE
-  options.addStringOption("-html5")
-  options.addBooleanOption("Xdoclint:-missing", true)
   // set the sources
   val sources = subprojects.filter { it.plugins.hasPlugin("java") }.map { it.path }
   source(files(sources.flatMap { project(it).sourceSets()["main"].allJava }))


### PR DESCRIPTION
### Motivation
The current generated javadocs can be improved; both ways: how we do it, and what gets generated.

### Modification
1. Move common javadoc options into a seperate method so that modifications of the options is easier.
2. Add links to external javadocs so that people can read the documentation of annotations/fields/parameters etc. as well. (this only includes some picked libraries which are considered part of our api)

### Result
Better javadoc readability & generation.

##### Other context
Example:
![image](https://user-images.githubusercontent.com/40468651/180014343-5eee10ef-0b2a-4c84-a0fa-31902b3a8e95.png)
(Ignore the duplicate annotations, thats a java bug)