### PR TITLE
fix(node): use mutable hashset for the ip whitelist

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
@@ -174,7 +174,7 @@ public final class JsonConfiguration implements Configuration {
       this.ipWhitelist = ConfigurationUtil.get(
         "cloudnet.config.ipWhitelist",
         NetworkUtil.availableIPAddresses(),
-        value -> Set.of(value.split(",")));
+        value -> new HashSet<>(Set.of(value.split(","))));
     }
 
     if (this.maxCPUUsageToStartServices <= 0) {


### PR DESCRIPTION
### Motivation
Currently the ip whitelist is parsed into an immutable set which is a problem as we try to add entries to the set.

### Modification

Wrapped the set into a new HashSet to ensure it to be mutable.
### Result
No UnsupportedOperationException.