### PR TITLE
chore: improve java version handling

### DIFF
--- a/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
+++ b/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
@@ -55,7 +55,7 @@ public enum JavaVersion {
   private static @NonNull JavaVersion[] resolveActualJavaVersions() {
     // remove index 0 and 1 (UNSUPPORTED and NEXT) as they shouldn't be resolvable
     var values = JavaVersion.values();
-    return Arrays.copyOfRange(values, 2, values.length);
+    return Arrays.copyOfRange(values, JAVA_8.ordinal(), values.length);
   }
 
   public static @NonNull JavaVersion runtimeVersion() {

--- a/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
+++ b/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
@@ -39,7 +39,7 @@ public enum JavaVersion {
   JAVA_19(19, 63D, "Java 19"),
   JAVA_20(20, 64D, "Java 20");
 
-  private static final JavaVersion[] JAVA_VERSIONS = JavaVersion.values();
+  private static final JavaVersion[] JAVA_VERSIONS = resolveActualJavaVersions();
   private static final JavaVersion LATEST_VERSION = JAVA_VERSIONS[JAVA_VERSIONS.length - 1];
 
   private final int majorVersion;
@@ -50,6 +50,12 @@ public enum JavaVersion {
     this.majorVersion = majorVersion;
     this.classFileVersion = classFileVersion;
     this.displayName = displayName;
+  }
+
+  private static @NonNull JavaVersion[] resolveActualJavaVersions() {
+    // remove index 0 and 1 (UNSUPPORTED and NEXT) as they shouldn't be resolvable
+    var values = JavaVersion.values();
+    return Arrays.copyOfRange(values, 2, values.length);
   }
 
   public static @NonNull JavaVersion runtimeVersion() {

--- a/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
+++ b/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
@@ -22,7 +22,9 @@ import lombok.NonNull;
 
 public enum JavaVersion {
 
-  UNKNOWN(-1, -1D, "Unknown Java"),
+  JAVA_UNSUPPORTED(-1, -1D, "Unsupported Java"),
+  JAVA_NEXT(Integer.MAX_VALUE, Double.MAX_VALUE, "Next Java"),
+
   JAVA_8(8, 52D, "Java 8"),
   JAVA_9(9, 53D, "Java 9"),
   JAVA_10(10, 54D, "Java 10"),
@@ -34,35 +36,41 @@ public enum JavaVersion {
   JAVA_16(16, 60D, "Java 16"),
   JAVA_17(17, 61D, "Java 17"),
   JAVA_18(18, 62D, "Java 18"),
-  JAVA_19(19, 63D, "Java 19");
+  JAVA_19(19, 63D, "Java 19"),
+  JAVA_20(20, 64D, "Java 20");
 
   private static final JavaVersion[] JAVA_VERSIONS = JavaVersion.values();
+  private static final JavaVersion LATEST_VERSION = JAVA_VERSIONS[JAVA_VERSIONS.length - 1];
 
-  private final int version;
+  private final int majorVersion;
   private final double classFileVersion;
-  private final String name;
+  private final String displayName;
 
-  JavaVersion(int version, double classFileVersion, @NonNull String name) {
-    this.version = version;
+  JavaVersion(int majorVersion, double classFileVersion, @NonNull String displayName) {
+    this.majorVersion = majorVersion;
     this.classFileVersion = classFileVersion;
-    this.name = name;
+    this.displayName = displayName;
   }
 
   public static @NonNull JavaVersion runtimeVersion() {
-    var classVersion = Double.parseDouble(System.getProperty("java.class.version"));
-    return fromClassFileVersion(classVersion).orElse(UNKNOWN);
+    var jcv = Double.parseDouble(System.getProperty("java.class.version"));
+    return fromClassFileVersion(jcv).orElse(jcv > LATEST_VERSION.classFileVersion() ? JAVA_NEXT : JAVA_UNSUPPORTED);
   }
 
-  public static @NonNull Optional<JavaVersion> fromClassFileVersion(double versionId) {
-    return Arrays.stream(JAVA_VERSIONS).filter(javaVersion -> javaVersion.classFileVersion == versionId).findFirst();
+  public static @NonNull Optional<JavaVersion> fromClassFileVersion(double classFileVersion) {
+    return Arrays.stream(JAVA_VERSIONS).filter(version -> version.classFileVersion() == classFileVersion).findFirst();
   }
 
-  public static @NonNull Optional<JavaVersion> fromVersion(int version) {
-    return Arrays.stream(JAVA_VERSIONS).filter(javaVersion -> javaVersion.version == version).findFirst();
+  public static @NonNull JavaVersion guessFromMajor(int major) {
+    return fromMajor(major).orElse(major > LATEST_VERSION.majorVersion() ? JAVA_NEXT : JAVA_UNSUPPORTED);
   }
 
-  public int version() {
-    return this.version;
+  public static @NonNull Optional<JavaVersion> fromMajor(int version) {
+    return Arrays.stream(JAVA_VERSIONS).filter(javaVersion -> javaVersion.majorVersion == version).findFirst();
+  }
+
+  public int majorVersion() {
+    return this.majorVersion;
   }
 
   public double classFileVersion() {
@@ -70,23 +78,22 @@ public enum JavaVersion {
   }
 
   public @NonNull String displayName() {
-    return this.name;
+    return this.displayName;
   }
 
-  public boolean unknown() {
-    return this == UNKNOWN;
+  public boolean supported() {
+    return this != JAVA_UNSUPPORTED;
   }
 
-  public boolean isSupported(@NonNull JavaVersion minJavaVersion, @NonNull JavaVersion maxJavaVersion) {
-    return this.unknown() || this.classFileVersion >= minJavaVersion.classFileVersion
-      && this.classFileVersion <= maxJavaVersion.classFileVersion;
+  public boolean isInRange(@NonNull JavaVersion lowerBound, @NonNull JavaVersion upperBound) {
+    return this.isNewerOrAt(lowerBound) && this.isOlderOrAt(upperBound);
   }
 
-  public boolean isSupportedByMin(@NonNull JavaVersion minRequiredJavaVersion) {
-    return this.unknown() || this.classFileVersion >= minRequiredJavaVersion.classFileVersion;
+  public boolean isNewerOrAt(@NonNull JavaVersion lowerBound) {
+    return lowerBound.supported() && this.classFileVersion >= lowerBound.classFileVersion;
   }
 
-  public boolean isSupportedByMax(@NonNull JavaVersion maxRequiredJavaVersion) {
-    return this.unknown() || this.classFileVersion <= maxRequiredJavaVersion.classFileVersion;
+  public boolean isOlderOrAt(@NonNull JavaVersion upperBound) {
+    return this.supported() && this.classFileVersion <= upperBound.classFileVersion;
   }
 }

--- a/common/src/test/java/eu/cloudnetservice/common/JavaVersionTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/JavaVersionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.common;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class JavaVersionTest {
+
+  @Test
+  void testRuntimeVersion() {
+    // we require java 17 to build (atm)
+    var runtimeVersion = JavaVersion.runtimeVersion();
+    Assertions.assertTrue(runtimeVersion.isNewerOrAt(JavaVersion.JAVA_17));
+  }
+
+  @Test
+  void testVersionGuessing() {
+    var newerVersion = JavaVersion.guessFromMajor(1290);
+    Assertions.assertTrue(newerVersion.supported());
+    Assertions.assertSame(JavaVersion.JAVA_NEXT, newerVersion);
+    Assertions.assertTrue(newerVersion.isNewerOrAt(JavaVersion.JAVA_17));
+
+    var unsupportedVersion = JavaVersion.guessFromMajor(4);
+    Assertions.assertFalse(unsupportedVersion.supported());
+    Assertions.assertSame(JavaVersion.JAVA_UNSUPPORTED, unsupportedVersion);
+    Assertions.assertFalse(unsupportedVersion.isNewerOrAt(JavaVersion.JAVA_17));
+    Assertions.assertFalse(unsupportedVersion.isOlderOrAt(JavaVersion.JAVA_17));
+
+    var knownVersion = JavaVersion.guessFromMajor(16);
+    Assertions.assertTrue(knownVersion.supported());
+    Assertions.assertSame(JavaVersion.JAVA_16, knownVersion);
+    Assertions.assertTrue(knownVersion.isNewerOrAt(JavaVersion.JAVA_16));
+    Assertions.assertTrue(knownVersion.isNewerOrAt(JavaVersion.JAVA_11));
+    Assertions.assertFalse(knownVersion.isNewerOrAt(JavaVersion.JAVA_17));
+    Assertions.assertTrue(knownVersion.isOlderOrAt(JavaVersion.JAVA_16));
+    Assertions.assertTrue(knownVersion.isOlderOrAt(JavaVersion.JAVA_17));
+    Assertions.assertFalse(knownVersion.isOlderOrAt(JavaVersion.JAVA_14));
+  }
+
+  @Test
+  void testResolveFromClassVersion() {
+    var knownVersion = JavaVersion.fromClassFileVersion(57D);
+    Assertions.assertTrue(knownVersion.isPresent());
+    Assertions.assertSame(JavaVersion.JAVA_13, knownVersion.get());
+
+    var unknownVersion = JavaVersion.fromClassFileVersion(23D);
+    Assertions.assertTrue(unknownVersion.isEmpty());
+  }
+
+  @Test
+  void testResolveFromMajor() {
+    var knownVersion = JavaVersion.fromMajor(9);
+    Assertions.assertTrue(knownVersion.isPresent());
+    Assertions.assertSame(JavaVersion.JAVA_9, knownVersion.get());
+
+    var unknownVersion = JavaVersion.fromMajor(3);
+    Assertions.assertTrue(unknownVersion.isEmpty());
+  }
+}

--- a/common/src/test/java/eu/cloudnetservice/common/JavaVersionTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/JavaVersionTest.java
@@ -29,6 +29,14 @@ class JavaVersionTest {
   }
 
   @Test
+  void testNextAndUnsupportedAreHidden() {
+    Assertions.assertTrue(JavaVersion.fromMajor(-1).isEmpty());
+    Assertions.assertTrue(JavaVersion.fromMajor(Integer.MAX_VALUE).isEmpty());
+    Assertions.assertTrue(JavaVersion.fromClassFileVersion(-1D).isEmpty());
+    Assertions.assertTrue(JavaVersion.fromClassFileVersion(Double.MAX_VALUE).isEmpty());
+  }
+
+  @Test
   void testVersionGuessing() {
     var newerVersion = JavaVersion.guessFromMajor(1290);
     Assertions.assertTrue(newerVersion.supported());

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfiguration.java
@@ -78,8 +78,8 @@ public record ModuleConfiguration(
   /**
    * Get the data folder path of this module or a default version of it based on the module's name.
    *
-   * @param baseDirectory the base directory of the module provider used to resolve the data folder if no
-   *                                    data folder is specified explicitly.
+   * @param baseDirectory the base directory of the module provider used to resolve the data folder if no data folder is
+   *                      specified explicitly.
    * @return the data folder in path form of this module.
    */
   public @NonNull Path dataFolder(@NonNull Path baseDirectory) {
@@ -98,7 +98,7 @@ public record ModuleConfiguration(
    * @return the minimum java runtime version this module can run on.
    */
   public @Nullable JavaVersion minJavaVersion() {
-    return JavaVersion.fromVersion(this.minJavaVersionId).orElse(null);
+    return this.minJavaVersionId > 0 ? JavaVersion.guessFromMajor(this.minJavaVersionId) : null;
   }
 
   /**
@@ -109,6 +109,6 @@ public record ModuleConfiguration(
    */
   public boolean canRunOn(@NonNull JavaVersion javaVersion) {
     var minJavaVersion = this.minJavaVersion();
-    return minJavaVersion == null || minJavaVersion.isSupportedByMax(javaVersion);
+    return minJavaVersion == null || !minJavaVersion.supported() || javaVersion.isNewerOrAt(minJavaVersion);
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeServiceTaskProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeServiceTaskProvider.java
@@ -191,10 +191,9 @@ public class NodeServiceTaskProvider implements ServiceTaskProvider {
 
         // remove all custom java paths that do not support Java 17
         var javaVersion = JavaVersionResolver.resolveFromJavaExecutable(task.javaCommand());
-        if (javaVersion == null) {
-          LOGGER.severe(I18n.trans("cloudnet-load-task-unknown-java-version", taskName));
-        } else if (!javaVersion.isSupportedByMin(JavaVersion.JAVA_17)) {
+        if (javaVersion == null || !javaVersion.isNewerOrAt(JavaVersion.JAVA_17)) {
           task = ServiceTask.builder(task).javaCommand(null).build();
+          LOGGER.warning(I18n.trans("cloudnet-load-task-unsupported-java-version", taskName));
         }
       }
 

--- a/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersion.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersion.java
@@ -74,15 +74,8 @@ public class ServiceVersion implements Nameable {
   }
 
   public boolean canRun(@NonNull JavaVersion javaVersion) {
-    var minJavaVersion = JavaVersion.fromVersion(this.minJavaVersion);
-    var maxJavaVersion = JavaVersion.fromVersion(this.maxJavaVersion);
-
-    if (minJavaVersion.isPresent() && maxJavaVersion.isPresent()) {
-      return javaVersion.isSupported(minJavaVersion.get(), maxJavaVersion.get());
-    }
-
-    return minJavaVersion.map(javaVersion::isSupportedByMin)
-      .orElseGet(() -> maxJavaVersion.map(javaVersion::isSupportedByMax).orElse(true));
+    return this.minJavaVersion().map(javaVersion::isNewerOrAt).orElse(true)
+      && this.maxJavaVersion().map(javaVersion::isOlderOrAt).orElse(true);
   }
 
   public @NonNull String name() {
@@ -98,11 +91,11 @@ public class ServiceVersion implements Nameable {
   }
 
   public @NonNull Optional<JavaVersion> minJavaVersion() {
-    return JavaVersion.fromVersion(this.minJavaVersion);
+    return JavaVersion.fromMajor(this.minJavaVersion);
   }
 
   public @NonNull Optional<JavaVersion> maxJavaVersion() {
-    return JavaVersion.fromVersion(this.maxJavaVersion);
+    return JavaVersion.fromMajor(this.maxJavaVersion);
   }
 
   public @NonNull JsonDocument properties() {

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -258,7 +258,7 @@ command-groups-create-success=The group {0$name$} was successfully created
 #
 # Tasks
 #
-cloudnet-load-task-unknown-java-version=Could not resolve Java version for {0$task$}
+cloudnet-load-task-unsupported-java-version=Removing java command from {0$task$} because it isn't a valid java installation or incompatible with Java 17
 #
 # Command Tasks
 #


### PR DESCRIPTION
### Motivation
The current java version handling is very limited and some util methods are only hardly understandable. For example: there is no way currently to use a newer java version than the latest version known to us in some cases, or (even worse) some checks like `isNewerThan(17)` would return true on unsupported versions (like 6).

### Modification
Enhance the JavaVersion class to take of these problems and improve the code where the java version is used to use the new possibilities as well.

### Result
Better overall java version handling, which also accounts for edge cases.