### PR TITLE
fix(node): only allow actual files when trying to load a module

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ModulesCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ModulesCommand.java
@@ -97,9 +97,13 @@ public final class ModulesCommand {
     var path = this.provider.moduleDirectoryPath().resolve(fileName);
     // check if the file exists
     if (Files.notExists(path)) {
-      throw new ArgumentNotAvailableException(
-        I18n.trans("command-modules-module-file-not-found", fileName));
+      throw new ArgumentNotAvailableException(I18n.trans("command-modules-module-file-not-found", fileName));
     }
+    // dont allow directories
+    if (Files.isDirectory(path)) {
+      throw new ArgumentNotAvailableException(I18n.trans("command-modules-module-not-a-file", fileName));
+    }
+
     return path;
   }
 

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -223,6 +223,7 @@ command-modules-description=Manages installed modules and allows to load local o
 command-modules-install-missing-depend=The module {0$module$} requires these dependencies to run: {1$dependencies$}
 command-modules-module-already-loaded=The module {0$module$} is already loaded
 command-modules-module-file-not-found=The file {0$path$} does not exist
+command-modules-module-not-a-file={0$path$} is not a file
 command-modules-module-installed=The module {0$module$} was successfully installed
 command-module-skipping-checksum-fail=The checksum of the official module {0$module$} did not match but the validation was skipped!
 command-modules-checksum-validation-skippable=The module checksum of the official module {0$module$} did not match! (most likely your module definition is outdated, restart CloudNet to auto update them) You can install the module by appending "--ncv" to the command (! could lead to problems !)


### PR DESCRIPTION
### Motivation
Currently the module path parser successfully parses paths to a directory. But a directory is never a module and therefore can't get loaded.

### Modification
Check if the specified path points to a directory and if so abort the parsing process.

### Result
Only files are parsed sucessfully.