### PR TITLE
ci: let build and tests run on zulu-19-ea as well.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: 17
           check-latest: true
           cache: 'gradle'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         java:
           - 17
-          - 20-ea
+          - 19-ea
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         java:
           - 17
-          - 18
+          - 20-ea
 
     steps:
       - name: Checkout repository
@@ -36,7 +36,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'gradle'


### PR DESCRIPTION
### Motivation
All tests should run on the latest lts version of java (currently 17) and the latest available version (currently 19-ea). The change of the distribution to zulu was needed as temurin had no 20-ea builds, but we're currently limited by mockito which only supports up to java 19. To make later updates easier the distribution should be zulu anyway.

### Modification
Use java 19-ea as the latest test version instead of 18, replaced temurin with zulu jdk distribution.

### Result
Faster updates to newer java versions & tests are running on jdk 19 which makes it easier to determine if we need to do something in order to support a newer java version.