### PR TITLE
chore: remove unneeded wildcard type usages

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionSetGroupsEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionSetGroupsEvent.java
@@ -30,7 +30,7 @@ import lombok.NonNull;
  */
 public final class PermissionSetGroupsEvent extends PermissionEvent {
 
-  private final Collection<? extends PermissionGroup> groups;
+  private final Collection<PermissionGroup> groups;
 
   /**
    * Constructs a new permission event.
@@ -41,7 +41,7 @@ public final class PermissionSetGroupsEvent extends PermissionEvent {
    */
   public PermissionSetGroupsEvent(
     @NonNull PermissionManagement permissionManagement,
-    @NonNull Collection<? extends PermissionGroup> groups
+    @NonNull Collection<PermissionGroup> groups
   ) {
     super(permissionManagement);
     this.groups = groups;
@@ -52,7 +52,7 @@ public final class PermissionSetGroupsEvent extends PermissionEvent {
    *
    * @return all groups which were set during the update.
    */
-  public @NonNull Collection<? extends PermissionGroup> groups() {
+  public @NonNull Collection<PermissionGroup> groups() {
     return this.groups;
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionManagement.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionManagement.java
@@ -421,7 +421,7 @@ public interface PermissionManagement {
    *
    * @param groups the groups to add after clearing all other groups.
    */
-  void groups(@Nullable Collection<? extends PermissionGroup> groups);
+  void groups(@Nullable Collection<PermissionGroup> groups);
 
   /**
    * Gets the permission group with the given name by using {@link #group(String)} and, if not null, puts it into the
@@ -743,7 +743,7 @@ public interface PermissionManagement {
    * @param groups the groups to add after clearing all other groups.
    * @return a task that completes after the groups were replaced.
    */
-  default @NonNull Task<Void> groupsAsync(@Nullable Collection<? extends PermissionGroup> groups) {
+  default @NonNull Task<Void> groupsAsync(@Nullable Collection<PermissionGroup> groups) {
     return Task.supply(() -> this.groups(groups));
   }
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/player/NodePlayerProvider.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/player/NodePlayerProvider.java
@@ -27,15 +27,15 @@ import lombok.NonNull;
 
 final class NodePlayerProvider implements PlayerProvider {
 
-  private final Supplier<Stream<? extends CloudPlayer>> playerSupplier;
+  private final Supplier<Stream<CloudPlayer>> playerSupplier;
 
-  public NodePlayerProvider(@NonNull Supplier<Stream<? extends CloudPlayer>> playerSupplier) {
+  public NodePlayerProvider(@NonNull Supplier<Stream<CloudPlayer>> playerSupplier) {
     this.playerSupplier = playerSupplier;
   }
 
   @Override
-  public @NonNull Collection<? extends CloudPlayer> players() {
-    return this.playerSupplier.get().collect(Collectors.toList());
+  public @NonNull Collection<CloudPlayer> players() {
+    return this.playerSupplier.get().toList();
   }
 
   @Override

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
@@ -83,7 +83,7 @@ public interface PlayerManager {
    * @return a list of all online players with the given name.
    * @throws NullPointerException if the given name is null.
    */
-  @NonNull List<? extends CloudPlayer> onlinePlayers(@NonNull String name);
+  @NonNull List<CloudPlayer> onlinePlayers(@NonNull String name);
 
   /**
    * Gets all online cloud players that are connected to a service of given service environment.
@@ -94,7 +94,7 @@ public interface PlayerManager {
    * @return a list of all cloud players connected to a service of the given service environment.
    * @throws NullPointerException if the given environment is null.
    */
-  @NonNull List<? extends CloudPlayer> environmentOnlinePlayers(@NonNull ServiceEnvironmentType environment);
+  @NonNull List<CloudPlayer> environmentOnlinePlayers(@NonNull ServiceEnvironmentType environment);
 
   /**
    * Gets the jvm static player executor for all players that are connected to the network. All methods account for all
@@ -171,7 +171,7 @@ public interface PlayerManager {
    * @return a list of all registered players with the given name.
    * @throws NullPointerException if the given name is null.
    */
-  @NonNull List<? extends CloudOfflinePlayer> offlinePlayers(@NonNull String name);
+  @NonNull List<CloudOfflinePlayer> offlinePlayers(@NonNull String name);
 
   /**
    * Gets a list with all registered players from the database.
@@ -181,7 +181,7 @@ public interface PlayerManager {
    *
    * @return a list of all registered players.
    */
-  @NonNull List<? extends CloudOfflinePlayer> registeredPlayers();
+  @NonNull List<CloudOfflinePlayer> registeredPlayers();
 
   /**
    * Updates the given cloud offline player in the database, in the local cache of the node and calls the update in the
@@ -236,7 +236,7 @@ public interface PlayerManager {
    * @return a task containing the online cloud player or an empty task if the player is not online.
    * @throws NullPointerException if the given unique id is null.
    */
-  default @NonNull Task<? extends CloudPlayer> onlinePlayerAsync(@NonNull UUID uniqueId) {
+  default @NonNull Task<CloudPlayer> onlinePlayerAsync(@NonNull UUID uniqueId) {
     return Task.supply(() -> this.onlinePlayer(uniqueId));
   }
 
@@ -262,7 +262,7 @@ public interface PlayerManager {
    * @return a task containing a list of all online players with the given name.
    * @throws NullPointerException if the given name is null.
    */
-  default @NonNull Task<List<? extends CloudPlayer>> onlinePlayerAsync(@NonNull String name) {
+  default @NonNull Task<List<CloudPlayer>> onlinePlayerAsync(@NonNull String name) {
     return Task.supply(() -> this.onlinePlayers(name));
   }
 
@@ -275,7 +275,7 @@ public interface PlayerManager {
    * @return a task containing a list of all cloud players connected to a service of the given service environment.
    * @throws NullPointerException if the given environment is null.
    */
-  default @NonNull Task<List<? extends CloudPlayer>> onlinePlayerAsync(@NonNull ServiceEnvironmentType env) {
+  default @NonNull Task<List<CloudPlayer>> onlinePlayerAsync(@NonNull ServiceEnvironmentType env) {
     return Task.supply(() -> this.environmentOnlinePlayers(env));
   }
 
@@ -314,7 +314,7 @@ public interface PlayerManager {
    * @return a task containing a list of all registered players with the given name.
    * @throws NullPointerException if the given name is null.
    */
-  default @NonNull Task<List<? extends CloudOfflinePlayer>> offlinePlayerAsync(@NonNull String name) {
+  default @NonNull Task<List<CloudOfflinePlayer>> offlinePlayerAsync(@NonNull String name) {
     return Task.supply(() -> this.offlinePlayers(name));
   }
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerProvider.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerProvider.java
@@ -44,7 +44,7 @@ public interface PlayerProvider {
    *
    * @return all supplied cloud players.
    */
-  @NonNull Collection<? extends CloudPlayer> players();
+  @NonNull Collection<CloudPlayer> players();
 
   /**
    * Gets all unique ids of the players supplied by this player provider.
@@ -72,7 +72,7 @@ public interface PlayerProvider {
    *
    * @return a task containing all supplied cloud players.
    */
-  default @NonNull Task<Collection<? extends CloudPlayer>> playersAsync() {
+  default @NonNull Task<Collection<CloudPlayer>> playersAsync() {
     return Task.supply(this::players);
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/permission/DefaultDatabasePermissionManagement.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/DefaultDatabasePermissionManagement.java
@@ -312,7 +312,7 @@ public class DefaultDatabasePermissionManagement extends DefaultPermissionManage
   }
 
   @Override
-  public void groups(@Nullable Collection<? extends PermissionGroup> groups) {
+  public void groups(@Nullable Collection<PermissionGroup> groups) {
     // handle the setGroups
     this.setGroupsSilently(groups);
     // publish to the listeners
@@ -350,7 +350,7 @@ public class DefaultDatabasePermissionManagement extends DefaultPermissionManage
   }
 
   @Override
-  public void setGroupsSilently(@Nullable Collection<? extends PermissionGroup> groups) {
+  public void setGroupsSilently(@Nullable Collection<PermissionGroup> groups) {
     this.groups.clear();
     // set the provided groups
     if (groups != null) {

--- a/node/src/main/java/eu/cloudnetservice/node/permission/DefaultPermissionManagementHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/DefaultPermissionManagementHandler.java
@@ -97,10 +97,7 @@ public final class DefaultPermissionManagementHandler implements PermissionManag
   }
 
   @Override
-  public void handleSetGroups(
-    @NonNull PermissionManagement management,
-    @NonNull Collection<? extends PermissionGroup> groups
-  ) {
+  public void handleSetGroups(@NonNull PermissionManagement management, @NonNull Collection<PermissionGroup> groups) {
     this.eventManager.callEvent(new PermissionSetGroupsEvent(management, groups));
     this.baseMessage("set_groups").buffer(DataBuf.empty().writeObject(groups)).build().send();
   }

--- a/node/src/main/java/eu/cloudnetservice/node/permission/NodePermissionManagement.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/NodePermissionManagement.java
@@ -31,7 +31,7 @@ public interface NodePermissionManagement extends PermissionManagement {
 
   void deleteGroupSilently(@NonNull PermissionGroup permissionGroup);
 
-  void setGroupsSilently(@Nullable Collection<? extends PermissionGroup> groups);
+  void setGroupsSilently(@Nullable Collection<PermissionGroup> groups);
 
   @NonNull PermissionManagementHandler permissionManagementHandler();
 

--- a/node/src/main/java/eu/cloudnetservice/node/permission/handler/PermissionManagementHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/handler/PermissionManagementHandler.java
@@ -36,7 +36,7 @@ public interface PermissionManagementHandler {
 
   void handleDeleteGroup(@NonNull PermissionManagement management, @NonNull PermissionGroup group);
 
-  void handleSetGroups(@NonNull PermissionManagement management, @NonNull Collection<? extends PermissionGroup> groups);
+  void handleSetGroups(@NonNull PermissionManagement management, @NonNull Collection<PermissionGroup> groups);
 
   void handleReloaded(@NonNull PermissionManagement management);
 }

--- a/node/src/main/java/eu/cloudnetservice/node/permission/handler/PermissionManagementHandlerAdapter.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/handler/PermissionManagementHandlerAdapter.java
@@ -69,10 +69,7 @@ public class PermissionManagementHandlerAdapter implements PermissionManagementH
   }
 
   @Override
-  public void handleSetGroups(
-    @NonNull PermissionManagement management,
-    @NonNull Collection<? extends PermissionGroup> groups
-  ) {
+  public void handleSetGroups(@NonNull PermissionManagement management, @NonNull Collection<PermissionGroup> groups) {
   }
 
   @Override


### PR DESCRIPTION
### Motivation
The usage of wildcard types in the changed places is not needed and can lead to exceptions, for example when used in combination with our rpc system.

### Modification
Remove uneeded wildcard types when they are exposed by our api.

### Result
No more usages of wildcard types.

##### Other context
Closes #775