### PR TITLE
chore: improve logging when launcher update repo/branch wasn't found

### DIFF
--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/CloudNetLauncher.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/CloudNetLauncher.java
@@ -27,6 +27,7 @@ import eu.cloudnetservice.launcher.java17.updater.updaters.LauncherCloudNetUpdat
 import eu.cloudnetservice.launcher.java17.updater.updaters.LauncherModuleJsonUpdater;
 import eu.cloudnetservice.launcher.java17.updater.updaters.LauncherPatcherUpdater;
 import eu.cloudnetservice.launcher.java17.updater.updaters.LauncherUpdater;
+import eu.cloudnetservice.launcher.java17.util.BootstrapUtil;
 import eu.cloudnetservice.launcher.java17.util.CommandLineHelper;
 import eu.cloudnetservice.launcher.java17.util.Environment;
 import java.nio.file.Files;
@@ -75,15 +76,14 @@ public final class CloudNetLauncher {
       System.err.println("║     It looks like CloudNet is already running! Stop the other     ║");
       System.err.println("║          running instance and try running CloudNet again!         ║");
       System.err.println("║                                                                   ║");
-      System.err.println("║              This instance will stop in 10 Seconds!               ║");
+      System.err.println("║              This instance will stop in 5 Seconds!                ║");
       System.err.println("║                                                                   ║");
       System.err.println("║                                                                   ║");
       System.err.println("║  If you are sure that there are no instances running, delete the  ║");
       System.err.println("║          app.lock file located in the launcher directory.         ║");
       System.err.println("╚═══════════════════════════════════════════════════════════════════╝");
       // wait 10 Seconds and stop
-      TimeUnit.SECONDS.sleep(10);
-      System.exit(1);
+      BootstrapUtil.waitAndExit();
       // CHECKSTYLE.ON
     }
 

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/BootstrapUtil.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/BootstrapUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.launcher.java17.util;
+
+import java.util.concurrent.TimeUnit;
+
+public final class BootstrapUtil {
+
+  private BootstrapUtil() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static void waitAndExit() {
+    try {
+      TimeUnit.SECONDS.sleep(5);
+    } catch (InterruptedException ignored) {
+    }
+
+    // goodbye!
+    System.exit(1);
+  }
+}

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/HttpUtil.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/HttpUtil.java
@@ -72,17 +72,4 @@ public final class HttpUtil {
       StandardOpenOption.WRITE,
       StandardOpenOption.TRUNCATE_EXISTING);
   }
-
-  public static @NonNull <T> HttpResponse.BodyHandler<T> handlerFromSubscriber(
-    @NonNull HttpResponse.BodySubscriber<T> subscriber
-  ) {
-    return info -> {
-      // only apply the subscriber for successful responses
-      if (info.statusCode() == 200) {
-        return subscriber;
-      } else {
-        throw new IllegalStateException("Expected response code 200, got " + info.statusCode());
-      }
-    };
-  }
 }


### PR DESCRIPTION
### Motivation
Currently when we get an invalid status (other than 200) from the remote server we're just throwing an exception which gives closes to 0 information to the end user and the support.

### Modification
Remove throwing the exception when an invalid status gets send by the remote server and replace it with proper logging.

### Result
Better errors for the user and hints for the support.
