### PR TITLE
chore(driver): rename the module helper

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/util/ModuleUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/ModuleUtil.java
@@ -48,7 +48,7 @@ public final class ModuleUtil {
    * @return true if the entry was copied successfully, false otherwise.
    * @throws NullPointerException if clazz or target is null.
    */
-  public static boolean copyCurrentModuleInstanceFromClass(@NonNull Class<?> clazz, @NonNull Path target) {
+  public static boolean copyJarContainingClass(@NonNull Class<?> clazz, @NonNull Path target) {
     try {
       // get the location of the class path entry associated with the given class
       var uri = ResourceResolver.resolveURIFromResourceByClass(clazz);

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/ModuleUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/ModuleUtil.java
@@ -32,16 +32,11 @@ import lombok.NonNull;
  *
  * @since 4.0
  */
-public final class DefaultModuleHelper {
+public final class ModuleUtil {
 
-  private static final Logger LOGGER = LogManager.logger(DefaultModuleHelper.class);
+  private static final Logger LOGGER = LogManager.logger(ModuleUtil.class);
 
-  /**
-   * Creating an instance of this helper class is not allowed, results in {@link UnsupportedOperationException}.
-   *
-   * @throws UnsupportedOperationException on invocation
-   */
-  private DefaultModuleHelper() {
+  private ModuleUtil() {
     throw new UnsupportedOperationException();
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/module/listener/PluginIncludeListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/listener/PluginIncludeListener.java
@@ -20,7 +20,7 @@ import eu.cloudnetservice.common.io.FileUtil;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
 import eu.cloudnetservice.driver.event.EventListener;
-import eu.cloudnetservice.driver.util.DefaultModuleHelper;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.node.event.service.CloudServicePreProcessStartEvent;
 import eu.cloudnetservice.node.service.CloudService;
 import java.nio.file.Path;
@@ -54,9 +54,9 @@ public record PluginIncludeListener(
       var pluginFile = event.service().pluginDirectory().resolve(this.moduleName + ".jar");
       FileUtil.delete(pluginFile);
       // try to copy the current plugin file
-      if (DefaultModuleHelper.copyCurrentModuleInstanceFromClass(this.moduleClass, pluginFile)) {
+      if (ModuleUtil.copyCurrentModuleInstanceFromClass(this.moduleClass, pluginFile)) {
         // copy the plugin.yml file for the environment
-        DefaultModuleHelper.copyPluginConfigurationFileForEnvironment(
+        ModuleUtil.copyPluginConfigurationFileForEnvironment(
           this.moduleClass,
           event.service().serviceId().environment(),
           pluginFile);

--- a/node/src/main/java/eu/cloudnetservice/node/module/listener/PluginIncludeListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/listener/PluginIncludeListener.java
@@ -54,7 +54,7 @@ public record PluginIncludeListener(
       var pluginFile = event.service().pluginDirectory().resolve(this.moduleName + ".jar");
       FileUtil.delete(pluginFile);
       // try to copy the current plugin file
-      if (ModuleUtil.copyCurrentModuleInstanceFromClass(this.moduleClass, pluginFile)) {
+      if (ModuleUtil.copyJarContainingClass(this.moduleClass, pluginFile)) {
         // copy the plugin.yml file for the environment
         ModuleUtil.copyPluginConfigurationFileForEnvironment(
           this.moduleClass,


### PR DESCRIPTION
### Motivation
The module util was named `DefaultModuleHelper` and thats not a great name for a util like that.

### Modifications
Renamed the helper to `ModuleUtil` and the jar copy method.

### Result
The names are matching the code.