### PR TITLE
chore(deps): bump checkstyle to 10.3.3

### DIFF
--- a/build-extensions/src/main/kotlin/Versions.kt
+++ b/build-extensions/src/main/kotlin/Versions.kt
@@ -21,5 +21,5 @@ object Versions {
   const val cloudNetCodeName = "Blizzard"
 
   // external tools
-  const val checkstyleTools = "10.3.1"
+  const val checkstyleTools = "10.3.3"
 }


### PR DESCRIPTION
### Motivation
Checkstyle has relased version 10.3.3 which has an important bug-fix to the RequireThis check.

### Modification
Bump checkstyle to 10.3.3.

### Result
Checkstyle is up-to-date.
