### PR TITLE
chore: properly unregister commands from backing manager

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/CommandProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/CommandProvider.java
@@ -68,13 +68,22 @@ public interface CommandProvider {
   @NonNull Task<?> execute(@NonNull CommandSource source, @NonNull String input);
 
   /**
-   * Registers a command on a per-class basis. All methods annotated with {@link cloud.commandframework.annotations.CommandMethod}
-   * are parsed into a command and only one common {@link CommandInfo}.
+   * Registers a command on a per-class basis. All methods annotated with
+   * {@link cloud.commandframework.annotations.CommandMethod} are parsed into a command and only one common
+   * {@link CommandInfo}.
    *
    * @param command the instance of the class to register all commands for.
    * @throws NullPointerException if object is null.
    */
   void register(@NonNull Object command);
+
+  /**
+   * Unregisters the command with the given name or alias.
+   *
+   * @param name the name or alias of the command to unregister.
+   * @throws NullPointerException if the given name is null.
+   */
+  void unregister(@NonNull String name);
 
   /**
    * Unregisters every command that was registered by the given classloader.

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandManager.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.node.command.defaults;
 
+import cloud.commandframework.CloudCapability;
 import cloud.commandframework.CommandManager;
 import cloud.commandframework.execution.AsynchronousCommandExecutionCoordinator;
 import cloud.commandframework.internal.CommandRegistrationHandler;
@@ -36,8 +37,10 @@ final class DefaultCommandManager extends CommandManager<CommandSource> {
    */
   public DefaultCommandManager() {
     super(AsynchronousCommandExecutionCoordinator.<CommandSource>newBuilder()
-        .withExecutor(Executors.newFixedThreadPool(4)).build(),
+        .withExecutor(Executors.newFixedThreadPool(4))
+        .build(),
       CommandRegistrationHandler.nullCommandRegistrationHandler());
+    this.registerCapability(CloudCapability.StandardCapabilities.ROOT_COMMAND_DELETION);
   }
 
   /**


### PR DESCRIPTION
### Motivation
Unregistering a command is currently not done in the backing cloud command manager, the command is only removed from our known registered commands (which isn't working either as the wrong class loader in association with the commands was stored). This causes exceptions, when for example a module is updated during runtime, the new file starts and tries to register the same command as previously registered by the old module.

### Modification
Due to a relatively new feature in cloud it is possible to unregister commands. This PR makes now use of that feature.

### Result
Unregistering a command is now working as expected and later registrations of the same command are possible.
