### PR TITLE
[ci skip] ci: allow prs from nightly and beta to go into release

### DIFF
--- a/.github/workflows/prbranch.yml
+++ b/.github/workflows/prbranch.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: Vankka/pr-target-branch-action@v2
         with:
           target: release
-          exclude: nightly
+          exclude: "nightly beta"

--- a/build-extensions/src/main/kotlin/Versions.kt
+++ b/build-extensions/src/main/kotlin/Versions.kt
@@ -17,7 +17,7 @@
 object Versions {
 
   // internal versions
-  const val cloudNet = "4.0.0-RC1"
+  const val cloudNet = "4.0.0-RC2-SNAPSHOT"
   const val cloudNetCodeName = "Blizzard"
 
   // external tools

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/InstallStep.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/InstallStep.java
@@ -22,6 +22,7 @@ import eu.cloudnetservice.node.version.execute.defaults.DeployStepExecutor;
 import eu.cloudnetservice.node.version.execute.defaults.DownloadStepExecutor;
 import eu.cloudnetservice.node.version.execute.defaults.FabricApiVersionFetch;
 import eu.cloudnetservice.node.version.execute.defaults.PaperApiVersionFetchStepExecutor;
+import eu.cloudnetservice.node.version.execute.defaults.SpongeApiVersionFetchStepExecutor;
 import eu.cloudnetservice.node.version.execute.defaults.UnzipStepExecutor;
 import eu.cloudnetservice.node.version.information.VersionInstaller;
 import java.io.IOException;
@@ -37,7 +38,8 @@ public enum InstallStep {
   COPY_FILTER(new CopyFilterStepExecutor()),
   DEPLOY(new DeployStepExecutor()),
   PAPER_API(new PaperApiVersionFetchStepExecutor()),
-  FABRIC_API(new FabricApiVersionFetch());
+  FABRIC_API(new FabricApiVersionFetch()),
+  SPONGE_API(new SpongeApiVersionFetchStepExecutor());
 
   private final InstallStepExecutor executor;
 

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/SpongeApiVersionFetchStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/SpongeApiVersionFetchStepExecutor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.node.version.execute.defaults;
+
+import com.google.common.collect.Iterables;
+import eu.cloudnetservice.common.document.gson.JsonDocument;
+import eu.cloudnetservice.node.version.execute.InstallStepExecutor;
+import eu.cloudnetservice.node.version.information.VersionInstaller;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Set;
+import kong.unirest.HttpStatus;
+import kong.unirest.Unirest;
+import lombok.NonNull;
+
+public class SpongeApiVersionFetchStepExecutor implements InstallStepExecutor {
+
+  private static final String VERSION_DOWNLOAD_URL = "https://repo.spongepowered.org/repository/maven-releases/%s/%s/%s/spongevanilla-%s-universal.jar";
+  private static final String VERSION_FETCH_URL = "https://dl-api-new.spongepowered.org/api/v2/groups/%s/artifacts/%s/versions?tags=minecraft:%s&offset=0&limit=1";
+
+  @Override
+  public @NonNull Set<Path> execute(
+    @NonNull VersionInstaller installer,
+    @NonNull Path workingDirectory,
+    @NonNull Set<Path> files
+  ) throws IOException {
+    // check if we need to fetch using the sponge api
+    var properties = installer.serviceVersion().properties();
+    var enabled = properties.getBoolean("fetchOverSpongeApi");
+    if (enabled) {
+      // get all properties which we need to download the version
+      var artifact = properties.getString("artifact");
+      var mcVersion = properties.getString("mcVersion");
+      var groupId = properties.getString("group", "org.spongepowered");
+
+      // build the url and get the data from the url
+      var fetchUrl = String.format(VERSION_FETCH_URL, groupId, artifact, mcVersion);
+      var jsonResponse = Unirest.get(fetchUrl)
+        .accept("application/json")
+        .asObject(response -> {
+          if (response.getStatus() == HttpStatus.OK) {
+            return JsonDocument.fromJsonString(response.getContentAsString());
+          } else {
+            return JsonDocument.emptyDocument();
+          }
+        }).getBody();
+
+      // check if the document contains any artifacts
+      var artifacts = jsonResponse.getDocument("artifacts");
+      if (!artifacts.empty()) {
+        // get the first key - it is the version we need to download
+        var versionKey = Iterables.getFirst(artifacts.keys(), null);
+        if (versionKey != null) {
+          // version if present - set the download url of the version
+          var downloadUrl = String.format(
+            VERSION_DOWNLOAD_URL,
+            groupId.replace('.', '/'),
+            artifact,
+            versionKey,
+            versionKey);
+          installer.serviceVersion().url(downloadUrl);
+        }
+      }
+    }
+
+    // we generated no paths
+    return Set.of();
+  }
+}

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -429,6 +429,7 @@
       "environmentType": "MINECRAFT_SERVER",
       "website": "https://spongepowered.org",
       "installSteps": [
+        "SPONGE_API",
         "DOWNLOAD",
         "BUILD",
         "COPY_FILTER"
@@ -436,36 +437,42 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://repo.spongepowered.org/repository/maven-releases/org/spongepowered/spongevanilla/1.18.2-9.0.0-RC1157/spongevanilla-1.18.2-9.0.0-RC1157-universal.jar",
           "cacheFiles": false,
           "properties": {
             "copy": {
               "libraries/.*": "/",
               "launcher\\.conf": "/",
               "spongevanilla\\.jar": "/"
-            }
+            },
+            "fetchOverSpongeApi": true,
+            "artifact": "spongevanilla",
+            "mcVersion": "1.18.2"
           }
         },
         {
           "name": "1.18.2",
-          "url": "https://repo.spongepowered.org/repository/maven-releases/org/spongepowered/spongevanilla/1.18.2-9.0.0-RC1157/spongevanilla-1.18.2-9.0.0-RC1157-universal.jar",
           "properties": {
             "copy": {
               "libraries/.*": "/",
               "launcher\\.conf": "/",
               "spongevanilla\\.jar": "/"
-            }
+            },
+            "fetchOverSpongeApi": true,
+            "artifact": "spongevanilla",
+            "mcVersion": "1.18.2"
           }
         },
         {
           "name": "1.16.5",
-          "url": "https://repo.spongepowered.org/repository/maven-releases/org/spongepowered/spongevanilla/1.16.5-8.1.0-RC1164/spongevanilla-1.16.5-8.1.0-RC1164-universal.jar",
           "properties": {
             "copy": {
               "libraries/.*": "/",
               "launcher\\.conf": "/",
               "spongevanilla\\.jar": "/"
-            }
+            },
+            "fetchOverSpongeApi": true,
+            "artifact": "spongevanilla",
+            "mcVersion": "1.16.5"
           }
         }
       ]


### PR DESCRIPTION
### Motivation
Currently only prs from "nightly" can be merged into the "release" branch without the prbranch worklow failing. This is incorrect as prs from beta into release should be permitted as well.

### Modification
Allow prs from branch "beta" to target "release" by excluding beta and nightly from the check.

### Result
PRs from beta can now be created to target release without ci failures.