### PR TITLE
chore: replace usages of ConcurrentLinkedQueue with a proper set

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
@@ -39,7 +39,7 @@ import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
@@ -57,7 +57,7 @@ public class NettyNetworkClient implements DefaultNetworkComponent, NetworkClien
   protected final Executor packetDispatcher = NettyUtil.newPacketDispatcher();
   protected final EventLoopGroup eventLoopGroup = NettyUtil.newEventLoopGroup(0);
 
-  protected final Collection<NetworkChannel> channels = new ConcurrentLinkedQueue<>();
+  protected final Collection<NetworkChannel> channels = ConcurrentHashMap.newKeySet();
   protected final PacketListenerRegistry packetRegistry = new DefaultPacketListenerRegistry();
 
   protected final SSLConfiguration sslConfiguration;

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServer.java
@@ -34,7 +34,6 @@ import io.netty5.util.concurrent.Future;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -48,7 +47,7 @@ public class NettyHttpServer extends NettySslServer implements HttpServer {
   private static final Logger LOGGER = LogManager.logger(NettyHttpServer.class);
 
   protected final Map<HostAndPort, Future<Void>> channelFutures = new ConcurrentHashMap<>();
-  protected final Collection<HttpHandlerEntry> registeredHandlers = new ConcurrentLinkedQueue<>();
+  protected final Collection<HttpHandlerEntry> registeredHandlers = ConcurrentHashMap.newKeySet();
 
   protected final EventLoopGroup bossGroup = NettyUtil.newEventLoopGroup(1);
   protected final EventLoopGroup workerGroup = NettyUtil.newEventLoopGroup(0);

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyWebSocketServerChannel.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyWebSocketServerChannel.java
@@ -31,7 +31,7 @@ import io.netty5.handler.codec.http.websocketx.TextWebSocketFrame;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
@@ -44,7 +44,7 @@ import org.jetbrains.annotations.Nullable;
  */
 final class NettyWebSocketServerChannel implements WebSocketChannel {
 
-  private final Collection<WebSocketListener> webSocketListeners = new ConcurrentLinkedQueue<>();
+  private final Collection<WebSocketListener> webSocketListeners = ConcurrentHashMap.newKeySet();
 
   private final Channel channel;
   private final HttpChannel httpChannel;

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
@@ -55,7 +54,7 @@ public class NettyNetworkServer extends NettySslServer implements DefaultNetwork
   protected final EventLoopGroup bossEventLoopGroup = NettyUtil.newEventLoopGroup(1);
   protected final EventLoopGroup workerEventLoopGroup = NettyUtil.newEventLoopGroup(0);
 
-  protected final Collection<NetworkChannel> channels = new ConcurrentLinkedQueue<>();
+  protected final Collection<NetworkChannel> channels = ConcurrentHashMap.newKeySet();
   protected final Map<HostAndPort, Future<Void>> channelFutures = new ConcurrentHashMap<>();
 
   protected final Executor packetDispatcher = NettyUtil.newPacketDispatcher();

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/defaults/DefaultPacketListenerRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/defaults/DefaultPacketListenerRegistry.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
@@ -59,7 +58,7 @@ public class DefaultPacketListenerRegistry implements PacketListenerRegistry {
    */
   public DefaultPacketListenerRegistry(@Nullable PacketListenerRegistry parent) {
     this.parent = parent;
-    this.listeners = Multimaps.newMultimap(new ConcurrentHashMap<>(), ConcurrentLinkedQueue::new);
+    this.listeners = Multimaps.newMultimap(new ConcurrentHashMap<>(), ConcurrentHashMap::newKeySet);
   }
 
   /**

--- a/driver/src/main/java/eu/cloudnetservice/driver/registry/DefaultServiceRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/registry/DefaultServiceRegistry.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Multimaps;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.NonNull;
 
 /**
@@ -33,7 +32,7 @@ public class DefaultServiceRegistry implements ServiceRegistry {
 
   protected final Multimap<Class<?>, RegistryEntry<?>> providers = Multimaps.newMultimap(
     new ConcurrentHashMap<>(),
-    ConcurrentLinkedQueue::new);
+    ConcurrentHashMap::newKeySet);
 
   /**
    * {@inheritDoc}

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/CloudFlareAPI.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/CloudFlareAPI.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import kong.unirest.HttpRequestWithBody;
 import kong.unirest.Unirest;
@@ -45,7 +44,7 @@ public class CloudFlareAPI implements AutoCloseable {
 
   protected final Multimap<UUID, DnsRecordDetail> createdRecords = Multimaps.newMultimap(
     new ConcurrentHashMap<>(),
-    ConcurrentLinkedQueue::new);
+    ConcurrentHashMap::newKeySet);
 
   public @Nullable DnsRecordDetail createRecord(
     @NonNull UUID serviceUniqueId,


### PR DESCRIPTION
### Motivation
At some places a ConcurrentLinkedQueue is used to represent a concurrent collection, but the usage of a proper set is much more efficient at these places.

### Modification
Replace unneeded usages of ConcurrentLinkedQueue with ConcurrentHashMap.newKeySet to get a proper concurrent set backing a collection field.

### Result
No more unneeded and inefficent usages of ConcurrentLinkedQueue.
