### PR TITLE
fix(sftp): properly close all ssh client connection

### DIFF
--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -379,6 +379,8 @@ public class SFTPTemplateStorage implements TemplateStorage {
     if (this.pool.stillActive()) {
       try (SFTPClient client = this.pool.takeClient()) {
         return handler.apply(client);
+      } catch (IllegalStateException ignored) {
+        // cancelled while getting a client from the pool or the pool is closed
       } catch (Exception exception) {
         LOGGER.fine("Exception executing sftp task", exception);
       }

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -341,7 +341,12 @@ public class SFTPTemplateStorage implements TemplateStorage {
 
   @Override
   public void close() throws IOException {
-    this.sshClient.disconnect();
+    // check if we've ever opened a session
+    var client = this.sshClient;
+    if (client != null) {
+      this.pool.close();
+      client.disconnect();
+    }
   }
 
   protected @NonNull String constructRemotePath(@NonNull ServiceTemplate template, String @NonNull ... parents) {
@@ -368,11 +373,16 @@ public class SFTPTemplateStorage implements TemplateStorage {
   }
 
   protected <T> T executeWithClient(@NonNull ThrowableFunction<SFTPClient, T, Exception> handler, T def) {
-    try (SFTPClient client = this.pool.takeClient()) {
-      return handler.apply(client);
-    } catch (Exception exception) {
-      LOGGER.fine("Exception executing sftp task", exception);
-      return def;
+    // only take a client & execute the action if the pool is still available
+    if (this.pool.stillActive()) {
+      try (SFTPClient client = this.pool.takeClient()) {
+        return handler.apply(client);
+      } catch (Exception exception) {
+        LOGGER.fine("Exception executing sftp task", exception);
+      }
     }
+
+    // either an exception was thrown or the pool is closed
+    return def;
   }
 }

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -341,10 +341,12 @@ public class SFTPTemplateStorage implements TemplateStorage {
 
   @Override
   public void close() throws IOException {
+    // if the base-client is null there are no pooled clients as well, but we need to mark the pool itself as closed
+    this.pool.close();
+
     // check if we've ever opened a session
     var client = this.sshClient;
     if (client != null) {
-      this.pool.close();
       client.disconnect();
     }
   }


### PR DESCRIPTION
### Motivation
Currently the pooled sftp clients are not disconnected properly from the remote server on close, which means that we rely on the fact that the server will timeout the connection at some point. If no client ever connected to a remote ssh server, an exception is thrown on shutdown as well.

### Modification
Properly close all pooled sftp clients and only disconnect the root client if it got initialized.

### Result
All connections are now closed on shutdown properly and no more exception are thrown.
