### PR TITLE
fix: remove some checks from java version regex

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/util/JavaVersionResolver.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/JavaVersionResolver.java
@@ -32,8 +32,9 @@ public final class JavaVersionResolver {
 
   private static final Logger LOGGER = LogManager.logger(JavaVersionResolver.class);
 
-  // https://regex101.com/r/6Z4jZT/1
-  private static final Pattern JAVA_REGEX = Pattern.compile("^.* version \"(\\d+)\\.?(\\d+)?\\.?([\\d_]+)?\".*",
+  // https://regex101.com/r/VO0bsk/1
+  private static final Pattern JAVA_REGEX = Pattern.compile(
+    "^.* version \"(\\d+)\\.?(\\d+)?.*",
     Pattern.MULTILINE | Pattern.DOTALL);
 
   private JavaVersionResolver() {
@@ -47,8 +48,8 @@ public final class JavaVersionResolver {
    * @return the java version of the executable, null if not parseable or if the version is unsupported.
    */
   public static @Nullable JavaVersion resolveFromJavaExecutable(@Nullable String input) {
-    // the default java command input can always evaluate in the current runtime version
-    if (input == null || input.equals("java")) {
+    // no input is always the runtime version
+    if (input == null) {
       return JavaVersion.runtimeVersion();
     }
 


### PR DESCRIPTION
### Motivation
Some version outputs are not matching the current java version regex, for example versions with more than major.minor.patch like 17.0.4.1. As we only need the major and minor version for matching (minor only for older versions, where the version was prefixed with 1.), we can remove all checks which are following these two parts and just let them be.

### Modification
Remove checks after the major & minor group to make the regex less dependant on version formatting.

### Result
The regex should match java versions way better.
