### PR TITLE
chore(deps): Update tj-actions/branch-names action to v6

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v5.5
+        uses: tj-actions/branch-names@v6
 
       - name: Validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
### Motivation
The branch-names action relased v6 2 days ago with no changes which would break our build, but renovate only detects the update to v5.6.

### Modification
Bump tj-actions/branch-names to v6.

### Result
All used actions in our build are up-to-date again.

##### Other context
Closes #819
