### PR TITLE
[ci skip] ci: publish snapshots to sonatype on push to nightly

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -67,7 +67,7 @@ jobs:
           fi
 
       - name: Publish to Sonatype
-        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/unstable/rewrite') && matrix.java == 17 }}
+        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') && matrix.java == 17 }}
         run: ./gradlew publish
         env:
           sonatypeUsername: "${{ secrets.SONATYPE_USER }}"


### PR DESCRIPTION
### Motivation
The current check if a release to sonatype should be published still checks for unstable/rewrite instead of nightly.

### Modification
Use nightly when checking if a snapshot should be published to sonatype.

### Result
Pushes to nightly will trigger a publish to sonatype.
