### PR TITLE
feat: allow custom node selection implementations

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.node.event.service;
+
+import eu.cloudnetservice.driver.event.Cancelable;
+import eu.cloudnetservice.driver.event.Event;
+import eu.cloudnetservice.driver.service.ServiceConfiguration;
+import eu.cloudnetservice.node.cluster.NodeServer;
+import lombok.NonNull;
+import org.jetbrains.annotations.UnknownNullability;
+
+public class CloudServiceNodeSelectEvent extends Event implements Cancelable {
+
+  private final ServiceConfiguration configuration;
+
+  private boolean cancelled;
+  private NodeServer nodeServer;
+
+  public CloudServiceNodeSelectEvent(@NonNull ServiceConfiguration configuration) {
+    this.configuration = configuration;
+  }
+
+  public @NonNull ServiceConfiguration configuration() {
+    return this.configuration;
+  }
+
+  public @UnknownNullability NodeServer nodeServer() {
+    return this.nodeServer;
+  }
+
+  public void nodeServer(@NonNull NodeServer server) {
+    this.nodeServer = server;
+  }
+
+  @Override
+  public boolean cancelled() {
+    return this.cancelled;
+  }
+
+  @Override
+  public void cancelled(boolean cancel) {
+    this.cancelled = cancel;
+  }
+}

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
@@ -22,7 +22,7 @@ import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.node.cluster.NodeServer;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import lombok.NonNull;
-import org.jetbrains.annotations.UnknownNullability;
+import org.jetbrains.annotations.Nullable;
 
 public class CloudServiceNodeSelectEvent extends Event implements Cancelable {
 
@@ -48,11 +48,11 @@ public class CloudServiceNodeSelectEvent extends Event implements Cancelable {
     return this.configuration;
   }
 
-  public @UnknownNullability NodeServer nodeServer() {
+  public @Nullable NodeServer nodeServer() {
     return this.nodeServer;
   }
 
-  public void nodeServer(@NonNull NodeServer server) {
+  public void nodeServer(@Nullable NodeServer server) {
     this.nodeServer = server;
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
@@ -20,18 +20,28 @@ import eu.cloudnetservice.driver.event.Cancelable;
 import eu.cloudnetservice.driver.event.Event;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.node.cluster.NodeServer;
+import eu.cloudnetservice.node.service.CloudServiceManager;
 import lombok.NonNull;
 import org.jetbrains.annotations.UnknownNullability;
 
 public class CloudServiceNodeSelectEvent extends Event implements Cancelable {
 
+  private final CloudServiceManager serviceManager;
   private final ServiceConfiguration configuration;
 
   private boolean cancelled;
   private NodeServer nodeServer;
 
-  public CloudServiceNodeSelectEvent(@NonNull ServiceConfiguration configuration) {
+  public CloudServiceNodeSelectEvent(
+    @NonNull CloudServiceManager serviceManager,
+    @NonNull ServiceConfiguration configuration
+  ) {
+    this.serviceManager = serviceManager;
     this.configuration = configuration;
+  }
+
+  public @NonNull CloudServiceManager serviceManager() {
+    return this.serviceManager;
   }
 
   public @NonNull ServiceConfiguration configuration() {

--- a/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
@@ -23,6 +23,7 @@ import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceTask;
+import eu.cloudnetservice.node.cluster.NodeServer;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
@@ -66,6 +67,8 @@ public interface CloudServiceManager extends CloudServiceProvider {
   int currentUsedHeapMemory();
 
   int currentReservedMemory();
+
+  @Nullable NodeServer selectNodeForService(@NonNull ServiceConfiguration configuration);
 
   @NonNull
   @UnmodifiableView Collection<CloudService> localCloudServices();

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
@@ -341,6 +341,7 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
       .sum();
   }
 
+  @Override
   public @Nullable NodeServer selectNodeForService(@NonNull ServiceConfiguration configuration) {
     // check if the node is already specified
     if (configuration.serviceId().nodeUniqueId() != null) {

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
@@ -78,7 +78,7 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
 
   protected final RPCSender sender;
   protected final Collection<String> defaultJvmOptions;
-  protected final NodeServerProvider clusterNodeServerProvider;
+  protected final NodeServerProvider nodeServerProvider;
 
   protected final Map<UUID, SpecificCloudServiceProvider> knownServices = new ConcurrentHashMap<>();
   protected final Map<String, CloudServiceFactory> cloudServiceFactories = new ConcurrentHashMap<>();
@@ -86,7 +86,7 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
 
   public DefaultCloudServiceManager(@NonNull Node nodeInstance, @NonNull Collection<String> defaultJvmOptions) {
     this.defaultJvmOptions = defaultJvmOptions;
-    this.clusterNodeServerProvider = nodeInstance.nodeServerProvider();
+    this.nodeServerProvider = nodeInstance.nodeServerProvider();
     // rpc init
     this.sender = nodeInstance.rpcFactory().providerForClass(null, CloudServiceProvider.class);
     nodeInstance.rpcFactory()
@@ -115,7 +115,7 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
         .convertObject(ServiceInfoSnapshot.class)
         .writer(ser -> {
           // ugly hack to get the channel of the service's associated node
-          var node = this.clusterNodeServerProvider.node(ser.serviceId().nodeUniqueId());
+          var node = this.nodeServerProvider.node(ser.serviceId().nodeUniqueId());
           if (node != null && node.available()) {
             this.handleServiceUpdate(ser, node.channel());
           }
@@ -341,6 +341,51 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
       .sum();
   }
 
+  public @Nullable NodeServer selectNodeForService(@NonNull ServiceConfiguration configuration) {
+    // check if the node is already specified
+    if (configuration.serviceId().nodeUniqueId() != null) {
+      // check for a cluster node server
+      var server = this.nodeServerProvider.node(configuration.serviceId().nodeUniqueId());
+      if (server != null) {
+        // the requested node is a cluster node, check if that node is still accepting services
+        return !server.available() || server.nodeInfoSnapshot().draining() ? null : server;
+      }
+      // no node server with the given name which can start services found
+      return null;
+    }
+
+    // find the best node server
+    return this.nodeServerProvider.nodeServers().stream()
+      .filter(NodeServer::available)
+      .filter(nodeServer -> !nodeServer.nodeInfoSnapshot().draining())
+      .filter(server -> {
+        var allowedNodes = configuration.serviceId().allowedNodes();
+        return allowedNodes.isEmpty() || allowedNodes.contains(server.info().uniqueId());
+      })
+      .min((left, right) -> {
+        // calculate the reserved memory amount based on the cached service information on this node
+        // this is the better way to do this, as newly created services on other nodes will get cached instantly, rather
+        // than us needing to wait for the updated node info to be sent by the associated node. In normal scenarios
+        // that is not a big problem, however when many start requests are coming in, that can lead to one node picking
+        // up a lot of services until (only a few ms later) the updated snapshot is present.
+        var leftReservedMemory = this.calculateReservedMemoryPercentage(left);
+        var rightReservedMemory = this.calculateReservedMemoryPercentage(right);
+
+        // we elevate the used heap memory percentage over the cpu usage, as it's varying much more
+        var chain = ComparisonChain.start().compare(leftReservedMemory, rightReservedMemory);
+        // only include the cpu usage if both nodes can provide a value
+        if (left.nodeInfoSnapshot().processSnapshot().systemCpuUsage() >= 0
+          && right.nodeInfoSnapshot().processSnapshot().systemCpuUsage() >= 0) {
+          // add the system usage to the chain
+          chain = chain.compare(
+            left.nodeInfoSnapshot().processSnapshot().systemCpuUsage(),
+            right.nodeInfoSnapshot().processSnapshot().systemCpuUsage());
+        }
+        // use the result of the comparison
+        return chain.result();
+      }).orElse(null);
+  }
+
   @Override
   public void registerLocalService(@NonNull CloudService service) {
     this.knownServices.putIfAbsent(service.serviceId().uniqueId(), service);
@@ -396,7 +441,7 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
   @Override
   public @NonNull SpecificCloudServiceProvider selectOrCreateService(@NonNull ServiceTask task) {
     // filter out all nodes which are able to start a service of the given task
-    var nodes = this.clusterNodeServerProvider.nodeServers().stream()
+    var nodes = this.nodeServerProvider.nodeServers().stream()
       .filter(NodeServer::available)
       .filter(nodeServer -> !nodeServer.nodeInfoSnapshot().draining())
       .filter(server -> {
@@ -449,5 +494,15 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
         .createCloudService(ServiceConfiguration.builder(task).build());
       return service == null ? EmptySpecificCloudServiceProvider.INSTANCE : service.provider();
     }
+  }
+
+  protected int calculateReservedMemoryPercentage(@NonNull NodeServer server) {
+    // get the reserved memory on the given node based on the services which are running on it and sum it up
+    var reservedMemory = this.services().stream()
+      .filter(info -> info.serviceId().nodeUniqueId().equals(server.name()))
+      .mapToInt(info -> info.configuration().processConfig().maxHeapMemorySize())
+      .sum();
+    // convert to a percentage
+    return (reservedMemory * 100) / server.nodeInfoSnapshot().maxMemory();
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
@@ -73,8 +73,9 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
         this.replaceServiceUniqueId(serviceConfiguration, configurationBuilder);
         this.includeGroupComponents(serviceConfiguration, configurationBuilder);
 
-        var nodeSelectEvent = this.eventManager.callEvent(
-          new CloudServiceNodeSelectEvent(this.serviceManager, serviceConfiguration));
+        var nodeSelectEvent = this.eventManager.callEvent(new CloudServiceNodeSelectEvent(
+          this.serviceManager,
+          serviceConfiguration));
         // check if we are allowed to start the service - return null otherwise
         if (nodeSelectEvent.cancelled()) {
           return null;
@@ -118,7 +119,6 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
         serviceConfiguration);
     }
   }
-
 
   protected @Nullable ServiceInfoSnapshot sendNodeServerStartRequest(
     @NonNull String message,

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
@@ -73,7 +73,8 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
         this.replaceServiceUniqueId(serviceConfiguration, configurationBuilder);
         this.includeGroupComponents(serviceConfiguration, configurationBuilder);
 
-        var nodeSelectEvent = this.eventManager.callEvent(new CloudServiceNodeSelectEvent(serviceConfiguration));
+        var nodeSelectEvent = this.eventManager.callEvent(
+          new CloudServiceNodeSelectEvent(this.serviceManager, serviceConfiguration));
         // check if we are allowed to start the service - return null otherwise
         if (nodeSelectEvent.cancelled()) {
           return null;


### PR DESCRIPTION
### Motivation
Currently there is no way to modify the node selection for a service which is about to be created.

### Modifications
Added a new event allowing the cancellation of the service creation process and giving the option to select a different node to pick up the service.

### Result
The node selection is now modifiable using the mentioned event.