### PR TITLE
chore: update to minecraft 1.19.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ protocolLib = "master-SNAPSHOT"
 npcLib = "development-SNAPSHOT"
 
 # fabric platform special dependencies
-minecraft = "1.19"
+minecraft = "1.19.1"
 fabricLoader = "0.14.8"
 
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricDirectPlayerExecutor.java
@@ -26,7 +26,6 @@ import lombok.NonNull;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -76,7 +75,7 @@ public final class FabricDirectPlayerExecutor extends PlatformPlayerExecutorAdap
   public void sendChatMessage(@NonNull Component message, @Nullable String permission) {
     // we're unable to check the permission for the player
     var text = this.vanillaFromAdventure(message);
-    this.forEach(player -> player.sendSystemMessage(text, ChatType.SYSTEM));
+    this.forEach(player -> player.sendSystemMessage(text, false));
   }
 
   @Override
@@ -91,7 +90,7 @@ public final class FabricDirectPlayerExecutor extends PlatformPlayerExecutorAdap
   public void spoofCommandExecution(@NonNull String command, boolean redirectToServer) {
     this.forEach(player -> {
       var stack = player.createCommandSourceStack();
-      player.server.getCommands().performCommand(stack, command);
+      player.server.getCommands().performPrefixedCommand(stack, command);
     });
   }
 

--- a/modules/bridge/src/main/resources/fabric.mod.json
+++ b/modules/bridge/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
   "accessWidener": "cloudnet_bridge.accesswidener",
   "depends": {
     "fabricloader": ">=0.14.8",
-    "minecraft": "~1.19",
+    "minecraft": "~1.19.1",
     "java": ">=17"
   }
 }

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -99,11 +99,11 @@
               "-Dpaperclip.patchonly=true"
             ],
             "fetchOverPaperApi": true,
-            "versionGroup": "1.19"
+            "versionGroup": "1.19.1"
           }
         },
         {
-          "name": "1.19",
+          "name": "1.19.1",
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -114,11 +114,13 @@
               "-Dpaperclip.patchonly=true"
             ],
             "fetchOverPaperApi": true,
-            "versionGroup": "1.19"
+            "versionGroup": "1.19.1"
           }
         },
         {
           "name": "1.18.2",
+          "url": "https://api.papermc.io/v2/projects/paper/versions/1.18.2/builds/387/downloads/paper-1.18.2-387.jar",
+          "deprecated": true,
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -127,9 +129,7 @@
             },
             "jvmOptions": [
               "-Dpaperclip.patchonly=true"
-            ],
-            "fetchOverPaperApi": true,
-            "versionGroup": "1.18.2"
+            ]
           }
         },
         {
@@ -270,7 +270,7 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://api.purpurmc.org/v2/purpur/1.19/latest/download",
+          "url": "https://api.purpurmc.org/v2/purpur/1.19.1/latest/download",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -284,8 +284,8 @@
           }
         },
         {
-          "name": "1.19",
-          "url": "https://api.purpurmc.org/v2/purpur/1.19/latest/download",
+          "name": "1.19.1",
+          "url": "https://api.purpurmc.org/v2/purpur/1.19.1/latest/download",
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -300,6 +300,7 @@
         {
           "name": "1.18.2",
           "url": "https://api.purpurmc.org/v2/purpur/1.18.2/latest/download",
+          "deprecated": true,
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -336,12 +337,12 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://download.getbukkit.org/spigot/spigot-1.19.jar",
+          "url": "https://download.getbukkit.org/spigot/spigot-1.19.1.jar",
           "cacheFiles": false
         },
         {
-          "name": "1.19",
-          "url": "https://download.getbukkit.org/spigot/spigot-1.19.jar"
+          "name": "1.19.1",
+          "url": "https://download.getbukkit.org/spigot/spigot-1.19.1.jar"
         },
         {
           "name": "1.18.2",
@@ -412,7 +413,7 @@
       "website": "https://fabricmc.net",
       "versions": [
         {
-          "name": "1.19",
+          "name": "1.19.1",
           "cacheFiles": false,
           "properties": {
             "copy": {

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -444,7 +444,7 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://repo.spongepowered.org/repository/maven-releases/org/spongepowered/spongevanilla/1.18.2-9.0.0-RC1147/spongevanilla-1.18.2-9.0.0-RC1147-universal.jar",
+          "url": "https://repo.spongepowered.org/repository/maven-releases/org/spongepowered/spongevanilla/1.18.2-9.0.0-RC1157/spongevanilla-1.18.2-9.0.0-RC1157-universal.jar",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -456,7 +456,7 @@
         },
         {
           "name": "1.18.2",
-          "url": "https://repo.spongepowered.org/repository/maven-releases/org/spongepowered/spongevanilla/1.18.2-9.0.0-RC1147/spongevanilla-1.18.2-9.0.0-RC1147-universal.jar",
+          "url": "https://repo.spongepowered.org/repository/maven-releases/org/spongepowered/spongevanilla/1.18.2-9.0.0-RC1157/spongevanilla-1.18.2-9.0.0-RC1157-universal.jar",
           "properties": {
             "copy": {
               "libraries/.*": "/",
@@ -467,7 +467,7 @@
         },
         {
           "name": "1.16.5",
-          "url": "https://repo.spongepowered.org/repository/maven-releases/org/spongepowered/spongevanilla/1.16.5-8.1.0-RC1150/spongevanilla-1.16.5-8.1.0-RC1150-universal.jar",
+          "url": "https://repo.spongepowered.org/repository/maven-releases/org/spongepowered/spongevanilla/1.16.5-8.1.0-RC1164/spongevanilla-1.16.5-8.1.0-RC1164-universal.jar",
           "properties": {
             "copy": {
               "libraries/.*": "/",


### PR DESCRIPTION
### Motivation
Recently mojang released a patch for 1.19 therefore we should update our downloads.

### Modifications
Updated the downloads to 1.19.1 and deprecated 1.18.2.

### Result
All our downloads are up-to date.