### PR TITLE
feat: allow service creation retries

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceDeferredStateEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceDeferredStateEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.event.events.service;
+
+import eu.cloudnetservice.driver.event.events.DriverEvent;
+import eu.cloudnetservice.driver.service.ServiceCreateResult;
+import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
+import java.util.UUID;
+import lombok.NonNull;
+
+public final class CloudServiceDeferredStateEvent extends DriverEvent {
+
+  private final UUID creationId;
+  private final ServiceCreateResult createResult;
+
+  public CloudServiceDeferredStateEvent(@NonNull UUID creationId, @NonNull ServiceCreateResult createResult) {
+    this.creationId = creationId;
+    this.createResult = createResult;
+  }
+
+  public @NonNull UUID deferredCreationId() {
+    return this.creationId;
+  }
+
+  public @NonNull ServiceCreateResult.State state() {
+    return this.createResult.state();
+  }
+
+  public @NonNull ServiceInfoSnapshot createdService() {
+    return this.createResult.serviceInfo();
+  }
+
+  public @NonNull ServiceCreateResult serviceCreateResult() {
+    return this.createResult;
+  }
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceDeferredStateEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceDeferredStateEvent.java
@@ -22,28 +22,66 @@ import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import java.util.UUID;
 import lombok.NonNull;
 
+/**
+ * An event which gets called when a deferred service creation gets a state update, either by successfully creating the
+ * service or by failing if the maximum retry count is reached.
+ * <p>
+ * This event is only called on all channel message receivers which were defined previously.
+ *
+ * @since 4.0
+ */
 public final class CloudServiceDeferredStateEvent extends DriverEvent {
 
   private final UUID creationId;
   private final ServiceCreateResult createResult;
 
+  /**
+   * Constructs a new deferred state event instance.
+   *
+   * @param creationId   the id submitted in the initial result of the service creation.
+   * @param createResult the result of the creation process.
+   * @throws NullPointerException if the given creation id or result is null.
+   */
   public CloudServiceDeferredStateEvent(@NonNull UUID creationId, @NonNull ServiceCreateResult createResult) {
     this.creationId = creationId;
     this.createResult = createResult;
   }
 
+  /**
+   * Get the id of the deferred result this event is associated with. The same id was given in the service create result
+   * with the {@code DEFERRED} state.
+   *
+   * @return the creation id of the deferred service.
+   */
   public @NonNull UUID deferredCreationId() {
     return this.creationId;
   }
 
+  /**
+   * Get the state of the service creation. Equivalent to {@code serviceCreateResult().state()}.
+   *
+   * @return the state of the service creation.
+   */
   public @NonNull ServiceCreateResult.State state() {
     return this.createResult.state();
   }
 
+  /**
+   * Get the underlying service of the service result. This method throws an exception if the state of the creation is
+   * not {@code CREATED}. Equivalent to {@code serviceCreateResult().createdService()}.
+   *
+   * @return the underlying service of the service result.
+   * @throws IllegalStateException if the underlying result was not completed successfully.
+   */
   public @NonNull ServiceInfoSnapshot createdService() {
     return this.createResult.serviceInfo();
   }
 
+  /**
+   * Get the raw underlying create result.
+   *
+   * @return the raw underlying create result.
+   */
   public @NonNull ServiceCreateResult serviceCreateResult() {
     return this.createResult;
   }

--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceFactory.java
@@ -19,9 +19,8 @@ package eu.cloudnetservice.driver.provider;
 import eu.cloudnetservice.common.concurrent.Task;
 import eu.cloudnetservice.driver.network.rpc.annotation.RPCValidation;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
-import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
+import eu.cloudnetservice.driver.service.ServiceCreateResult;
 import lombok.NonNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * The main factory class to create cloud services based on a given service configuration. This factory is designed to
@@ -55,7 +54,8 @@ public interface CloudServiceFactory {
    * Creates and prepares a new cloud service based on the given configuration. This method can be called with the same
    * configuration multiple times and will always (if the service was created successfully) in a different result.
    * <p>
-   * This method will return null if the service could not get created. This can happen (for example) if:
+   * This method will return a result with the state set to {@code FAILED} if the service could not get created. This
+   * can happen (for example) if:
    * <ol>
    *   <li>no node in the cluster can currently pick up the service (for example if all nodes are draining).
    *   <li>the configured node in the configuration is not connected or draining.
@@ -63,12 +63,15 @@ public interface CloudServiceFactory {
    * </ol>
    * This list only includes some common reasons for the service not getting created. Not that there is never a
    * guarantee that the method returns a (non-null) service result.
+   * <p>
+   * The result of the service creation will only have a state of {@code DEFERRED} if a retry configuration was provided
+   * to the given service configuration.
    *
    * @param serviceConfiguration the configuration to base the newly created service on.
-   * @return a snapshot of the newly created service, can be null if the service was not created successfully.
+   * @return a result representing the state of the service creation.
    * @throws NullPointerException if the given service configuration is null.
    */
-  @Nullable ServiceInfoSnapshot createCloudService(@NonNull ServiceConfiguration serviceConfiguration);
+  @NonNull ServiceCreateResult createCloudService(@NonNull ServiceConfiguration serviceConfiguration);
 
   /**
    * Creates and prepares a new cloud service based on the given configuration. This method can be called with the same
@@ -83,12 +86,15 @@ public interface CloudServiceFactory {
    * </ol>
    * This list only includes some common reasons for the service not getting created. Not that there is never a
    * guarantee that the method returns a (non-null) service result.
+   * <p>
+   * The result of the service creation will only have a state of {@code DEFERRED} if a retry configuration was provided
+   * to the given service configuration.
    *
    * @param configuration the configuration to base the newly created service on.
-   * @return a task completed with a snapshot of the newly created service or null if the service was not created.
+   * @return a task completed with a result representing the state of the service creation.
    * @throws NullPointerException if the given service configuration is null.
    */
-  default @NonNull Task<ServiceInfoSnapshot> createCloudServiceAsync(@NonNull ServiceConfiguration configuration) {
+  default @NonNull Task<ServiceCreateResult> createCloudServiceAsync(@NonNull ServiceConfiguration configuration) {
     return Task.supply(() -> this.createCloudService(configuration));
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
@@ -119,6 +119,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
 
   protected final ServiceId serviceId;
   protected final ProcessConfiguration processConfig;
+  protected final ServiceCreateRetryConfiguration retryConfiguration;
 
   protected final int port;
   protected final String runtime;
@@ -136,6 +137,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
    *
    * @param serviceId             the id of the service to create based on the configuration.
    * @param processConfig         the process configuration of the service which gets created.
+   * @param retryConfiguration    the service create retry configuration to apply if the initial service create fails.
    * @param port                  the port of the service to start with, might get increased when already taken.
    * @param runtime               the runtime of the service to create it based on, for example {@code jvm}.
    * @param hostAddress           the host address the service based on this configuration is bound to.
@@ -153,6 +155,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
   protected ServiceConfiguration(
     @NonNull ServiceId serviceId,
     @NonNull ProcessConfiguration processConfig,
+    @NonNull ServiceCreateRetryConfiguration retryConfiguration,
     int port,
     @NonNull String runtime,
     @Nullable String hostAddress,
@@ -177,6 +180,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
     this.staticService = staticService;
     this.processConfig = processConfig;
     this.groups = groups;
+    this.retryConfiguration = retryConfiguration;
     this.deletedFilesAfterStop = deletedFilesAfterStop;
   }
 
@@ -253,7 +257,8 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
       .templates(configuration.templates())
       .deployments(configuration.deployments())
       .inclusions(configuration.inclusions())
-      .properties(configuration.properties());
+      .properties(configuration.properties())
+      .retryConfiguration(configuration.retryConfiguration());
   }
 
   /**
@@ -266,6 +271,10 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
    */
   public @NonNull ServiceId serviceId() {
     return this.serviceId;
+  }
+
+  public @NonNull ServiceCreateRetryConfiguration retryConfiguration() {
+    return this.retryConfiguration;
   }
 
   /**
@@ -399,20 +408,20 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
   /**
    * Creates and prepares a service based on this configuration using the default cloud service factory.
    *
-   * @return a service snapshot of a service created based on this configuration, can be null.
+   * @return a result representing the state of the service creation.
    * @see CloudServiceFactory#createCloudService(ServiceConfiguration)
    */
-  public @Nullable ServiceInfoSnapshot createNewService() {
+  public @NonNull ServiceCreateResult createNewService() {
     return CloudNetDriver.instance().cloudServiceFactory().createCloudService(this);
   }
 
   /**
    * Creates and prepares a service based on this configuration using the default cloud service factory.
    *
-   * @return a task completed with a service snapshot of a service created based on this configuration.
+   * @return a task completed with a result representing the state of the service creation.
    * @see CloudServiceFactory#createCloudServiceAsync(ServiceConfiguration)
    */
-  public @NonNull Task<ServiceInfoSnapshot> createNewServiceAsync() {
+  public @NonNull Task<ServiceCreateResult> createNewServiceAsync() {
     return CloudNetDriver.instance().cloudServiceFactory().createCloudServiceAsync(this);
   }
 
@@ -437,6 +446,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
 
     protected ServiceId.Builder serviceId = ServiceId.builder();
     protected ProcessConfiguration.Builder processConfig = ProcessConfiguration.builder();
+    protected ServiceCreateRetryConfiguration retryConfiguration = ServiceCreateRetryConfiguration.NO_RETRY;
 
     protected String javaCommand;
     protected String hostAddress;
@@ -473,6 +483,11 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
      */
     public @NonNull Builder processConfig(@NonNull ProcessConfiguration.Builder processConfig) {
       this.processConfig = processConfig;
+      return this;
+    }
+
+    public @NonNull Builder retryConfiguration(@NonNull ServiceCreateRetryConfiguration retryConfiguration) {
+      this.retryConfiguration = retryConfiguration;
       return this;
     }
 
@@ -830,6 +845,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
       return new ServiceConfiguration(
         this.serviceId.build(),
         this.processConfig.build(),
+        this.retryConfiguration,
         this.port,
         this.runtime,
         this.hostAddress,

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
@@ -273,6 +273,13 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
     return this.serviceId;
   }
 
+  /**
+   * Get the creation retry configuration that will be applied to all services which are created based on the
+   * configuration. If the configuration is enabled and a service cannot get created, then the configuration will be
+   * used to retry the service creation.
+   *
+   * @return the retry configuration for services created using this configuration.
+   */
   public @NonNull ServiceCreateRetryConfiguration retryConfiguration() {
     return this.retryConfiguration;
   }
@@ -486,6 +493,15 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
       return this;
     }
 
+    /**
+     * Sets the creation retry configuration that will be applied to all services which are created based on the
+     * configuration. If the configuration is enabled and a service cannot get created, then the configuration will be
+     * used to retry the service creation.
+     *
+     * @param retryConfiguration the retry configuration to use.
+     * @return the same instance as used to call the method, for chaining.
+     * @throws NullPointerException if the given retry configuration is null.
+     */
     public @NonNull Builder retryConfiguration(@NonNull ServiceCreateRetryConfiguration retryConfiguration) {
       this.retryConfiguration = retryConfiguration;
       return this;

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
@@ -36,6 +36,10 @@ public record ServiceCreateResult(
     Preconditions.checkArgument(state != State.CREATED || serviceInfo != null);
   }
 
+  public static @NonNull ServiceCreateResult deferred(@NonNull UUID creationId) {
+    return new ServiceCreateResult(State.CREATED, creationId, null);
+  }
+
   public static @NonNull ServiceCreateResult created(@NonNull ServiceInfoSnapshot serviceInfo) {
     return new ServiceCreateResult(State.CREATED, serviceInfo.serviceId().uniqueId(), serviceInfo);
   }

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
@@ -21,14 +21,42 @@ import java.util.UUID;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Represents the result of a service creation. A result can have three states:
+ * <ol>
+ *   <li>CREATED: the service was created successfully, the service info is available via {@link #serviceInfo()}.
+ *   <li>DEFERRED: this state can only happen when a retry configuration was specified during the creation of the
+ *   service. In that case, the creation id of the result can be used to listen to
+ *   the {@link eu.cloudnetservice.driver.event.events.service.CloudServiceDeferredStateEvent} to catch updates
+ *   of the retries.
+ *   <li>FAILED: indicates that the service couldn't be created.
+ * </ol>
+ *
+ * @param state       the creation state of the service.
+ * @param creationId  the creation id of this result, if the state is not {@code FAILED}.
+ * @param serviceInfo the underlying service info, if the service was created successfully.
+ * @since 4.0
+ */
 public record ServiceCreateResult(
   @NonNull State state,
   @Nullable UUID creationId,
   @Nullable ServiceInfoSnapshot serviceInfo
 ) {
 
+  /**
+   * A static create result indicating that the service creation failed.
+   */
   public static final ServiceCreateResult FAILED = new ServiceCreateResult(State.FAILED, null, null);
 
+  /**
+   * Creates a new result instance.
+   *
+   * @param state       the creation state of the service.
+   * @param creationId  the creation id of this result, if the state is not {@code FAILED}.
+   * @param serviceInfo the underlying service info, if the service was created successfully.
+   * @throws NullPointerException     if the given state is null.
+   * @throws IllegalArgumentException if the creation id is missing or the service info depending on the given state.
+   */
   public ServiceCreateResult {
     // creation id must be present for deferred and created
     Preconditions.checkArgument(state == State.FAILED || creationId != null);
@@ -36,32 +64,78 @@ public record ServiceCreateResult(
     Preconditions.checkArgument(state != State.CREATED || serviceInfo != null);
   }
 
+  /**
+   * Creates a new result with the state set to deferred and using the given creation id.
+   *
+   * @param creationId the creation id for deferred service event updates.
+   * @return a new result instance.
+   * @throws NullPointerException if the given creation id is null.
+   */
   public static @NonNull ServiceCreateResult deferred(@NonNull UUID creationId) {
     return new ServiceCreateResult(State.DEFERRED, creationId, null);
   }
 
+  /**
+   * Creates a new result with the state set to created and using the given service info.
+   *
+   * @param serviceInfo the service info of the created service.
+   * @return a new result instance.
+   * @throws NullPointerException if the given service info is null.
+   */
   public static @NonNull ServiceCreateResult created(@NonNull ServiceInfoSnapshot serviceInfo) {
     return new ServiceCreateResult(State.CREATED, serviceInfo.serviceId().uniqueId(), serviceInfo);
   }
 
+  /**
+   * Get the creation id of this create result. If the service was created successfully, this id is set to the unique id
+   * of the service. If the creation was deferred the id is set to a unique notification id which can be used to
+   * identify the final creation result.
+   *
+   * @return the creation id of this service.
+   * @throws IllegalStateException if called when the state of this result is {@code FAILED}.
+   */
   @Override
   public @NonNull UUID creationId() {
     // we could check for state != State.FAILED as well, but then IJ gives a warning that creationId might be null
-    Preconditions.checkNotNull(this.creationId, "Cannot retrieve creationId for State.FAILED");
+    Preconditions.checkState(this.creationId != null, "Cannot retrieve creationId for State.FAILED");
     return this.creationId;
   }
 
+  /**
+   * Get the service info of the service which was created. This is only present if the state of this result is
+   * {@code CREATED}.
+   *
+   * @return the service info of the created service.
+   * @throws IllegalStateException if called when the state of this result is not {@code CREATED}.
+   */
   @Override
   public @NonNull ServiceInfoSnapshot serviceInfo() {
     // we could check for state == State.CREATED as well, but then IJ gives a warning that serviceInfo might be null
-    Preconditions.checkNotNull(this.serviceInfo, "Can only retrieve service info for State.CREATED");
+    Preconditions.checkState(this.serviceInfo != null, "Can only retrieve service info for State.CREATED");
     return this.serviceInfo;
   }
 
+  /**
+   * Represents the state of a service creation.
+   *
+   * @since 4.0
+   */
   public enum State {
 
+    /**
+     * The service was created successfully and is fully available for further actions.
+     */
     CREATED,
+    /**
+     * the service creation was deferred and retries to create the service will be made based on the supplied retry
+     * configuration. Updates of the creation will be sent to all subscribed channel message targets using the present
+     * creation id as an identifier for the service create.
+     */
     DEFERRED,
+    /**
+     * The service couldn't be created. Either no retry configuration was present and there was no successful creation
+     * possible, or the maximum retry count was reached without a successful creation.
+     */
     FAILED
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.service;
+
+import com.google.common.base.Preconditions;
+import java.util.UUID;
+import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
+
+public record ServiceCreateResult(
+  @NonNull State state,
+  @Nullable UUID creationId,
+  @Nullable ServiceInfoSnapshot serviceInfo
+) {
+
+  public static final ServiceCreateResult FAILED = new ServiceCreateResult(State.FAILED, null, null);
+
+  public ServiceCreateResult {
+    // creation id must be present for deferred and created
+    Preconditions.checkArgument(state == State.FAILED || creationId != null);
+    // created services must have a service information present
+    Preconditions.checkArgument(state != State.CREATED || serviceInfo != null);
+  }
+
+  public static @NonNull ServiceCreateResult created(@NonNull ServiceInfoSnapshot serviceInfo) {
+    return new ServiceCreateResult(State.CREATED, serviceInfo.serviceId().uniqueId(), serviceInfo);
+  }
+
+  @Override
+  public @NonNull UUID creationId() {
+    // we could check for state != State.FAILED as well, but then IJ gives a warning that creationId might be null
+    Preconditions.checkNotNull(this.creationId, "Cannot retrieve creationId for State.FAILED");
+    return this.creationId;
+  }
+
+  @Override
+  public @NonNull ServiceInfoSnapshot serviceInfo() {
+    // we could check for state == State.CREATED as well, but then IJ gives a warning that serviceInfo might be null
+    Preconditions.checkNotNull(this.serviceInfo, "Can only retrieve service info for State.CREATED");
+    return this.serviceInfo;
+  }
+
+  public enum State {
+
+    CREATED,
+    DEFERRED,
+    FAILED
+  }
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
@@ -37,7 +37,7 @@ public record ServiceCreateResult(
   }
 
   public static @NonNull ServiceCreateResult deferred(@NonNull UUID creationId) {
-    return new ServiceCreateResult(State.CREATED, creationId, null);
+    return new ServiceCreateResult(State.DEFERRED, creationId, null);
   }
 
   public static @NonNull ServiceCreateResult created(@NonNull ServiceInfoSnapshot serviceInfo) {

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateRetryConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateRetryConfiguration.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.service;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import eu.cloudnetservice.driver.channel.ChannelMessageTarget;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode(callSuper = false)
+public class ServiceCreateRetryConfiguration implements Cloneable {
+
+  public static final ServiceCreateRetryConfiguration NO_RETRY = new ServiceCreateRetryConfiguration(0, List.of(),
+    Map.of());
+
+  private final int maxRetries;
+  private final List<Long> backoffStrategy;
+  private final Map<ServiceCreateResult.State, List<ChannelMessageTarget>> eventReceivers;
+
+  protected ServiceCreateRetryConfiguration(
+    int maxRetries,
+    @NonNull List<Long> backoffStrategy,
+    @NonNull Map<ServiceCreateResult.State, List<ChannelMessageTarget>> eventReceivers
+  ) {
+    this.maxRetries = maxRetries;
+    this.backoffStrategy = backoffStrategy;
+    this.eventReceivers = eventReceivers;
+  }
+
+  public static @NonNull Builder builder() {
+    return new Builder();
+  }
+
+  public boolean enabled() {
+    return this.maxRetries >= 0 && !this.backoffStrategy.isEmpty();
+  }
+
+  public int maxRetries() {
+    return this.maxRetries;
+  }
+
+  public @NonNull List<Long> backoffStrategy() {
+    return this.backoffStrategy;
+  }
+
+  public @NonNull Map<ServiceCreateResult.State, List<ChannelMessageTarget>> eventReceivers() {
+    return this.eventReceivers;
+  }
+
+  @Override
+  public ServiceCreateRetryConfiguration clone() {
+    try {
+      return (ServiceCreateRetryConfiguration) super.clone();
+    } catch (CloneNotSupportedException exception) {
+      throw new IllegalStateException(); // cannot happen - just explode
+    }
+  }
+
+  public static final class Builder {
+
+    private int maxRetries = 0;
+    private List<Long> backoffStrategy = Lists.newArrayList(10_000L, 20_000L, 30_000L);
+    private Map<ServiceCreateResult.State, List<ChannelMessageTarget>> eventReceivers = new HashMap<>();
+
+    public @NonNull Builder maxRetries(int maxRetries) {
+      this.maxRetries = maxRetries;
+      return this;
+    }
+
+    public @NonNull Builder fixedRetryDelay(@NonNull Duration delay) {
+      this.backoffStrategy = Lists.newArrayList(delay.toMillis());
+      return this;
+    }
+
+    public @NonNull Builder backoffStrategy(@NonNull List<Duration> backoffStrategy) {
+      this.backoffStrategy = backoffStrategy.stream().map(Duration::toMillis).collect(Collectors.toList());
+      return this;
+    }
+
+    public @NonNull Builder notificationReceivers(@NonNull ChannelMessageTarget... receivers) {
+      return this
+        .notificationReceivers(ServiceCreateResult.State.CREATED, receivers)
+        .notificationReceivers(ServiceCreateResult.State.FAILED, receivers);
+    }
+
+    public @NonNull Builder notificationReceivers(
+      @NonNull ServiceCreateResult.State state,
+      @NonNull ChannelMessageTarget... receivers
+    ) {
+      this.eventReceivers.put(state, Arrays.asList(receivers));
+      return this;
+    }
+
+    public @NonNull Builder notificationReceivers(
+      @NonNull Map<ServiceCreateResult.State, List<ChannelMessageTarget>> eventReceivers
+    ) {
+      this.eventReceivers = new HashMap<>(Map.copyOf(eventReceivers));
+      return this;
+    }
+
+    public @NonNull ServiceCreateRetryConfiguration build() {
+      return new ServiceCreateRetryConfiguration(
+        this.maxRetries,
+        ImmutableList.copyOf(this.backoffStrategy),
+        Map.copyOf(this.eventReceivers));
+    }
+  }
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateRetryConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateRetryConfiguration.java
@@ -30,11 +30,23 @@ import java.util.function.Consumer;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+import org.jetbrains.annotations.Range;
+import org.jetbrains.annotations.Unmodifiable;
 
+/**
+ * A configuration applied when the initial creation of a service fails. The caller has the ability to specify how the
+ * retry of the service creation should be done. Additionally, if the service creation was deferred the further state
+ * changes will be published to the configured event receivers.
+ *
+ * @since 4.0
+ */
 @ToString
 @EqualsAndHashCode(callSuper = false)
 public class ServiceCreateRetryConfiguration implements Cloneable {
 
+  /**
+   * A jvm static retry configuration which will not retry failed service creations.
+   */
   public static final ServiceCreateRetryConfiguration NO_RETRY = new ServiceCreateRetryConfiguration(
     0,
     List.of(),
@@ -44,6 +56,14 @@ public class ServiceCreateRetryConfiguration implements Cloneable {
   private final List<Long> backoffStrategy;
   private final Map<ServiceCreateResult.State, List<ChannelMessageTarget>> eventReceivers;
 
+  /**
+   * Constructs a new retry configuration instance.
+   *
+   * @param maxRetries      the maximum amount of retries for the service creation.
+   * @param backoffStrategy the strategy to apply to delay the service creation based on executed times.
+   * @param eventReceivers  the receivers of state events if the creation was deferred.
+   * @throws NullPointerException if the given backoff strategy or event receivers are null.
+   */
   protected ServiceCreateRetryConfiguration(
     int maxRetries,
     @NonNull List<Long> backoffStrategy,
@@ -54,26 +74,78 @@ public class ServiceCreateRetryConfiguration implements Cloneable {
     this.eventReceivers = eventReceivers;
   }
 
+  /**
+   * Constructs a new builder instance for a retry configuration.
+   *
+   * @return a new retry configuration builder.
+   */
   public static @NonNull Builder builder() {
     return new Builder();
   }
 
-  public boolean enabled() {
-    return this.maxRetries >= 0 && !this.backoffStrategy.isEmpty();
+  /**
+   * Creates a new retry configuration builder which has the same options set as the given retry configuration. Changes
+   * made to the given configuration will not reflect into the new builder and vice-versa.
+   * <p>
+   * When calling build directly after creating the builder based on the given retry configuration it will return a
+   * retry configuration which is equal to the given one, but not identical.
+   *
+   * @param retryConfiguration the configuration to copy the set options of.
+   * @return a new builder instance which has the same options set as the given configuration.
+   * @throws NullPointerException if the given configuration is null.
+   */
+  public static @NonNull Builder builder(@NonNull ServiceCreateRetryConfiguration retryConfiguration) {
+    return builder()
+      .maxRetries(retryConfiguration.maxRetries())
+      .notificationReceivers(retryConfiguration.eventReceivers())
+      .backoffStrategy(retryConfiguration.backoffStrategy().stream().map(Duration::ofMillis).toList());
   }
 
+  /**
+   * Checks if this configuration is enabled, in other words if there is at least one retry and delay specified.
+   *
+   * @return if this configuration is enabled.
+   */
+  public boolean enabled() {
+    return this.maxRetries > 0 && !this.backoffStrategy.isEmpty();
+  }
+
+  /**
+   * Get the maximum number of retries until the retry process should stop. Negative values or zero indicate that no
+   * retry attempts should be made.
+   *
+   * @return the maximum number of retries.
+   */
   public int maxRetries() {
     return this.maxRetries;
   }
 
+  /**
+   * Get an unmodifiable copy of the backoff strategy which should be applied when retrying the service creation. An
+   * empty list indicates that no retry attempts should be made.
+   *
+   * @return the backoff strategy which should be applied when retrying the service creation.
+   */
+  @Unmodifiable
   public @NonNull List<Long> backoffStrategy() {
     return this.backoffStrategy;
   }
 
+  /**
+   * Get an unmodifiable copy of the event receivers which should get notified about state change events if the service
+   * creation was deferred. The listeners won't be called if the service creation succeeded or failed without any
+   * retries.
+   *
+   * @return the event receivers for deferred service state changes.
+   */
+  @Unmodifiable
   public @NonNull Map<ServiceCreateResult.State, List<ChannelMessageTarget>> eventReceivers() {
     return this.eventReceivers;
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public ServiceCreateRetryConfiguration clone() {
     try {
@@ -83,38 +155,102 @@ public class ServiceCreateRetryConfiguration implements Cloneable {
     }
   }
 
+  /**
+   * Represents a builder for a creation retry configuration.
+   *
+   * @since 4.0
+   */
   public static final class Builder {
 
-    private int maxRetries = 0;
-    private List<Duration> backoffStrategy = Lists.newArrayList(Duration.ofSeconds(15), Duration.ofSeconds(30));
+    private int maxRetries = 1;
+    private List<Duration> backoffStrategy = Lists.newArrayList(Duration.ofSeconds(15));
     private Map<ServiceCreateResult.State, List<ChannelMessageTarget>> eventReceivers = new HashMap<>();
 
-    public @NonNull Builder maxRetries(int maxRetries) {
+    /**
+     * Sets the maximum amount of times to retry the service creation. Only numbers higher than zero are accepted by the
+     * method.
+     * <p>
+     * If you want zero retries (or in other words no retries) use {@link ServiceCreateRetryConfiguration#NO_RETRY}
+     * instead.
+     *
+     * @param maxRetries the maximum amount of retries to do before marking the creation as failed.
+     * @return the same instance as used to call the method, for chaining.
+     * @throws IllegalArgumentException if the given max retries are lower or equal to zero.
+     */
+    public @NonNull Builder maxRetries(@Range(from = 1, to = Integer.MAX_VALUE) int maxRetries) {
+      Preconditions.checkArgument(maxRetries > 0, "Max retries must be > 0");
       this.maxRetries = maxRetries;
       return this;
     }
 
+    /**
+     * Sets the delay between each service creation retry to the given duration.
+     *
+     * @param delay the fixed delay between each service creation retry.
+     * @return the same instance as used to call the method, for chaining.
+     * @throws NullPointerException if the given retry duration is null.
+     */
     public @NonNull Builder fixedRetryDelay(@NonNull Duration delay) {
       this.backoffStrategy = Lists.newArrayList(delay);
       return this;
     }
 
+    /**
+     * Sets the backoff strategy when retrying a service creation. Each index in the given collection will be used for
+     * the retry delay, the first one as the initial delay before the first retry. If the retry count exceeds the
+     * entries in the given collection, a fixed retry delay based on the last index will be used for further retries.
+     *
+     * @param backoffStrategy the backoff strategy to apply when retrying a service creation.
+     * @return the same instance as used to call the method, for chaining.
+     * @throws NullPointerException if the given backoff strategy is null.
+     */
     public @NonNull Builder backoffStrategy(@NonNull Collection<Duration> backoffStrategy) {
       this.backoffStrategy = new ArrayList<>(backoffStrategy);
       return this;
     }
 
-    public @NonNull Builder modifyBackoffStrategy(@NonNull Consumer<Collection<Duration>> modifier) {
+    /**
+     * Modifies the backoff strategy which is currently applied to this builder.
+     *
+     * @param modifier the modifier to apply to the already added backoff entries of this builder.
+     * @return the same instance as used to call the method, for chaining.
+     * @throws NullPointerException if the given modifier function is null.
+     */
+    public @NonNull Builder modifyBackoffStrategy(@NonNull Consumer<List<Duration>> modifier) {
       modifier.accept(this.backoffStrategy);
       return this;
     }
 
+    /**
+     * Sets the receivers of state change events when a service creation which was deferred either succeeded or failed.
+     * The given targets will be notified about both these events. Already added receivers for one of the states will
+     * get overridden.
+     * <p>
+     * The event will not be called on the receivers if no retry was needed, therefore the service either got created
+     * instantly or the creation failed because no retry was specified.
+     *
+     * @param receivers the receivers for state event changes of deferred service creations.
+     * @return the same instance as used to call the method, for chaining.
+     * @throws NullPointerException if the given receivers are null.
+     */
     public @NonNull Builder notificationReceivers(@NonNull ChannelMessageTarget... receivers) {
       return this
         .notificationReceivers(ServiceCreateResult.State.CREATED, receivers)
         .notificationReceivers(ServiceCreateResult.State.FAILED, receivers);
     }
 
+    /**
+     * Sets the receivers of state change events when a service creation which was deferred reached the given target
+     * state of the service creation. Already added receivers for the same state will get overridden.
+     * <p>
+     * The event will not be called on the receivers if no retry was needed, therefore the service either got created
+     * instantly or the creation failed because no retry was specified.
+     *
+     * @param state     the state in which the deferred service creation must run in order to call the receivers.
+     * @param receivers the receivers for state event changes of deferred service creations.
+     * @return the same instance as used to call the method, for chaining.
+     * @throws NullPointerException if the given state or receivers are null.
+     */
     public @NonNull Builder notificationReceivers(
       @NonNull ServiceCreateResult.State state,
       @NonNull ChannelMessageTarget... receivers
@@ -123,6 +259,18 @@ public class ServiceCreateRetryConfiguration implements Cloneable {
       return this;
     }
 
+    /**
+     * Sets the event receivers for state changes. These are mapped in a state-to-receivers relation, meaning that all
+     * receivers for key state will be called when a deferred creation results in the state. Adding receivers for the
+     * {@code DEFERRED} state is acceptable but will be without effect.
+     * <p>
+     * The event will not be called on the receivers if no retry was needed, therefore the service either got created
+     * instantly or the creation failed because no retry was specified.
+     *
+     * @param eventReceivers the receivers mapping for state changes of deferred services.
+     * @return the same instance as used to call the method, for chaining.
+     * @throws NullPointerException if the given receiver mapping is null.
+     */
     public @NonNull Builder notificationReceivers(
       @NonNull Map<ServiceCreateResult.State, List<ChannelMessageTarget>> eventReceivers
     ) {
@@ -130,6 +278,12 @@ public class ServiceCreateRetryConfiguration implements Cloneable {
       return this;
     }
 
+    /**
+     * Builds a new retry configuration based on the previously supplied properties.
+     *
+     * @return a new retry configuration based on this builder.
+     * @throws IllegalArgumentException if the backoff strategy has no entries.
+     */
     public @NonNull ServiceCreateRetryConfiguration build() {
       Preconditions.checkArgument(!this.backoffStrategy.isEmpty(), "BackoffStrategy has no entries");
       return new ServiceCreateRetryConfiguration(

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceHelper.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceHelper.java
@@ -19,6 +19,7 @@ package eu.cloudnetservice.modules.bridge;
 import eu.cloudnetservice.common.unsafe.CPUUsageResolver;
 import eu.cloudnetservice.driver.CloudNetDriver;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
+import eu.cloudnetservice.driver.service.ServiceCreateResult;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceLifeCycle;
 import eu.cloudnetservice.wrapper.Wrapper;
@@ -75,7 +76,11 @@ public final class BridgeServiceHelper {
         .serviceTaskAsync(taskName)
         .thenApply(task -> ServiceConfiguration.builder(task).build())
         .thenApply(config -> CloudNetDriver.instance().cloudServiceFactory().createCloudService(config))
-        .thenAccept(service -> service.provider().start());
+        .thenAccept(createResult -> {
+          if (createResult.state() == ServiceCreateResult.State.CREATED) {
+            createResult.serviceInfo().provider().start();
+          }
+        });
     }
   }
 

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -2144,8 +2144,8 @@
                     "$ref" : "#/components/schemas/Success"
                   }, {
                     "properties" : {
-                      "snapshot" : {
-                        "$ref" : "#/components/schemas/ServiceInfoSnapshot"
+                      "result" : {
+                        "$ref" : "#/components/schemas/ServiceCreateResult"
                       }
                     }
                   } ]
@@ -4688,6 +4688,22 @@
             }
           }
         } ]
+      },
+      "ServiceCreateResult" : {
+        "type" : "object",
+        "properties" : {
+          "state" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "DEFERRED", "FAILED" ]
+          },
+          "creationId" : {
+            "type" : "string",
+            "example" : "43a9e824-cc3c-459b-b574-4f41e6509bda"
+          },
+          "serviceInfo" : {
+            "$ref" : "#/components/schemas/ServiceInfoSnapshot"
+          }
+        }
       },
       "HostAndPort" : {
         "type" : "object",

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetTickListener.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetTickListener.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.common.collection.Pair;
 import eu.cloudnetservice.driver.event.EventListener;
 import eu.cloudnetservice.driver.provider.CloudServiceFactory;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
+import eu.cloudnetservice.driver.service.ServiceCreateResult;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceLifeCycle;
 import eu.cloudnetservice.driver.service.ServiceTask;
@@ -194,9 +195,10 @@ public final class CloudNetTickListener {
       server = this.selectNodeServer(services);
     }
     // create a new service based on the task
-    return this.serviceFactory().createCloudService(ServiceConfiguration.builder(task)
+    var createResult = this.serviceFactory().createCloudService(ServiceConfiguration.builder(task)
       .node(server == null ? null : server.info().uniqueId())
       .build());
+    return createResult.state() == ServiceCreateResult.State.CREATED ? createResult.serviceInfo() : null;
   }
 
   private @Nullable NodeServer selectNodeServer(@NonNull Collection<ServiceInfoSnapshot> services) {

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/CreateCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/CreateCommand.java
@@ -25,6 +25,7 @@ import eu.cloudnetservice.common.JavaVersion;
 import eu.cloudnetservice.common.collection.Pair;
 import eu.cloudnetservice.common.language.I18n;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
+import eu.cloudnetservice.driver.service.ServiceCreateResult;
 import eu.cloudnetservice.driver.service.ServiceTask;
 import eu.cloudnetservice.node.Node;
 import eu.cloudnetservice.node.command.annotation.Description;
@@ -93,9 +94,9 @@ public final class CreateCommand {
     }
     // try to start the provided amount of services based on the configuration
     for (var i = 0; i < amount; i++) {
-      var service = configuration.createNewService();
+      var createResult = configuration.createNewService();
       // stop creating new services if the creation failed once
-      if (service == null) {
+      if (createResult.state() == ServiceCreateResult.State.FAILED) {
         source.sendMessage(I18n.trans("command-create-by-task-failed"));
         // stop the animation
         if (animation != null) {
@@ -104,8 +105,8 @@ public final class CreateCommand {
         return;
       }
       // start the service if requested
-      if (start) {
-        service.provider().start();
+      if (createResult.state() == ServiceCreateResult.State.CREATED && start) {
+        createResult.serviceInfo().provider().start();
       }
       // step the progress bar by one if given
       if (animation != null) {

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
@@ -27,6 +27,7 @@ import eu.cloudnetservice.driver.network.rpc.generation.GenerationContext;
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
 import eu.cloudnetservice.driver.provider.SpecificCloudServiceProvider;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
+import eu.cloudnetservice.driver.service.ServiceCreateResult;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceLifeCycle;
@@ -444,10 +445,12 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
       return prepared.first().provider();
     } else {
       // create a new service
-      var service = Node.instance()
+      var createResult = Node.instance()
         .cloudServiceFactory()
         .createCloudService(ServiceConfiguration.builder(task).build());
-      return service == null ? EmptySpecificCloudServiceProvider.INSTANCE : service.provider();
+      return createResult.state() != ServiceCreateResult.State.CREATED
+        ? EmptySpecificCloudServiceProvider.INSTANCE
+        : createResult.serviceInfo().provider();
     }
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
@@ -139,7 +139,7 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
       .get(5, TimeUnit.SECONDS, null);
 
     // read the result service info from the buffer, if the there was no response then we need to fail (only the head
-    // no should queue start requests)
+    // node should queue start requests)
     var createResult = result == null ? null : result.content().readObject(ServiceCreateResult.class);
     return Objects.requireNonNullElse(createResult, ServiceCreateResult.FAILED);
   }
@@ -206,7 +206,7 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
 
     // create a new result which indicates that the service create was deferred, including the id to which the
     // state events will be sent if the service gets created successfully later
-    return new ServiceCreateResult(ServiceCreateResult.State.DEFERRED, tracker.creationId(), null);
+    return ServiceCreateResult.deferred(tracker.creationId());
   }
 
   protected void includeGroupComponents(

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
@@ -108,7 +108,7 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
           var createResult = this.sendNodeServerStartRequest(
             "head_node_to_node_start_service",
             nodeServer.info().uniqueId(),
-            configurationBuilder.build());
+            serviceConfiguration);
           if (createResult.state() == ServiceCreateResult.State.CREATED) {
             // register the service locally in case the registration packet was not sent before a response to this
             // packet was received
@@ -122,7 +122,7 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
             serviceConfiguration);
         } else {
           // start on the current node
-          var serviceInfo = this.serviceManager.createLocalCloudService(configurationBuilder.build()).serviceInfo();
+          var serviceInfo = this.serviceManager.createLocalCloudService(serviceConfiguration).serviceInfo();
           return ServiceCreateResult.created(serviceInfo);
         }
       } finally {

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/ServiceCreateRetryTracker.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/ServiceCreateRetryTracker.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.node.service.defaults;
+
+import com.google.common.base.Preconditions;
+import eu.cloudnetservice.driver.channel.ChannelMessage;
+import eu.cloudnetservice.driver.network.buffer.DataBuf;
+import eu.cloudnetservice.driver.network.def.NetworkConstants;
+import eu.cloudnetservice.driver.provider.CloudServiceFactory;
+import eu.cloudnetservice.driver.service.ServiceConfiguration;
+import eu.cloudnetservice.driver.service.ServiceCreateResult;
+import eu.cloudnetservice.driver.service.ServiceCreateRetryConfiguration;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import lombok.NonNull;
+
+final class ServiceCreateRetryTracker implements Runnable {
+
+  private final UUID creationId;
+  private final ServiceConfiguration configuration;
+  private final ScheduledExecutorService retryExecutor;
+  private final CloudServiceFactory cloudServiceFactory;
+  private final ServiceCreateRetryConfiguration retryConfiguration;
+
+  private int retries = 0;
+
+  public ServiceCreateRetryTracker(
+    @NonNull ServiceConfiguration configuration,
+    @NonNull ScheduledExecutorService retryExecutor,
+    @NonNull CloudServiceFactory requestingFactory,
+    @NonNull ServiceCreateRetryConfiguration retryConfiguration
+  ) {
+    this.configuration = configuration;
+    this.retryExecutor = retryExecutor;
+    this.cloudServiceFactory = requestingFactory;
+    this.retryConfiguration = retryConfiguration;
+
+    this.creationId = UUID.randomUUID();
+  }
+
+  @Override
+  public void run() {
+    // try to create the service - the result can only fail or succeed, we removed the retry configuration previously
+    var createResult = this.cloudServiceFactory.createCloudService(this.configuration);
+    Preconditions.checkArgument(createResult.state() != ServiceCreateResult.State.DEFERRED);
+
+    if (createResult == ServiceCreateResult.FAILED) {
+      // increase the retry count and check if we should still go on with retrying to create the service
+      this.retries++;
+      if (this.shouldRetry()) {
+        this.retryExecutor.schedule(this, this.nextRetryDelay(), TimeUnit.MILLISECONDS);
+        return;
+      }
+    }
+
+    // ok, we reached the maximum retry count or the creation was successful - time to notify all listeners
+    this.notifyListeners(createResult);
+  }
+
+  public @NonNull UUID creationId() {
+    return this.creationId;
+  }
+
+  public long nextRetryDelay() {
+    // returns either the current backoff delay based on the retries or the last added backoff delay
+    var backoffStrategy = this.retryConfiguration.backoffStrategy();
+    return backoffStrategy.size() > this.retries
+      ? backoffStrategy.get(this.retries)
+      : backoffStrategy.get(backoffStrategy.size() - 1);
+  }
+
+  private boolean shouldRetry() {
+    return this.retries < this.retryConfiguration.maxRetries();
+  }
+
+  private void notifyListeners(@NonNull ServiceCreateResult createResult) {
+    // get all event listeners for the creation state, and notify them if there are any
+    var eventListeners = this.retryConfiguration.eventReceivers().get(createResult.state());
+    if (eventListeners != null && !eventListeners.isEmpty()) {
+      // build the base message and add all channel message targets
+      var messageBuilder = ChannelMessage.builder()
+        .message("deferred_service_event")
+        .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
+        .buffer(DataBuf.empty().writeUniqueId(this.creationId).writeObject(createResult));
+      eventListeners.forEach(messageBuilder::target);
+
+      // build the message and send it out
+      messageBuilder.build().send();
+    }
+  }
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/ServiceChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/ServiceChannelMessageListener.java
@@ -20,11 +20,13 @@ import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.event.EventListener;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.event.events.channel.ChannelMessageReceiveEvent;
+import eu.cloudnetservice.driver.event.events.service.CloudServiceDeferredStateEvent;
 import eu.cloudnetservice.driver.event.events.service.CloudServiceLifecycleChangeEvent;
 import eu.cloudnetservice.driver.event.events.service.CloudServiceLogEntryEvent;
 import eu.cloudnetservice.driver.event.events.service.CloudServiceUpdateEvent;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.def.NetworkConstants;
+import eu.cloudnetservice.driver.service.ServiceCreateResult;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceLifeCycle;
 import eu.cloudnetservice.wrapper.Wrapper;
@@ -80,6 +82,14 @@ public final class ServiceChannelMessageListener {
             : CloudServiceLogEntryEvent.StreamType.STDOUT;
 
           this.eventManager.callEvent(eventChannel, new CloudServiceLogEntryEvent(snapshot, line, type));
+        }
+
+        // a deferred service start result is available, call the event
+        case "deferred_service_event" -> {
+          var creationId = event.content().readUniqueId();
+          var createResult = event.content().readObject(ServiceCreateResult.class);
+
+          this.eventManager.callEvent(new CloudServiceDeferredStateEvent(creationId, createResult));
         }
 
         // none of our business


### PR DESCRIPTION
### Motivation
Currently there is no way for a plugin to automatically schedule the retry of a service creation if the initial request failed. 

### Modification
Added the possibility to specify a retry configuration in the service configuration which allows the retry of a service creation. The creation has a fixed amount of max retries (there is no way to schedule forever) and the possibility to backoff the service re-creation according to the current retry count.

Once the creation process suceeded, an event will be fired on previously added listeners for the state of the service creation. The deferred creation can be associated with the service by either using the creation id of the CreationResult or by (for example) adding a marker to the supplied service configuration when creating the service initially.

### Result
API users now have a much easier way to define how a service creation should be retried.