### PR TITLE
fix: unregister all our bindings & listeners when stopping

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/util/ModuleUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/ModuleUtil.java
@@ -18,9 +18,12 @@ package eu.cloudnetservice.driver.util;
 
 import eu.cloudnetservice.common.StringUtil;
 import eu.cloudnetservice.common.io.FileUtil;
+import eu.cloudnetservice.common.language.I18n;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
 import eu.cloudnetservice.common.unsafe.ResourceResolver;
+import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.network.rpc.defaults.object.DefaultObjectMapper;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -101,5 +104,38 @@ public final class ModuleUtil {
         in.close();
       }
     });
+  }
+
+  /**
+   * Unregisters all kind of listeners and bindings:
+   * <ul>
+   *   <li>Registered events in the {@link eu.cloudnetservice.driver.event.EventManager}</li>
+   *   <li>Registered services in the {@link eu.cloudnetservice.driver.registry.ServiceRegistry}</li>
+   *   <li>Registered bindings for the {@link DefaultObjectMapper#DEFAULT_MAPPER}</li>
+   *   <li>Registered rpc handlers in the {@link eu.cloudnetservice.driver.network.rpc.RPCHandlerRegistry}</li>
+   *   <li>Registered language files in {@link I18n}</li>
+   *   <li>Registered packet listeners in the {@link eu.cloudnetservice.driver.network.protocol.PacketListenerRegistry}</li>
+   * </ul>
+   *
+   * @param classLoader the class loader that registered all the mentioned listeners and bindings.
+   * @throws NullPointerException if the given class loader is null.
+   */
+  public static void unregisterAll(@NonNull ClassLoader classLoader) {
+    var driver = CloudNetDriver.instance();
+    // remove all event listeners
+    driver.eventManager().unregisterListeners(classLoader);
+    // remove all registered services
+    driver.serviceRegistry().unregisterAll(classLoader);
+    // remove custom mapper bindings
+    DefaultObjectMapper.DEFAULT_MAPPER.unregisterBindings(classLoader);
+    // remove rpc handlers
+    driver.rpcHandlerRegistry().unregisterHandlers(classLoader);
+    // remove registered languages
+    I18n.unregisterLanguageFiles(classLoader);
+    // remove all packet listeners
+    driver.networkClient().packetRegistry().removeListeners(classLoader);
+    for (var channel : driver.networkClient().channels()) {
+      channel.packetRegistry().removeListeners(classLoader);
+    }
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgePlugin.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.modules.bridge.platform.bukkit;
 
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.wrapper.Wrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -35,5 +36,6 @@ public final class BukkitBridgePlugin extends JavaPlugin {
   @Override
   public void onDisable() {
     Bukkit.getScheduler().cancelTasks(this);
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgePlugin.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.modules.bridge.platform.bungeecord;
 
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.bungeecord.command.BungeeCordCloudCommand;
 import eu.cloudnetservice.modules.bridge.platform.bungeecord.command.BungeeCordFakeReloadCommand;
@@ -52,5 +53,10 @@ public final class BungeeCordBridgePlugin extends Plugin {
         names[0],
         names.length > 1 ? Arrays.copyOfRange(names, 1, names.length) : new String[0]));
     }
+  }
+
+  @Override
+  public void onDisable() {
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomBridgeExtension.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomBridgeExtension.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.modules.bridge.platform.minestom;
 
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.wrapper.Wrapper;
 import net.minestom.server.extensions.Extension;
 import net.minestom.server.extras.MojangAuth;
@@ -47,6 +48,6 @@ public final class MinestomBridgeExtension extends Extension {
 
   @Override
   public void terminate() {
-
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgePlugin.java
@@ -18,6 +18,7 @@ package eu.cloudnetservice.modules.bridge.platform.nukkit;
 
 import cn.nukkit.Server;
 import cn.nukkit.plugin.PluginBase;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.wrapper.Wrapper;
 
 public final class NukkitBridgePlugin extends PluginBase {
@@ -34,5 +35,6 @@ public final class NukkitBridgePlugin extends PluginBase {
   @Override
   public void onDisable() {
     Server.getInstance().getScheduler().cancelTask(this);
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgePlugin.java
@@ -17,12 +17,14 @@
 package eu.cloudnetservice.modules.bridge.platform.sponge;
 
 import com.google.inject.Inject;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.wrapper.Wrapper;
 import lombok.NonNull;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.lifecycle.StartedEngineEvent;
+import org.spongepowered.api.event.lifecycle.StoppingEngineEvent;
 import org.spongepowered.plugin.PluginContainer;
 import org.spongepowered.plugin.builtin.jvm.Plugin;
 
@@ -43,5 +45,10 @@ public final class SpongeBridgePlugin {
     management.postInit();
     // register the listener
     Sponge.eventManager().registerListeners(this.plugin, new SpongePlayerManagementListener(this.plugin, management));
+  }
+
+  @Listener
+  public void handle(@NonNull StoppingEngineEvent<Server> event) {
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgePlugin.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.modules.bridge.platform.velocity;
 import com.google.inject.Inject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
-import com.velocitypowered.api.event.proxy.ProxyReloadEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.Player;
@@ -74,11 +73,6 @@ public final class VelocityBridgePlugin {
 
   @Subscribe
   public void handleProxyShutdown(@NonNull ProxyShutdownEvent event) {
-    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
-  }
-
-  @Subscribe
-  public void handleProxyReload(@NonNull ProxyReloadEvent event) {
     ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgePlugin.java
@@ -19,10 +19,13 @@ package eu.cloudnetservice.modules.bridge.platform.velocity;
 import com.google.inject.Inject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyReloadEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.velocity.commands.VelocityCloudCommand;
 import eu.cloudnetservice.modules.bridge.platform.velocity.commands.VelocityHubCommand;
@@ -67,5 +70,15 @@ public final class VelocityBridgePlugin {
         new VelocityHubCommand(this.proxy, management),
         names.length > 1 ? Arrays.copyOfRange(names, 1, names.length) : new String[0]);
     }
+  }
+
+  @Subscribe
+  public void handleProxyShutdown(@NonNull ProxyShutdownEvent event) {
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
+  }
+
+  @Subscribe
+  public void handleProxyReload(@NonNull ProxyReloadEvent event) {
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgePlugin.java
@@ -19,6 +19,7 @@ package eu.cloudnetservice.modules.bridge.platform.waterdog;
 import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 import dev.waterdog.waterdogpe.plugin.Plugin;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.waterdog.command.WaterDogPECloudCommand;
 import eu.cloudnetservice.modules.bridge.platform.waterdog.command.WaterDogPEHubCommand;
@@ -52,5 +53,10 @@ public final class WaterDogPEBridgePlugin extends Plugin {
         names[0],
         names.length > 1 ? Arrays.copyOfRange(names, 1, names.length) : new String[0]));
     }
+  }
+
+  @Override
+  public void onDisable() {
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
@@ -17,10 +17,10 @@
 package eu.cloudnetservice.modules.cloudperms.bukkit;
 
 import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.cloudperms.PermissionsUpdateListener;
 import eu.cloudnetservice.modules.cloudperms.bukkit.listener.BukkitCloudPermissionsPlayerListener;
 import eu.cloudnetservice.modules.cloudperms.bukkit.vault.VaultSupport;
-import eu.cloudnetservice.wrapper.Wrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -49,8 +49,7 @@ public final class BukkitCloudPermissionsPlugin extends JavaPlugin {
 
   @Override
   public void onDisable() {
-    CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
-    Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 
   private void checkForVault() {

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlugin.java
@@ -17,7 +17,7 @@
 package eu.cloudnetservice.modules.cloudperms.bungee;
 
 import eu.cloudnetservice.driver.CloudNetDriver;
-import eu.cloudnetservice.wrapper.Wrapper;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import net.md_5.bungee.api.plugin.Plugin;
 
 public final class BungeeCloudPermissionsPlugin extends Plugin {
@@ -31,7 +31,6 @@ public final class BungeeCloudPermissionsPlugin extends Plugin {
 
   @Override
   public void onDisable() {
-    CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
-    Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/MinestomCloudPermissionsExtension.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/MinestomCloudPermissionsExtension.java
@@ -18,9 +18,9 @@ package eu.cloudnetservice.modules.cloudperms.minestom;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.cloudperms.PermissionsUpdateListener;
 import eu.cloudnetservice.modules.cloudperms.minestom.listener.MinestomCloudPermissionsPlayerListener;
-import eu.cloudnetservice.wrapper.Wrapper;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.fakeplayer.FakePlayer;
@@ -53,6 +53,6 @@ public final class MinestomCloudPermissionsExtension extends Extension {
 
   @Override
   public void terminate() {
-    Wrapper.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPlugin.java
@@ -20,9 +20,9 @@ import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.plugin.PluginBase;
 import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.cloudperms.PermissionsUpdateListener;
 import eu.cloudnetservice.modules.cloudperms.nukkit.listener.NukkitCloudPermissionsPlayerListener;
-import eu.cloudnetservice.wrapper.Wrapper;
 
 public final class NukkitCloudPermissionsPlugin extends PluginBase {
 
@@ -43,8 +43,7 @@ public final class NukkitCloudPermissionsPlugin extends PluginBase {
 
   @Override
   public void onDisable() {
-    CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
-    Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 
   private void injectPlayersCloudPermissible() {

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongeCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongeCloudPermissionsPlugin.java
@@ -18,6 +18,7 @@ package eu.cloudnetservice.modules.cloudperms.sponge;
 
 import com.google.inject.Inject;
 import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.cloudperms.PermissionsUpdateListener;
 import eu.cloudnetservice.modules.cloudperms.sponge.service.CloudPermsPermissionService;
 import lombok.NonNull;
@@ -28,6 +29,7 @@ import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.lifecycle.ConstructPluginEvent;
 import org.spongepowered.api.event.lifecycle.ProvideServiceEvent;
 import org.spongepowered.api.event.lifecycle.StartingEngineEvent;
+import org.spongepowered.api.event.lifecycle.StoppingEngineEvent;
 import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.plugin.PluginContainer;
 import org.spongepowered.plugin.builtin.jvm.Plugin;
@@ -59,6 +61,11 @@ public final class SpongeCloudPermissionsPlugin {
       ServerPlayer::uniqueId,
       uuid -> Sponge.server().player(uuid).orElse(null),
       Sponge.server()::onlinePlayers));
+  }
+
+  @Listener
+  public void handle(@NonNull StoppingEngineEvent<Server> event) {
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 
   @Listener

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
@@ -19,13 +19,14 @@ package eu.cloudnetservice.modules.cloudperms.velocity;
 import com.google.inject.Inject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyReloadEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.cloudperms.velocity.listener.VelocityCloudPermissionsPlayerListener;
-import eu.cloudnetservice.wrapper.Wrapper;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -58,9 +59,13 @@ public final class VelocityCloudNetCloudPermissionsPlugin {
   }
 
   @Subscribe
+  public void handleReload(ProxyReloadEvent event) {
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
+  }
+
+  @Subscribe
   public void handleShutdown(ProxyShutdownEvent event) {
-    CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
-    Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 
   private void initPlayersPermissionFunction() {

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.modules.cloudperms.velocity;
 import com.google.inject.Inject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
-import com.velocitypowered.api.event.proxy.ProxyReloadEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.Player;
@@ -56,11 +55,6 @@ public final class VelocityCloudNetCloudPermissionsPlugin {
       this.proxyServer,
       new VelocityCloudPermissionProvider(CloudNetDriver.instance().permissionManagement()),
       CloudNetDriver.instance().permissionManagement()));
-  }
-
-  @Subscribe
-  public void handleReload(ProxyReloadEvent event) {
-    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 
   @Subscribe

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/waterdogpe/WaterdogPECloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/waterdogpe/WaterdogPECloudPermissionsPlugin.java
@@ -18,7 +18,7 @@ package eu.cloudnetservice.modules.cloudperms.waterdogpe;
 
 import dev.waterdog.waterdogpe.plugin.Plugin;
 import eu.cloudnetservice.driver.CloudNetDriver;
-import eu.cloudnetservice.wrapper.Wrapper;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 
 public class WaterdogPECloudPermissionsPlugin extends Plugin {
 
@@ -29,7 +29,6 @@ public class WaterdogPECloudPermissionsPlugin extends Plugin {
 
   @Override
   public void onDisable() {
-    CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
-    Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/bungeecord/BungeeCordLabyModPlugin.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/bungeecord/BungeeCordLabyModPlugin.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.modules.labymod.platform.bungeecord;
 
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.labymod.platform.PlatformLabyModListener;
 import eu.cloudnetservice.modules.labymod.platform.PlatformLabyModManagement;
 import eu.cloudnetservice.wrapper.Wrapper;
@@ -37,7 +38,6 @@ public class BungeeCordLabyModPlugin extends Plugin {
   @Override
   public void onDisable() {
     // unregister all listeners for cloudnet events
-    Wrapper.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
-    Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModPlugin.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModPlugin.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.modules.labymod.platform.velocity;
 import com.google.inject.Inject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
-import com.velocitypowered.api.event.proxy.ProxyReloadEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
@@ -68,10 +67,4 @@ public class VelocityLabyModPlugin {
     // unregister all listeners for cloudnet events
     ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
-
-  @Subscribe
-  public void handleProxyReload(@NonNull ProxyReloadEvent event) {
-    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
-  }
-
 }

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModPlugin.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModPlugin.java
@@ -19,11 +19,13 @@ package eu.cloudnetservice.modules.labymod.platform.velocity;
 import com.google.inject.Inject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyReloadEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.messages.LegacyChannelIdentifier;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.labymod.LabyModManagement;
 import eu.cloudnetservice.modules.labymod.platform.PlatformLabyModListener;
 import eu.cloudnetservice.modules.labymod.platform.PlatformLabyModManagement;
@@ -64,8 +66,12 @@ public class VelocityLabyModPlugin {
   @Subscribe
   public void handleProxyShutdown(@NonNull ProxyShutdownEvent event) {
     // unregister all listeners for cloudnet events
-    Wrapper.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
-    Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
+  }
+
+  @Subscribe
+  public void handleProxyReload(@NonNull ProxyReloadEvent event) {
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 
 }

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.modules.npc.platform.bukkit;
 
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.npc.platform.bukkit.command.NPCCommand;
 import eu.cloudnetservice.modules.npc.platform.bukkit.listener.BukkitEntityProtectionListener;
 import eu.cloudnetservice.modules.npc.platform.bukkit.listener.BukkitFunctionalityListener;
@@ -43,5 +44,10 @@ public final class BukkitNPCPlugin extends JavaPlugin {
       command.setExecutor(executor);
       command.setTabCompleter(executor);
     }
+  }
+
+  @Override
+  public void onDisable() {
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/CloudNetSignsModule.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/CloudNetSignsModule.java
@@ -78,7 +78,6 @@ public class CloudNetSignsModule extends DriverModule {
   @ModuleTask(order = 40, event = ModuleLifeCycle.STOPPED)
   public void handleStopping() throws Exception {
     this.database.close();
-    Node.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
   }
 
   @ModuleTask(event = ModuleLifeCycle.RELOADING)

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignsPlugin.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignsPlugin.java
@@ -17,9 +17,8 @@
 package eu.cloudnetservice.modules.signs.platform.bukkit;
 
 import eu.cloudnetservice.driver.CloudNetDriver;
-import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.signs.SharedChannelMessageListener;
-import eu.cloudnetservice.modules.signs.SignManagement;
 import eu.cloudnetservice.modules.signs.platform.SignsPlatformListener;
 import eu.cloudnetservice.modules.signs.platform.bukkit.functionality.SignInteractListener;
 import eu.cloudnetservice.modules.signs.platform.bukkit.functionality.SignsCommand;
@@ -50,7 +49,6 @@ public class BukkitSignsPlugin extends JavaPlugin {
 
   @Override
   public void onDisable() {
-    ServiceRegistry.first(SignManagement.class).unregisterFromServiceRegistry();
-    CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignsExtension.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignsExtension.java
@@ -17,6 +17,7 @@
 package eu.cloudnetservice.modules.signs.platform.minestom;
 
 import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.signs.SharedChannelMessageListener;
 import eu.cloudnetservice.modules.signs.platform.SignsPlatformListener;
 import eu.cloudnetservice.modules.signs.platform.minestom.functionality.SignInteractListener;
@@ -43,6 +44,6 @@ public class MinestomSignsExtension extends Extension {
 
   @Override
   public void terminate() {
-
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignsPlugin.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignsPlugin.java
@@ -20,9 +20,8 @@ import cn.nukkit.Server;
 import cn.nukkit.command.PluginCommand;
 import cn.nukkit.plugin.PluginBase;
 import eu.cloudnetservice.driver.CloudNetDriver;
-import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.signs.SharedChannelMessageListener;
-import eu.cloudnetservice.modules.signs.SignManagement;
 import eu.cloudnetservice.modules.signs.platform.SignsPlatformListener;
 import eu.cloudnetservice.modules.signs.platform.nukkit.functionality.SignInteractListener;
 import eu.cloudnetservice.modules.signs.platform.nukkit.functionality.SignsCommand;
@@ -49,7 +48,6 @@ public class NukkitSignsPlugin extends PluginBase {
 
   @Override
   public void onDisable() {
-    ServiceRegistry.first(SignManagement.class).unregisterFromServiceRegistry();
-    CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignsPlugin.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignsPlugin.java
@@ -18,9 +18,8 @@ package eu.cloudnetservice.modules.signs.platform.sponge;
 
 import com.google.inject.Inject;
 import eu.cloudnetservice.driver.CloudNetDriver;
-import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.signs.SharedChannelMessageListener;
-import eu.cloudnetservice.modules.signs.SignManagement;
 import eu.cloudnetservice.modules.signs.platform.PlatformSignManagement;
 import eu.cloudnetservice.modules.signs.platform.SignsPlatformListener;
 import eu.cloudnetservice.modules.signs.platform.sponge.functionality.SignInteractListener;
@@ -66,8 +65,7 @@ public class SpongeSignsPlugin {
 
   @Listener
   public void handleShutdown(@NonNull StoppingEngineEvent<Server> event) {
-    ServiceRegistry.first(SignManagement.class).unregisterFromServiceRegistry();
-    CloudNetDriver.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 
   @Listener

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyPlugin.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyPlugin.java
@@ -16,32 +16,28 @@
 
 package eu.cloudnetservice.modules.syncproxy.platform.bungee;
 
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.syncproxy.platform.listener.SyncProxyCloudListener;
 import eu.cloudnetservice.wrapper.Wrapper;
 import net.md_5.bungee.api.plugin.Plugin;
 
 public final class BungeeCordSyncProxyPlugin extends Plugin {
 
-  private BungeeCordSyncProxyManagement syncProxyManagement;
-
   @Override
   public void onEnable() {
-    this.syncProxyManagement = new BungeeCordSyncProxyManagement(this);
+    var syncProxyManagement = new BungeeCordSyncProxyManagement(this);
     // register the SyncProxyManagement in our service registry
-    this.syncProxyManagement.registerService(Wrapper.instance().serviceRegistry());
+    syncProxyManagement.registerService(Wrapper.instance().serviceRegistry());
     // register the event listener to handle service updates
-    Wrapper.instance().eventManager().registerListener(new SyncProxyCloudListener<>(this.syncProxyManagement));
+    Wrapper.instance().eventManager().registerListener(new SyncProxyCloudListener<>(syncProxyManagement));
     // register the bungeecord ping and join listener
     this.getProxy().getPluginManager()
-      .registerListener(this, new BungeeCordSyncProxyListener(this.syncProxyManagement));
+      .registerListener(this, new BungeeCordSyncProxyListener(syncProxyManagement));
   }
 
   @Override
   public void onDisable() {
     // unregister all listeners for cloudnet events
-    Wrapper.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
-    Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
-    // remove the service from the registry
-    this.syncProxyManagement.unregisterService(Wrapper.instance().serviceRegistry());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyPlugin.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyPlugin.java
@@ -17,30 +17,26 @@
 package eu.cloudnetservice.modules.syncproxy.platform.waterdog;
 
 import dev.waterdog.waterdogpe.plugin.Plugin;
+import eu.cloudnetservice.driver.util.ModuleUtil;
 import eu.cloudnetservice.modules.syncproxy.platform.listener.SyncProxyCloudListener;
 import eu.cloudnetservice.wrapper.Wrapper;
 
 public final class WaterDogPESyncProxyPlugin extends Plugin {
 
-  private WaterDogPESyncProxyManagement syncProxyManagement;
-
   @Override
   public void onEnable() {
-    this.syncProxyManagement = new WaterDogPESyncProxyManagement(this.getProxy());
+    var syncProxyManagement = new WaterDogPESyncProxyManagement(this.getProxy());
     // register the SyncProxyManagement in our service registry
-    this.syncProxyManagement.registerService(Wrapper.instance().serviceRegistry());
+    syncProxyManagement.registerService(Wrapper.instance().serviceRegistry());
     // register the event listener to handle service updates
-    Wrapper.instance().eventManager().registerListener(new SyncProxyCloudListener<>(this.syncProxyManagement));
+    Wrapper.instance().eventManager().registerListener(new SyncProxyCloudListener<>(syncProxyManagement));
     // register the waterdog ping & join listener
-    new WaterDogPESyncProxyListener(this.syncProxyManagement, this.getProxy());
+    new WaterDogPESyncProxyListener(syncProxyManagement, this.getProxy());
   }
 
   @Override
   public void onDisable() {
     // unregister all listeners for cloudnet events
-    Wrapper.instance().eventManager().unregisterListeners(this.getClass().getClassLoader());
-    Wrapper.instance().unregisterPacketListenersByClassLoader(this.getClass().getClassLoader());
-    // remove the service from the registry
-    this.syncProxyManagement.unregisterService(Wrapper.instance().serviceRegistry());
+    ModuleUtil.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/module/NodeModuleProviderHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/NodeModuleProviderHandler.java
@@ -58,6 +58,8 @@ public final class NodeModuleProviderHandler extends DefaultModuleProviderHandle
     DefaultObjectMapper.DEFAULT_MAPPER.unregisterBindings(moduleWrapper.classLoader());
     // unregister all language files
     I18n.unregisterLanguageFiles(moduleWrapper.classLoader());
+    // unregister all services from the service registry
+    this.nodeInstance.serviceRegistry().unregisterAll(moduleWrapper.classLoader());
   }
 
   private void removeListeners(@NonNull Collection<NetworkChannel> channels, @NonNull ClassLoader loader) {

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
@@ -348,21 +348,6 @@ public class Wrapper extends CloudNetDriver {
   }
 
   /**
-   * Removes all packet listeners which were loaded by the given class loaders from the network client packet registry
-   * and the packet registry of all client connections.
-   *
-   * @param classLoader the loader of the listener classes to unregister.
-   * @throws NullPointerException if the given class loader is null.
-   */
-  public void unregisterPacketListenersByClassLoader(@NonNull ClassLoader classLoader) {
-    this.networkClient.packetRegistry().removeListeners(classLoader);
-
-    for (var channel : this.networkClient.channels()) {
-      channel.packetRegistry().removeListeners(classLoader);
-    }
-  }
-
-  /**
    * Connects this wrapper with the node which started this service, allowing a maximum of 30 seconds for the connection
    * to establish completely (including the node authorization process).
    * <p>


### PR DESCRIPTION
### Motivation
Currently not all of our plugins unregister everything they register on the start leading to problems when they are reloaded.

### Modifications
Added a util method to unregister everything and call it when disabling the plugins.

### Result
All plugins unregister their stuff.