### PR TITLE
fix(node): add missing template command translation parameters

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TemplateCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TemplateCommand.java
@@ -189,7 +189,9 @@ public final class TemplateCommand {
   ) {
     var templateStorage = template.storage();
     if (templateStorage.contains(template)) {
-      source.sendMessage(I18n.trans("command-template-create-template-already-exists"));
+      source.sendMessage(I18n.trans("command-template-create-template-already-exists",
+        template.fullName(),
+        template.storageName()));
       return;
     }
 


### PR DESCRIPTION
### Motivation
One of the translations in the template command has to parameters but 0 are supplied in the runtime.

### Modification
Added the missing parameters for a correct translation.

### Result
The translation is displayed correctly.