### PR TITLE
chore: remove Glowstone support as it does not support Java 17

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
@@ -116,14 +116,6 @@ public class ServiceEnvironmentType extends JsonDocPropertyHolder implements Nam
     .properties(JsonDocument.newDocument().property(JAVA_SERVER, true).property(PLUGIN_DIR, "extensions"))
     .build();
   /**
-   * The default glowstone service environment type (Java Edition server).
-   */
-  public static final ServiceEnvironmentType GLOWSTONE = ServiceEnvironmentType.builder()
-    .name("GLOWSTONE")
-    .properties(JsonDocument.newDocument().property(JAVA_SERVER, true))
-    .build();
-
-  /**
    * The bungeecord service environment type, can also be any fork of bungeecord (Java Edition proxy).
    */
   public static final ServiceEnvironmentType BUNGEECORD = ServiceEnvironmentType.builder()

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
@@ -43,7 +43,6 @@ import eu.cloudnetservice.node.service.CloudServiceFactory;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import eu.cloudnetservice.node.service.ServiceConfigurationPreparer;
 import eu.cloudnetservice.node.service.defaults.config.BungeeConfigurationPreparer;
-import eu.cloudnetservice.node.service.defaults.config.GlowstoneConfigurationPreparer;
 import eu.cloudnetservice.node.service.defaults.config.NukkitConfigurationPreparer;
 import eu.cloudnetservice.node.service.defaults.config.VanillaServiceConfigurationPreparer;
 import eu.cloudnetservice.node.service.defaults.config.VelocityConfigurationPreparer;
@@ -102,7 +101,6 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
     this.addServicePreparer(ServiceEnvironmentType.NUKKIT, new NukkitConfigurationPreparer());
     this.addServicePreparer(ServiceEnvironmentType.VELOCITY, new VelocityConfigurationPreparer());
     this.addServicePreparer(ServiceEnvironmentType.BUNGEECORD, new BungeeConfigurationPreparer());
-    this.addServicePreparer(ServiceEnvironmentType.GLOWSTONE, new GlowstoneConfigurationPreparer());
     this.addServicePreparer(ServiceEnvironmentType.WATERDOG_PE, new WaterdogPEConfigurationPreparer());
     this.addServicePreparer(ServiceEnvironmentType.MINECRAFT_SERVER, new VanillaServiceConfigurationPreparer());
     this.addServicePreparer(ServiceEnvironmentType.MODDED_MINECRAFT_SERVER, new VanillaServiceConfigurationPreparer());

--- a/node/src/main/java/eu/cloudnetservice/node/template/listener/TemplatePrepareListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/template/listener/TemplatePrepareListener.java
@@ -75,12 +75,6 @@ public final class TemplatePrepareListener {
         var in = this.resourceStream("files/nms/server.properties");
         FileUtil.copy(in, out);
       }
-    } else if (event.environmentType().equals(ServiceEnvironmentType.GLOWSTONE)) {
-      // glowstone.yml
-      try (var out = event.storage().newOutputStream(event.template(), "config/glowstone.yml");
-        var in = this.resourceStream("files/glowstone/glowstone.yml")) {
-        FileUtil.copy(in, out);
-      }
     }
   }
 

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -479,29 +479,6 @@
       ]
     },
     {
-      "name": "glowstone",
-      "environmentType": "GLOWSTONE",
-      "website": "https://github.com/GlowstoneMC",
-      "installSteps": [
-        "DOWNLOAD"
-      ],
-      "versions": [
-        {
-          "name": "latest",
-          "url": "https://github.com/GlowstoneMC/Glowstone/releases/download/2021.8.0/glowstone.jar",
-          "cacheFiles": false
-        },
-        {
-          "name": "1.12.2",
-          "url": "https://github.com/GlowstoneMC/Glowstone/releases/download/2021.8.0/glowstone.jar"
-        },
-        {
-          "name": "1.8.9",
-          "url": "https://github.com/GlowstoneMC/Glowstone/releases/download/v1.8.9/glowstone.-1.8.9-SNAPSHOT.jar"
-        }
-      ]
-    },
-    {
       "name": "waterdogpe",
       "environmentType": "WATERDOG_PE",
       "website": "https://waterdog.dev",

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -32,14 +32,6 @@
       }
     },
     {
-      "name": "GLOWSTONE",
-      "defaultServiceStartPort": 44955,
-      "defaultProcessArguments": [],
-      "properties": {
-        "isJavaServer": true
-      }
-    },
-    {
       "name": "NUKKIT",
       "defaultServiceStartPort": 44955,
       "defaultProcessArguments": [


### PR DESCRIPTION
### Motivation
Currently we state that we support Glowstone by providing downloads in our installer but due to the usage of ASM6 in Glowstone we are unable to support it.

### Modification
Removed the Glowstone downloads and ServiceEnvironmentType.
### Result
Glowstone is not supported anymore (at least until they update to ASM9).