### PR TITLE
fix(node): fix the incrementation in the tick loop

### DIFF
--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetTickListener.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetTickListener.java
@@ -28,7 +28,6 @@ import eu.cloudnetservice.modules.smart.CloudNetSmartModule;
 import eu.cloudnetservice.modules.smart.SmartServiceTaskConfig;
 import eu.cloudnetservice.modules.smart.util.SmartUtil;
 import eu.cloudnetservice.node.Node;
-import eu.cloudnetservice.node.TickLoop;
 import eu.cloudnetservice.node.cluster.NodeServer;
 import eu.cloudnetservice.node.cluster.NodeServerProvider;
 import eu.cloudnetservice.node.event.instance.CloudNetTickServiceStartEvent;
@@ -58,10 +57,7 @@ public final class CloudNetTickListener {
 
   @EventListener
   public void handleTick(@NonNull CloudNetTickServiceStartEvent event) {
-    if (Node.instance().nodeServerProvider().localNode().head()
-      && event.ticker().currentTick() % TickLoop.TPS == 0) {
-      this.handleSmartEntries();
-    }
+    this.handleSmartEntries();
   }
 
   private void handleSmartEntries() {

--- a/node/src/main/java/eu/cloudnetservice/node/TickLoop.java
+++ b/node/src/main/java/eu/cloudnetservice/node/TickLoop.java
@@ -48,7 +48,7 @@ public final class TickLoop {
   private final AtomicLong currentTick = new AtomicLong();
   private final Queue<ScheduledTask<?>> processQueue = new ConcurrentLinkedQueue<>();
 
-  public TickLoop(Node node) {
+  public TickLoop(@NonNull Node node) {
     this.node = node;
   }
 
@@ -116,7 +116,7 @@ public final class TickLoop {
     while (this.node.running()) {
       try {
         // update the current tick we are in
-        tick = this.currentTick.getAndIncrement();
+        tick = this.currentTick.incrementAndGet();
         // calculate oversleep time
         lastTickLength = System.currentTimeMillis() - lastTick;
         if (lastTickLength < MILLIS_BETWEEN_TICKS) {


### PR DESCRIPTION
### Motivation
Currently the tick in the tick loop was retrieved and incremented after that causing problems when relaying on the TPS.

### Modifications
Now the tick is incremented first and retrieved after.

### Result
The smart module handles the tick correctly and starts the services based on the configuration.