### PR TITLE
feat: introduce translated command descriptions

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/BridgeCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/BridgeCommand.java
@@ -41,7 +41,7 @@ import java.util.Queue;
 import lombok.NonNull;
 
 @CommandPermission("cloudnet.command.bridge")
-@Description("Management for the config of the bridge module")
+@Description("module-bridge-command-description")
 public class BridgeCommand {
 
   private final BridgeManagement bridgeManagement;

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
@@ -49,7 +49,7 @@ import org.jetbrains.annotations.Nullable;
 
 @CommandAlias({"pl", "player"})
 @CommandPermission("cloudnet.command.players")
-@Description("Management for online and offline cloud players")
+@Description("module-bridge-player-command-description")
 public class PlayersCommand {
 
   private static final DateFormat DATE_FORMAT = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss");

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerCommand.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerCommand.java
@@ -39,7 +39,7 @@ import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
 @CommandPermission("cloudnet.command.docker")
-@Description("Administration of the docker module configuration")
+@Description("module-docker-command-description")
 public record DockerCommand(@NonNull DockerizedServicesModule module) {
 
   @CommandMethod("docker task <task> image <repository> [tag]")

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NPCCommand.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NPCCommand.java
@@ -39,7 +39,7 @@ import lombok.NonNull;
 
 @CommandAlias("npcs")
 @CommandPermission("cloudnet.command.npc")
-@Description("Create new npc configurations")
+@Description("module-npc-command-description")
 public class NPCCommand {
 
   private static final RowBasedFormatter<NPCConfigurationEntry> ENTRY_LIST_FORMATTER = RowBasedFormatter.<NPCConfigurationEntry>

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/command/ReportCommand.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/command/ReportCommand.java
@@ -52,7 +52,7 @@ import org.jetbrains.annotations.Nullable;
 
 @CommandAlias("paste")
 @CommandPermission("cloudnet.command.paste")
-@Description("Upload cloud specific data to a paste service")
+@Description("module-report-command-description")
 public final class ReportCommand {
 
   private static final Logger LOGGER = LogManager.logger(ReportCommand.class);

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/SignCommand.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/SignCommand.java
@@ -42,7 +42,7 @@ import lombok.NonNull;
 
 @CommandAlias("signs")
 @CommandPermission("cloudnet.command.sign")
-@Description("Create new sign configurations")
+@Description("module-sign-command-description")
 public class SignCommand {
 
   private static final RowBasedFormatter<SignConfigurationEntry> ENTRY_LIST_FORMATTER = RowBasedFormatter.<SignConfigurationEntry>

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/SmartCommand.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/SmartCommand.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
 import lombok.NonNull;
 
 @CommandPermission("cloudnet.command.smart")
-@Description("Administration for the smart config of each task")
+@Description("module-smart-command-description")
 public class SmartCommand {
 
   @Parser(name = "smartTask", suggestions = "smartTask")

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/command/SyncProxyCommand.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/command/SyncProxyCommand.java
@@ -43,7 +43,7 @@ import lombok.NonNull;
 
 @CommandAlias("sp")
 @CommandPermission("cloudnet.command.syncproxy")
-@Description("Administration of the syncproxy configuration management")
+@Description("module-syncproxy-command-description")
 public final class SyncProxyCommand {
 
   private final NodeSyncProxyManagement syncProxyManagement;

--- a/node/src/main/java/eu/cloudnetservice/node/command/annotation/Description.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/annotation/Description.java
@@ -23,8 +23,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation specifies the description of a command. The command description is collected into the {@link
- * CommandInfo}.
+ * This annotation specifies the description of a command. The command description is collected into the
+ * {@link CommandInfo}. By default, the annotation should contain a translation key, that is resolved in the runtime. If
+ * this is not the case the {@link #translatable()} option has to be false.
  *
  * @see CommandInfo
  * @since 4.0
@@ -34,9 +35,16 @@ import java.lang.annotation.Target;
 public @interface Description {
 
   /**
-   * Returns the description for all commands of a class which is annotated with this annotation.
+   * Gets the description for all commands of a class which is annotated with this annotation.
    *
    * @return the description.
    */
   String value();
+
+  /**
+   * Gets if the provided description is a translation key, that needs to be resolved at runtime.
+   *
+   * @return if the provided description is a translation key, that needs to be resolved at runtime.
+   */
+  boolean translatable() default true;
 }

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClearCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClearCommand.java
@@ -22,7 +22,7 @@ import eu.cloudnetservice.node.Node;
 import eu.cloudnetservice.node.command.annotation.Description;
 
 @CommandPermission("cloudnet.command.clear")
-@Description("Clears the entire console of the node to get a better overview")
+@Description("command-clear-description")
 public final class ClearCommand {
 
   @CommandMethod("clear")

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
@@ -59,7 +59,7 @@ import org.jetbrains.annotations.Nullable;
 
 @CommandAlias("clu")
 @CommandPermission("cloudnet.command.cluster")
-@Description("Manages the cluster and provides information about it")
+@Description("command-cluster-description")
 public final class ClusterCommand {
 
   public static final RowBasedFormatter<NodeServer> FORMATTER = RowBasedFormatter.<NodeServer>builder()

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
@@ -40,7 +40,7 @@ import lombok.NonNull;
 
 @CommandAlias("cfg")
 @CommandPermission("cloudnet.command.config")
-@Description("Administration of the cloudnet node configuration")
+@Description("command-config-description")
 public final class ConfigCommand {
 
   @Parser(name = "ipAlias")

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/CreateCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/CreateCommand.java
@@ -34,7 +34,7 @@ import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
 @CommandPermission("cloudnet.command.create")
-@Description("Creates one or more new services based on a task or completely independent")
+@Description("command-create-description")
 public final class CreateCommand {
 
   @CommandMethod("create by <task> <amount>")

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/DebugCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/DebugCommand.java
@@ -23,7 +23,7 @@ import eu.cloudnetservice.common.log.LoggingUtil;
 import eu.cloudnetservice.node.command.annotation.Description;
 import java.util.logging.Level;
 
-@Description("Toggle the global debug mode")
+@Description("command-debug-description")
 @CommandPermission("cloudnet.command.debug")
 public final class DebugCommand {
 

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ExitCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ExitCommand.java
@@ -26,7 +26,7 @@ import eu.cloudnetservice.node.command.source.ConsoleCommandSource;
 
 @CommandAlias({"shutdown", "stop"})
 @CommandPermission("cloudnet.command.exit")
-@Description("Stops the program and all managed subprocesses")
+@Description("command-exit-description")
 public final class ExitCommand {
 
   @Confirmation

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/GroupsCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/GroupsCommand.java
@@ -47,7 +47,7 @@ import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
 @CommandPermission("cloudnet.command.groups")
-@Description("Administers the configurations of all persistent groups")
+@Description("command-groups-description")
 public final class GroupsCommand {
 
   @Parser(suggestions = "groupConfiguration")

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/HelpCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/HelpCommand.java
@@ -38,7 +38,7 @@ import lombok.NonNull;
 
 @CommandAlias({"ask", "?"})
 @CommandPermission("cloudnet.command.help")
-@Description("Shows all commands and their description")
+@Description("commnad-help-description")
 public final class HelpCommand {
 
   private static final RowBasedFormatter<CommandInfo> HELP_LIST_FORMATTER = RowBasedFormatter.<CommandInfo>builder()

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/MeCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/MeCommand.java
@@ -34,7 +34,7 @@ import lombok.NonNull;
 
 @CommandAlias("info")
 @CommandPermission("cloudnet.command.me")
-@Description("Displays all important information about this process and the JVM")
+@Description("command-me-description")
 public final class MeCommand {
 
   private static final Pattern UUID_REPLACE_PATTERN = Pattern.compile("-\\w{4}-");

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/MigrateCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/MigrateCommand.java
@@ -39,7 +39,7 @@ import java.util.Queue;
 import lombok.NonNull;
 
 @CommandPermission("cloudnet.command.migrate")
-@Description("Migrate the database and other things that cloudnet uses")
+@Description("command-migrate-description")
 public final class MigrateCommand {
 
   private static final int DEFAULT_CHUNK_SIZE = 100;

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ModulesCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ModulesCommand.java
@@ -56,7 +56,7 @@ import org.jetbrains.annotations.Nullable;
 
 @CommandAlias("module")
 @CommandPermission("cloudnet.command.modules")
-@Description("Manages all available modules and loading new modules after the start")
+@Description("command-modules-description")
 public final class ModulesCommand {
 
   private static final Logger LOGGER = LogManager.logger(ModulesCommand.class);

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/PermissionsCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/PermissionsCommand.java
@@ -50,7 +50,7 @@ import org.jetbrains.annotations.Nullable;
 
 @CommandAlias("perms")
 @CommandPermission("cloudnet.command.permissions")
-@Description("Manages the permissions of users and groups")
+@Description("command-permissions-description")
 public final class PermissionsCommand {
 
   private static final DateFormat DATE_FORMAT = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss");

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
@@ -65,7 +65,7 @@ import org.jetbrains.annotations.Nullable;
 
 @CommandAlias("ser")
 @CommandPermission("cloudnet.command.service")
-@Description("Manages all services in the cluster")
+@Description("command-service-description")
 public final class ServiceCommand {
 
   private static final Logger LOGGER = LogManager.logger(ServiceCommand.class);

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -65,7 +65,7 @@ import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
 @CommandPermission("cloudnet.command.tasks")
-@Description("Administers the configurations of all persistent tasks")
+@Description("command-tasks-description")
 public final class TasksCommand {
 
   // Task Setup ASCII

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TemplateCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TemplateCommand.java
@@ -50,7 +50,7 @@ import org.jetbrains.annotations.Nullable;
 
 @CommandAlias("t")
 @CommandPermission("cloudnet.command.template")
-@Description("Manages the templates and allows installation of application files")
+@Description("command-template-description")
 public final class TemplateCommand {
 
   private static final RowBasedFormatter<ServiceTemplate> LIST_FORMATTER = RowBasedFormatter.<ServiceTemplate>builder()

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/VersionCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/VersionCommand.java
@@ -58,7 +58,7 @@ import org.jetbrains.annotations.Nullable;
 
 @CommandAlias("v")
 @CommandPermission("cloudnet.command.version")
-@Description("Manage service versions in templates or on static services")
+@Description("command-version-description")
 public final class VersionCommand {
 
   private static final RowBasedFormatter<Pair<ServiceVersionType, ServiceVersion>> VERSIONS =

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -115,6 +115,7 @@ cloudnet-post-unload-module=Module {0$module_group$}:{1$module_name$}:{2$module_
 #
 # Commands
 #
+command-no-description=No command description provided
 command-confirmation-no-requests=There are no commands to confirm
 command-confirmation-required=Please confirm executing the command by executing ''&bconfirm&r'' within 30s
 invalid-command-sender=This command can be executed using the '{0$source$}' only
@@ -142,13 +143,23 @@ command-any-host-and-port-invalid=The given input {0$input$} is not a valid host
 command-assignable-host-invalid=The given input {0$input$} is not an assignable host. Note: Wildcard addresses (like 0.0.0.0) are not allowed
 command-any-host-invalid=The given input {0$input$} is not a valid host address. Note: Wildcard addresses (like 0.0.0.0) are not allowed
 #
-# Command help
+# Command Help
 #
+commnad-help-description=Shows all commands and their description
 command-help-docs=Follow this url {0$url$} to get to the documentation for the {1$command$} command
 command-help-docs-no-url=The {0$command$} command has no documentation url
 #
+# Command Me
+#
+command-me-description=Displays all important information about this node and the running jvm
+#
+# Command clear
+#
+command-clear-description=Clears the entire console of the node to get a better overview
+#
 # Command Cluster
 #
+command-cluster-description=Manages the cluster and provides information about it
 command-cluster-add-node-success=Registered the new node ({0$name$}) to the cluster configuration
 command-cluster-node-not-found=That node doesn't exist
 command-cluster-node-set-drain=Draining is now {0, choice, 0#disabled|1#enabled$drain$} for node {1$node$}
@@ -168,6 +179,7 @@ command-cluster-start-sync=The cluster sync starts now
 #
 # Command Service
 #
+command-service-description=Manages all services in the cluster
 command-service-copy-no-default-template=The service you provided does not have a default template, use "copy {0$name$} template=storage:prefix/name" to provide a template you would like to copy to
 command-service-copy-success=The service {0$name$} was successfully copied to the template {1$template$}
 command-service-add-deployment-success=The deployment {0$deployment$} was successfully added to the waiting deployments
@@ -182,12 +194,22 @@ command-service-toggle-enabled=Enabled the automatic console logging for {0$serv
 #
 # Command Create
 #
+command-create-description=Creates one or more new services based on a task or completely independent
 command-create-by-task-starting=Starting to create {1$amount$} services for {0$task$}
 command-create-by-task-failed=The services couldn't be created
 command-create-by-task-success=The services were created based on the task. They can be managed with the 'service' command
 #
+# Command Debug
+#
+command-debug-description=Toggle the global debug mode
+#
+# Command exit
+#
+command-exit-description=Stops the program and all managed subprocesses
+#
 # Command Migrate
 #
+command-migrate-description=Migrate the database and other things that cloudnet uses
 command-migrate-current-database=Migration of {0$db$} in progress...
 command-migrate-database-connection-failed=The connection to the database failed
 command-migrate-source-equals-target=Migrating data to the same database is not possible
@@ -196,6 +218,7 @@ command-migrate-unknown-database-provider=This database type does not exist
 #
 # Command Modules
 #
+command-modules-description=Manages all available modules and loading new modules after the start
 command-modules-install-missing-depend=The module {0$module$} requires these dependencies to run: {1$dependencies$}
 command-modules-module-already-loaded=The module {0$module$} is already loaded
 command-modules-module-file-not-found=The file {0$path$} does not exist
@@ -212,6 +235,7 @@ command-modules-module-uninstall-failed=The module {0$module$} could not be unin
 #
 # Command Perms
 #
+command-permissions-description=Manages the permissions of users and groups
 command-permissions-create-group-already-exists=The group already exists
 command-permissions-create-group-successful=The group {0$name$} was successfully created
 command-permissions-create-user-already-exists=The user already exists
@@ -236,6 +260,7 @@ command-permissions-user-rename-success=The name of the user {0$name$} was chang
 #
 # Command Config
 #
+command-config-description=Administration of the cloudnet node configuration
 command-config-node-ip-alias-already-existing=The ip alias {0$alias$} already exists
 command-config-node-ip-alias-added=The host address {1$address$} aliased as {0$alias$} was added successfully
 command-config-node-ip-alias-remove=The ip alias {0$alias$} was removed
@@ -248,6 +273,7 @@ command-config-reload-config=Reloaded the node, task, group and permission confi
 #
 # Command Groups
 #
+command-groups-description=Administers the configurations of all persistent groups
 command-groups-add-collection-property=The {0$property$} {1$value$} was successfully added to the group {2$group$}
 command-groups-remove-collection-property=The {0$property$} {1$value$} was successfully removed from the group {2$group$}
 command-groups-clear-property=The {0$property$} for the group {1$group$} were cleared successfully
@@ -262,6 +288,7 @@ cloudnet-load-task-unknown-java-version=Could not resolve Java version for {0$ta
 #
 # Command Tasks
 #
+command-tasks-description=Administers the configurations of all persistent tasks
 command-tasks-create-task=The empty task was successfully created. Configure it via the command 'tasks' or in the configuration file
 command-tasks-delete-task=The task was successfully deleted
 command-tasks-node-not-found=That node doesn't exist!
@@ -293,6 +320,7 @@ command-tasks-setup-question-static=Should the services of this task be static t
 #
 # Command Template
 #
+command-template-description=Manages local and remote templates
 command-template-copy-failed=Unable to prepare source template for deployment! Does the source template exists?
 command-template-copy-same-source-and-target=The source and target templates cannot be the same
 command-template-copy-success=Successfully copied the template {0$sourceTemplate$} to the template {1$targetTemplate$}
@@ -311,6 +339,7 @@ command-template-environment-not-found=The environment {0$env$} doesn't exist
 #
 # Command Version
 #
+command-version-description=Manage service versions in templates or on static services
 command-version-static-service-invalid=The given service does not exist (maybe the service was never started before?)
 command-version-install-failed=Unable to install the requested service version!
 command-version-install-success=The requested service version was successfully installed
@@ -319,6 +348,8 @@ command-version-install-wrong-java=The version {0$version$} is not compatible wi
 #
 # Module Bridge
 #
+module-bridge-command-description=Management for the config of the bridge module
+module-bridge-player-command-description=Management for online and offline cloud players
 module-bridge-tasks-setup-default-fallback=Which fallback task should be used for this proxy? (Leave empty if you don't want to configure it now)
 module-bridge-command-create-entry-success=The bridge configuration entry has been created
 module-bridge-command-entry-already-exists=There already is a configuration entry for this group
@@ -338,12 +369,14 @@ module-cloudflare-delete-dns-record-for-service=DNS entry was deleted on domain 
 #
 # Module NPC
 #
+module-npc-command-description=Administration of npc configurations
 module-npc-command-create-entry-success=The npc configuration entry has been created
 module-npc-tasks-setup-generate-default-config=Should the default NPC configuration entry be generated for this task?
 module-npc-command-create-entry-group-already-exists=The npc configuration entry already exists
 #
 # Module Report
 #
+module-report-command-description=Upload cloud specific data to a paste service
 module-report-command-paste-failed=Failed to upload the data on {0$url$}
 module-report-command-paste-success=The data has been uploaded on {0$url$}
 module-report-command-service-not-found=The service {0$name$} is not registered
@@ -351,12 +384,14 @@ module-report-command-paste-server-not-found=The paste service {0$name$} is not 
 #
 # Module Signs
 #
+module-sign-command-description=Administration of sign configurations
 module-sign-command-create-entry-success=The sign configuration entry has been created
 module-sign-tasks-setup-generate-default-config=Should the default signs configuration entry be generated for this task?
 module-sign-command-create-entry-group-already-exists=The sign configuration entry already exists
 #
 # Module SyncProxy
 #
+module-syncproxy-command-description=Administration of all SyncProxy configurations
 module-syncproxy-command-add-whitelist-entry=The entry {0$name$} was added to the {1$group$} configuration whitelist
 module-syncproxy-command-create-entry-group-already-exists=There already is a configuration entry for this group
 module-syncproxy-command-create-entry-success=The SyncProxy configuration entry has been created
@@ -366,10 +401,12 @@ module-syncproxy-command-set-maxplayers=The player limit of configuration {0$gro
 #
 # Module Smart
 #
+module-smart-command-description=Administration for the smart config of each task
 module-smart-command-task-no-entry=The task {0$task$} has no configured smart entry
 #
 # Module Docker Services
 #
+module-docker-command-description=Administration of the docker module configuration
 module-docker-command-set-success=The property {0$property$} was successfully changed to {1$value$}
 module-docker-command-remove-success=The property {0$property$} was successfully removed
 module-docker-command-add-collection-property=The {0$property$} {1$value$} was successfully added


### PR DESCRIPTION
### Motivation
Currently all command descriptions are hardcoded and therefore only available in English.

### Modifications
Added a new translatable property to the description annotation which allows the opt-out of a translatable description.

### Result
Our descriptions can be translated to different languages on crowdin.