### PR TITLE
fix: resolve convert issues of old npc/sign entries

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/NPCConstants.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/NPCConstants.java
@@ -18,12 +18,11 @@ package eu.cloudnetservice.modules.npc._deprecated;
 
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
-import java.util.Set;
+import java.util.Collection;
 
 public class NPCConstants {
 
-  public static final Type NPC_COLLECTION_TYPE = new TypeToken<Set<CloudNPC>>() {
-  }.getType();
+  public static final Type NPC_COLLECTION_TYPE = TypeToken.getParameterized(Collection.class, CloudNPC.class).getType();
 
   public static final String NPC_CHANNEL_NAME = "cloudnet_npc_channel";
   public static final String NPC_CHANNEL_ADD_NPC_MESSAGE = "add_npc";

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
@@ -85,8 +85,13 @@ public class CloudNetNPCModule extends DriverModule {
       }
     }
 
-    // convert the old database
+    // convert the old database (old h2 databases convert the name to lower case - we need to check both names)
     var db = Node.instance().databaseProvider().database("cloudNet_module_configuration");
+    if (db.documentCount() == 0) {
+      db = Node.instance().databaseProvider().database("cloudnet_module_configuration");
+    }
+
+    // get the npc_store field of the database entry
     var npcStore = db.get("npc_store");
     if (npcStore != null) {
       Collection<CloudNPC> theOldOnes = npcStore.get("npcs", NPCConstants.NPC_COLLECTION_TYPE);

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/CloudNetSignsModule.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/CloudNetSignsModule.java
@@ -90,15 +90,20 @@ public class CloudNetSignsModule extends DriverModule {
 
   @Deprecated
   private void convertDatabaseIfNecessary() {
-    // load old database document
-    var database = Node.instance().databaseProvider().database("cloudNet_module_configuration");
-    var document = database.get("signs_store");
+    // convert the old database (old h2 databases convert the name to lower case - we need to check both names)
+    var db = Node.instance().databaseProvider().database("cloudNet_module_configuration");
+    if (db.documentCount() == 0) {
+      db = Node.instance().databaseProvider().database("cloudnet_module_configuration");
+    }
+
+    // get the npc_store field of the database entry
+    var document = db.get("signs_store");
     // when the document is null the conversation already happened
     if (document != null) {
       // notify the user about the change
       LOGGER.warning("Detected old signs database, running conversation...");
       // remove the old document from the database
-      database.delete("signs_store");
+      db.delete("signs_store");
       // check if the old sign document even contains the signs
       Collection<eu.cloudnetservice.modules.signs._deprecated.Sign> oldSigns = document.get("signs",
         SignConstants.COLLECTION_SIGNS);


### PR DESCRIPTION
### Motivation
The old npc & sign entries are not converted correctly from v3 to v4 as h2 stores all database names uppercase (and we convert them to lowercase). As the entries are stored in a database called `cloudNet_module_configuration` this leads to an issue when used with databases which use case-sensitive table naming (like xodus or mongodb).

### Modification
Check box database spelling variants (`cloudNet_module_configuration` and `cloudnet_module_configuration`) in order to find the database which contains the old entries after converting the database from h2.
On the other hand the npcs were parsed to a set type which caused the emit of some npc entries, therefore I changed the type to a collection to read all entries from the old document.

### Result
The created signs and npcs on v3 are now correctly converted to v4.
