### PR TITLE
chore: correctly mark interrupted threads as interrupted

### DIFF
--- a/common/src/main/java/eu/cloudnetservice/common/log/defaults/ThreadedLogRecordDispatcher.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/defaults/ThreadedLogRecordDispatcher.java
@@ -105,5 +105,7 @@ public final class ThreadedLogRecordDispatcher extends Thread implements LogReco
     for (var logRecord : this.queue) {
       this.logger.forceLog(logRecord);
     }
+    // reset the interrupted state of the thread
+    Thread.currentThread().interrupt();
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
@@ -200,7 +200,7 @@ public final class NettyUtil {
       // await the future and rethrow exceptions if any occur
       return future.asStage().sync().future();
     } catch (InterruptedException exception) {
-      Thread.currentThread().interrupt(); // not much we can do
+      Thread.currentThread().interrupt(); // reset the interrupted state of the thread
       throw new IllegalThreadStateException();
     }
   }

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/DefaultRPC.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/DefaultRPC.java
@@ -183,7 +183,7 @@ public class DefaultRPC extends DefaultRPCProvider implements RPC {
     try {
       Task<T> queryTask = this.fire(component);
       return queryTask.get();
-    } catch (InterruptedException | ExecutionException exception) {
+    } catch (ExecutionException exception) {
       if (exception.getCause() instanceof RPCExecutionException executionException) {
         // may be thrown when the handler did throw an exception, just rethrow that one
         throw executionException;
@@ -191,6 +191,9 @@ public class DefaultRPC extends DefaultRPCProvider implements RPC {
         // any other exception should get wrapped
         throw new RPCException(this, exception);
       }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt(); // reset the interrupted state of the thread
+      throw new IllegalThreadStateException();
     }
   }
 

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/DefaultRPCChain.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/DefaultRPCChain.java
@@ -146,7 +146,7 @@ public class DefaultRPCChain extends DefaultRPCProvider implements RPCChain {
     try {
       Task<T> queryTask = this.fire(component);
       return queryTask.get();
-    } catch (InterruptedException | ExecutionException exception) {
+    } catch (ExecutionException exception) {
       if (exception.getCause() instanceof RPCExecutionException) {
         // may be thrown when the handler did throw an exception, just rethrow that one
         throw (RPCExecutionException) exception.getCause();
@@ -154,6 +154,9 @@ public class DefaultRPCChain extends DefaultRPCProvider implements RPCChain {
         // any other exception should get wrapped
         throw new RPCException(this, exception);
       }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt(); // reset the interrupted state of the thread
+      throw new IllegalThreadStateException();
     }
   }
 

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/ApplicationBootstrap.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/ApplicationBootstrap.java
@@ -109,7 +109,7 @@ final class ApplicationBootstrap {
               // well looks like it didn't terminate - try to force it and don't wait
               processHandle.destroyForcibly();
             } catch (InterruptedException exception) {
-              Thread.currentThread().interrupt(); // not much we can do
+              Thread.currentThread().interrupt(); // reset the interrupted state of the thread
             }
           }
         }));
@@ -124,7 +124,7 @@ final class ApplicationBootstrap {
         exception.printStackTrace();
         // CHECKSTYLE.ON
       } catch (InterruptedException exception) {
-        Thread.currentThread().interrupt(); // not much we can do
+        Thread.currentThread().interrupt(); // reset the interrupted state of the thread
       }
     }, "Application-Thread");
     thread.setDaemon(false);

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/CloudPermissionsHelper.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/CloudPermissionsHelper.java
@@ -47,10 +47,13 @@ public final class CloudPermissionsHelper {
     PermissionUser permissionUser;
     try {
       permissionUser = permissionsManagement.getOrCreateUserAsync(uniqueId, name).get(5, TimeUnit.SECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException exception) {
+    } catch (ExecutionException | TimeoutException exception) {
       LOGGER.severe("Error while loading permission user: " + uniqueId + "/" + name, exception);
       // disconnect the player now
       disconnectHandler.accept("§cAn internal error while loading your permission profile");
+      return;
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt(); // reset the interrupted state of the thread
       return;
     }
 

--- a/node/src/main/java/eu/cloudnetservice/node/console/ConsoleReadThread.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/ConsoleReadThread.java
@@ -34,7 +34,7 @@ public class ConsoleReadThread extends Thread {
   @Override
   public void run() {
     String line;
-    while (!Thread.interrupted() && (line = this.readLine()) != null) {
+    while (!Thread.currentThread().isInterrupted() && (line = this.readLine()) != null) {
       if (this.currentTask != null) {
         this.currentTask.complete(line);
         this.currentTask = null;

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/AbstractConsoleAnimation.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/AbstractConsoleAnimation.java
@@ -82,12 +82,13 @@ public abstract class AbstractConsoleAnimation implements Runnable {
     // move the input one down to keep the last line in the console
     this.console.forceWriteLine(System.lineSeparator());
     // run the animation as long as the animation needs to run
-    while (!Thread.interrupted() && !this.handleTick()) {
+    while (!Thread.currentThread().isInterrupted() && !this.handleTick()) {
       try {
         //noinspection BusyWait
         Thread.sleep(this.updateInterval);
       } catch (InterruptedException exception) {
-        LOGGER.severe("Exception while awaiting console update", exception);
+        Thread.currentThread().interrupt(); // reset the interrupted state of the thread
+        break;
       }
     }
   }

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/ConsoleSetupAnimation.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/ConsoleSetupAnimation.java
@@ -214,6 +214,7 @@ public class ConsoleSetupAnimation extends AbstractConsoleAnimation {
             LockSupport.unpark(runningThread);
           }
         } catch (InterruptedException exception) {
+          Thread.currentThread().interrupt(); // reset the interrupted state of the thread
           throw new RuntimeException("Console thread got interrupted during handling of response input", exception);
         }
       }
@@ -299,7 +300,8 @@ public class ConsoleSetupAnimation extends AbstractConsoleAnimation {
     try {
       Thread.sleep(1000);
     } catch (InterruptedException exception) {
-      LOGGER.severe("Exception while resetting console", exception);
+      Thread.currentThread().interrupt(); // reset the interrupted state of the thread
+      return;
     }
 
     // remove the setup from the screen


### PR DESCRIPTION
### Motivation
The interrupted state of a thread will be reset in case an InterruptedException is thrown. As we need catch these exceptions any upper layer of the method call is unable to respond to the interuption and `Thread.currentThread().isInterrupted()` will falsely return false.

### Modification
Call `Thread.currentThread().interrupt()` to mark threads as interrupted when catching an InterruptedException. This PR also removes the usages of `Thread.interrupted()` which check if a thread is interrupted but also resets the interrupted state of the thread.

### Result
No more accidental wrong marks of threads which should be marked as interrupted.

##### Other context
A bit more context is given (for example) here: https://dzone.com/articles/why-do-we-need-threadcurrentthreadinterrupt-in-int