### PR TITLE
chore(cloudperms): remove late permission function injection

### DIFF
--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
@@ -30,7 +30,6 @@ public final class BukkitCloudPermissionsPlugin extends JavaPlugin {
   @Override
   public void onEnable() {
     this.checkForVault();
-    Bukkit.getOnlinePlayers().forEach(BukkitPermissionHelper::injectPlayer);
 
     this.getServer().getPluginManager().registerEvents(
       new BukkitCloudPermissionsPlayerListener(CloudNetDriver.instance().permissionManagement()),

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlayerListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlayerListener.java
@@ -19,10 +19,8 @@ package eu.cloudnetservice.modules.cloudperms.bungee;
 import eu.cloudnetservice.driver.permission.Permission;
 import eu.cloudnetservice.driver.permission.PermissionManagement;
 import eu.cloudnetservice.modules.cloudperms.CloudPermissionsHelper;
-import java.util.UUID;
 import lombok.NonNull;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -37,7 +35,7 @@ public final class BungeeCloudPermissionsPlayerListener implements Listener {
 
   private final PermissionManagement permissionsManagement;
 
-  public BungeeCloudPermissionsPlayerListener(PermissionManagement permissionsManagement) {
+  public BungeeCloudPermissionsPlayerListener(@NonNull PermissionManagement permissionsManagement) {
     this.permissionsManagement = permissionsManagement;
   }
 
@@ -56,9 +54,9 @@ public final class BungeeCloudPermissionsPlayerListener implements Listener {
 
   @EventHandler
   public void handle(@NonNull PermissionCheckEvent event) {
-    CommandSender sender = event.getSender();
+    var sender = event.getSender();
     if (sender instanceof ProxiedPlayer player) {
-      UUID uniqueId = player.getUniqueId(); // must not be set ¯\_(ツ)_/¯
+      var uniqueId = player.getUniqueId(); // must not be set ¯\_(ツ)_/¯
       if (uniqueId != null) {
         var permissionUser = this.permissionsManagement.user(uniqueId);
         if (permissionUser != null) {

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPlugin.java
@@ -28,8 +28,6 @@ public final class NukkitCloudPermissionsPlugin extends PluginBase {
 
   @Override
   public void onEnable() {
-    this.injectPlayersCloudPermissible();
-
     super.getServer().getPluginManager().registerEvents(
       new NukkitCloudPermissionsPlayerListener(CloudNetDriver.instance().permissionManagement()),
       this);
@@ -45,11 +43,5 @@ public final class NukkitCloudPermissionsPlugin extends PluginBase {
   public void onDisable() {
     CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
     Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
-  }
-
-  private void injectPlayersCloudPermissible() {
-    for (var player : Server.getInstance().getOnlinePlayers().values()) {
-      NukkitPermissionInjectionHelper.injectPermissible(player, CloudNetDriver.instance().permissionManagement());
-    }
   }
 }

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
@@ -21,13 +21,11 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
-import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import eu.cloudnetservice.driver.CloudNetDriver;
 import eu.cloudnetservice.modules.cloudperms.velocity.listener.VelocityCloudPermissionsPlayerListener;
 import eu.cloudnetservice.wrapper.Wrapper;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.NonNull;
 
 @Plugin(
   id = "cloudnet_cloudperms",
@@ -40,17 +38,14 @@ import java.util.logging.Logger;
 public final class VelocityCloudNetCloudPermissionsPlugin {
 
   private final ProxyServer proxyServer;
-  private final Logger logger;
 
   @Inject
-  public VelocityCloudNetCloudPermissionsPlugin(ProxyServer proxyServer, Logger logger) {
+  public VelocityCloudNetCloudPermissionsPlugin(@NonNull ProxyServer proxyServer) {
     this.proxyServer = proxyServer;
-    this.logger = logger;
   }
 
   @Subscribe
-  public void handleProxyInit(ProxyInitializeEvent event) {
-    this.initPlayersPermissionFunction();
+  public void handleProxyInit(@NonNull ProxyInitializeEvent event) {
     this.proxyServer.getEventManager().register(this, new VelocityCloudPermissionsPlayerListener(
       this.proxyServer,
       new VelocityCloudPermissionProvider(CloudNetDriver.instance().permissionManagement()),
@@ -58,26 +53,8 @@ public final class VelocityCloudNetCloudPermissionsPlugin {
   }
 
   @Subscribe
-  public void handleShutdown(ProxyShutdownEvent event) {
+  public void handleShutdown(@NonNull ProxyShutdownEvent event) {
     CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
     Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
-  }
-
-  private void initPlayersPermissionFunction() {
-    this.proxyServer.getAllPlayers().forEach(this::injectPermissionFunction);
-  }
-
-  private void injectPermissionFunction(Player player) {
-    try {
-      var field = player.getClass().getDeclaredField("permissionFunction");
-      field.setAccessible(true);
-      field.set(
-        player,
-        new VelocityCloudPermissionFunction(
-          player.getUniqueId(),
-          CloudNetDriver.instance().permissionManagement()));
-    } catch (Exception exception) {
-      this.logger.log(Level.SEVERE, "Exception while injecting permissions", exception);
-    }
   }
 }


### PR DESCRIPTION
### Motivation
Currently we inject the permission function into all players when the proxy is started, we don't have to do that as we dont support reloading it anyways.

### Modifications
Removed the injection of the permission function.

### Result
We don't use the reflection based injection anymore.