### PR TITLE
fix: Missing string

### DIFF
--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -289,6 +289,7 @@ command-tasks-setup-question-minservices=How many services of this task should b
 command-tasks-setup-question-name-splitter=What should the name splitter of the new task be?
 command-tasks-setup-question-name=What should the name of the new task be?
 command-tasks-setup-question-startport=What should be the start port of the task?
+command-tasks-setup-question-host-address=What is the host address of the task?
 command-tasks-setup-question-static=Should the services of this task be static that their files are never deleted?
 #
 # Command Template


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

Added a missing string in `tasks setup` (command-tasks-setup-question-host-address)
