### PR TITLE
chore: replace some AtomicXXX classes with their non-atomic equivalent

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkedPacketHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkedPacketHandler.java
@@ -27,7 +27,6 @@ import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import lombok.NonNull;
@@ -44,8 +43,8 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
   protected final RandomAccessFile targetFile;
   protected final Callback writeCompleteHandler;
   protected final Lock lock = new ReentrantLock(true);
-  protected final AtomicInteger writtenFileParts = new AtomicInteger(-1);
 
+  protected int writtenFileParts = -1;
   protected Integer expectedFileParts;
 
   /**
@@ -168,7 +167,7 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
     // write the content into the file at the current offset we sunk to
     this.targetFile.write(dataBuf.readByteArray());
     // notify our index about the write operation
-    this.writtenFileParts.incrementAndGet();
+    this.writtenFileParts++;
   }
 
   /**
@@ -183,7 +182,7 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
     // we only need to update the status when the transfer is running but the whole content was written
     if (this.transferStatus == TransferStatus.RUNNING
       && this.expectedFileParts != null
-      && this.expectedFileParts == this.writtenFileParts.get()
+      && this.expectedFileParts == this.writtenFileParts
     ) {
       this.transferStatus = TransferStatus.SUCCESS;
     }

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
@@ -34,7 +34,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 
@@ -44,7 +43,8 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
 
   private final Database database;
   private final Path configurationPath;
-  private final AtomicBoolean protocolLibAvailable;
+
+  private boolean protocolLibAvailable;
 
   public NodeNPCManagement(
     @NonNull NPCConfiguration npcConfiguration,
@@ -55,7 +55,6 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
     super(npcConfiguration);
     this.database = database;
     this.configurationPath = configPath;
-    this.protocolLibAvailable = new AtomicBoolean();
 
     // load all existing npcs
     this.database.documentsAsync().thenAccept(jsonDocuments -> {
@@ -70,7 +69,7 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
       "https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/target/ProtocolLib.jar",
       stream -> {
         FileUtil.copy(stream, PROTOCOL_LIB_CACHE_PATH);
-        this.protocolLibAvailable.set(true);
+        this.protocolLibAvailable = true;
       }
     );
 
@@ -80,7 +79,7 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
     eventManager.registerListener(new PluginIncludeListener(
       "cloudnet-npcs",
       CloudNetNPCModule.class,
-      service -> this.protocolLibAvailable.get()
+      service -> this.protocolLibAvailable
         && ServiceEnvironmentType.minecraftServer(service.serviceId().environment())
         && this.npcConfiguration
         .entries()

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
@@ -17,8 +17,6 @@
 package eu.cloudnetservice.modules.signs.configuration;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
@@ -30,8 +28,8 @@ public class SignLayoutsHolder {
   private final int animationsPerSecond;
   private final List<SignLayout> signLayouts;
 
-  private final transient AtomicBoolean tickBlocked = new AtomicBoolean();
-  private final transient AtomicInteger currentAnimation = new AtomicInteger(-1);
+  private transient boolean tickBlocked;
+  private transient int currentAnimation = -1;
 
   public SignLayoutsHolder(int animationsPerSecond, @NonNull List<SignLayout> signLayouts) {
     this.animationsPerSecond = animationsPerSecond;
@@ -55,15 +53,15 @@ public class SignLayoutsHolder {
   }
 
   public boolean tickBlocked() {
-    return this.tickBlocked.get();
+    return this.tickBlocked;
   }
 
   public void enableTickBlock() {
-    this.tickBlocked.set(true);
+    this.tickBlocked = true;
   }
 
   public @NonNull SignLayoutsHolder releaseTickBlock() {
-    this.tickBlocked.set(false);
+    this.tickBlocked = false;
     return this;
   }
 
@@ -73,14 +71,14 @@ public class SignLayoutsHolder {
 
   public @NonNull SignLayoutsHolder tick() {
     if (!this.tickBlocked()) {
-      if (this.currentAnimation.incrementAndGet() >= this.signLayouts.size()) {
-        this.currentAnimation.set(0);
+      if (++this.currentAnimation >= this.signLayouts.size()) {
+        this.currentAnimation = 0;
       }
     }
     return this;
   }
 
   public int currentAnimation() {
-    return Math.max(0, this.currentAnimation.get());
+    return Math.max(0, this.currentAnimation);
   }
 }

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabListConfiguration.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabListConfiguration.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.modules.syncproxy.config;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
@@ -34,7 +33,7 @@ public class SyncProxyTabListConfiguration {
   protected final List<SyncProxyTabList> entries;
   protected final double animationsPerSecond;
 
-  protected final transient AtomicInteger currentEntry;
+  protected transient int currentEntry = -1;
 
   protected SyncProxyTabListConfiguration(
     @NonNull String targetGroup,
@@ -44,8 +43,6 @@ public class SyncProxyTabListConfiguration {
     this.targetGroup = targetGroup;
     this.entries = entries;
     this.animationsPerSecond = animationsPerSecond;
-
-    this.currentEntry = new AtomicInteger(-1);
   }
 
   public static @NonNull Builder builder() {
@@ -87,8 +84,8 @@ public class SyncProxyTabListConfiguration {
   }
 
   public @NonNull SyncProxyTabList tick() {
-    if (this.currentEntry.incrementAndGet() >= this.entries.size()) {
-      this.currentEntry.set(0);
+    if (++this.currentEntry >= this.entries.size()) {
+      this.currentEntry = 0;
     }
 
     return this.currentEntry();
@@ -99,7 +96,7 @@ public class SyncProxyTabListConfiguration {
   }
 
   public int currentTick() {
-    return this.currentEntry.get();
+    return this.currentEntry;
   }
 
   public static class Builder {


### PR DESCRIPTION
### Motivation
Atomic wrappers are used to prevent concurrency issues caused by multiple threads accessing the same field. In CloudNet we use these atomic wrappers in some places, where calls to the fields (or methods which are mutating them) are only done either within a locked context or only from one thread. Therefore the atomic wrapping is not needed and can be replaced with the lighter direct accesses.

### Modification
Replace some AtomicXXX wrapper classes when they are not needed with their non-atomic equivalent.

### Result
No more atomic actions when not needed.
