### PR TITLE
fix(minestom): load guava using dumb minestom dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ sponge = "9.0.0"
 velocity = "3.1.1"
 waterdogpe = "1.1.10"
 nukkitX = "1.0-SNAPSHOT"
-minestom = "3821d204cf"
+minestom = "f5f323fef9"
 spigot = "1.8.8-R0.1-SNAPSHOT"
 bungeecord = "1.18-R0.1-SNAPSHOT"
 

--- a/modules/bridge/src/main/resources/extension.json
+++ b/modules/bridge/src/main/resources/extension.json
@@ -1,5 +1,16 @@
 {
   "name": "cloudnet_bridge",
   "version": "{project.build.version}",
-  "entrypoint": "eu.cloudnetservice.modules.bridge.platform.minestom.MinestomBridgeExtension"
+  "entrypoint": "eu.cloudnetservice.modules.bridge.platform.minestom.MinestomBridgeExtension",
+  "externalDependencies": {
+    "repositories": [
+      {
+        "name": "Central",
+        "url": "https://repo1.maven.org/maven2/"
+      }
+    ],
+    "artifacts": [
+      "com.google.guava:guava:31.1-jre"
+    ]
+  }
 }

--- a/modules/cloudperms/src/main/resources/extension.json
+++ b/modules/cloudperms/src/main/resources/extension.json
@@ -1,5 +1,16 @@
 {
   "name": "cloudnet_cloudperms",
   "version": "{project.build.version}",
-  "entrypoint": "eu.cloudnetservice.modules.cloudperms.minestom.MinestomCloudPermissionsExtension"
+  "entrypoint": "eu.cloudnetservice.modules.cloudperms.minestom.MinestomCloudPermissionsExtension",
+  "externalDependencies": {
+    "repositories": [
+      {
+        "name": "Central",
+        "url": "https://repo1.maven.org/maven2/"
+      }
+    ],
+    "artifacts": [
+      "com.google.guava:guava:31.1-jre"
+    ]
+  }
 }

--- a/plugins/simplenametags/src/main/resources/extension.json
+++ b/plugins/simplenametags/src/main/resources/extension.json
@@ -1,5 +1,8 @@
 {
   "name": "cloudnet_simplenametags",
   "version": "{project.build.version}",
-  "entrypoint": "eu.cloudnetservice.plugins.simplenametags.minestom.MinestomSimpleNameTagsExtension"
+  "entrypoint": "eu.cloudnetservice.plugins.simplenametags.minestom.MinestomSimpleNameTagsExtension",
+  "dependencies": [
+    "cloudnet_cloudperms"
+  ]
 }

--- a/wrapper-jvm/src/main/resources/META-INF/services/org.jboss.shrinkwrap.resolver.spi.format.FormatProcessor
+++ b/wrapper-jvm/src/main/resources/META-INF/services/org.jboss.shrinkwrap.resolver.spi.format.FormatProcessor
@@ -1,0 +1,1 @@
+org.jboss.shrinkwrap.resolver.impl.maven.format.MavenResolvedArtifactProcessor


### PR DESCRIPTION
### Motivation
Currently everybody that wants to use a Minestom implementation is forced to shade google-guava. As the dependency system of Minestom did not seem to work.

### Modification
Added the cloudperms dependency to simplenametags & chat. Furthermore added a new service loader file to point to the correct maven resolver.

### Result
Minestom dependency resolving works now and Minestom implementations are not forced to shade guava anymore.