### PR TITLE
build: move sonatype repo in front of sponge repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,8 @@ allprojects {
   repositories {
     mavenCentral()
     maven("https://jitpack.io/")
+    // must be before sponge as they mirror some repos including that one (which leads to outdated dependencies)
+    maven("https://oss.sonatype.org/content/repositories/snapshots/")
     maven("https://repo.spongepowered.org/maven/")
   }
 }

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -33,7 +33,6 @@ subprojects {
     maven("https://repo.waterdog.dev/artifactory/main/")
     maven("https://repo.opencollab.dev/maven-snapshots/")
     maven("https://repo.papermc.io/repository/maven-public/")
-    maven("https://oss.sonatype.org/content/repositories/snapshots/")
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
   }
 


### PR DESCRIPTION
### Motivation
We're currently using some snapshot dependencies which should be loaded from oss.sonatype.org, but they aren't because the sponge repo is defined before sonatype and mirrors it. This causes outdated dependency downloads as sponge is caching the dependencies as well for some time.

### Modification
Move sonatype repo declaration before sponge repo declaration.

### Result
Snapshot dependencies are now loaded correctly from sonatype and not from the sponge mirror.
