### PR TITLE
fix: correctly override methods from ServiceConfigurationBase#Builder

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/service/GroupConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/GroupConfiguration.java
@@ -234,7 +234,7 @@ public class GroupConfiguration extends ServiceConfigurationBase implements Clon
         Set.copyOf(this.templates),
         Set.copyOf(this.deployments),
         Set.copyOf(this.includes),
-        this.properties);
+        this.properties.clone());
     }
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
@@ -873,7 +873,7 @@ public class ServiceConfiguration extends ServiceConfigurationBase implements Cl
         Set.copyOf(this.templates),
         Set.copyOf(this.deployments),
         Set.copyOf(this.includes),
-        this.properties);
+        this.properties.clone());
     }
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
@@ -702,6 +702,42 @@ public class ServiceTask extends ServiceConfigurationBase implements Cloneable, 
      * {@inheritDoc}
      */
     @Override
+    public @NonNull Builder jvmOptions(@NonNull Collection<String> jvmOptions) {
+      this.processConfiguration.jvmOptions(jvmOptions);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NonNull Builder modifyJvmOptions(@NonNull Consumer<Collection<String>> modifier) {
+      this.processConfiguration.modifyJvmOptions(modifier);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NonNull Builder processParameters(@NonNull Collection<String> processParameters) {
+      this.processConfiguration.processParameters(processParameters);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NonNull Builder modifyProcessParameters(@NonNull Consumer<Collection<String>> modifier) {
+      this.processConfiguration.modifyProcessParameters(modifier);
+      return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     protected @NonNull Builder self() {
       return this;
     }
@@ -736,7 +772,7 @@ public class ServiceTask extends ServiceConfigurationBase implements Cloneable, 
         Set.copyOf(this.templates),
         Set.copyOf(this.deployments),
         Set.copyOf(this.includes),
-        this.properties);
+        this.properties.clone());
     }
   }
 }


### PR DESCRIPTION
### Motivation
Some methods from ServiceConfigurationBase#Builder are not overriden in ServiceTask#Builder but need to be in order to delegate these method calls to the underlying ServiceConfigurationBase#Builder methods. This results in incorrect modification of the underlying options, for example when using `tasks task <name> add jvmOption`.

### Modification
Override builder methods in ServiceTask#Builder that need to delegate their calls.

### Result
Correctly modify the underlying ServiceConfigurationBase.
