### PR TITLE
[ci skip] chore: remove all references to major version in texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CloudNet: The Cloud Network Environment Technology
 
-![CloudNet V3 Logo](.img/header.png)
+![CloudNet 4 Logo](.img/header.png)
 
 ![Build](https://github.com/CloudNetService/CloudNet-v3/actions/workflows/gradle.yml/badge.svg)
 ![Release](https://img.shields.io/maven-central/v/eu.cloudnetservice.cloudnet/driver?label=release&logo=gradle)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CloudNet: The Cloud Network Environment Technology
 
-![CloudNet 4 Logo](.img/header.png)
+![CloudNet Logo](.img/header.png)
 
 ![Build](https://github.com/CloudNetService/CloudNet-v3/actions/workflows/gradle.yml/badge.svg)
 ![Release](https://img.shields.io/maven-central/v/eu.cloudnetservice.cloudnet/driver?label=release&logo=gradle)

--- a/launcher/java8/src/main/java/eu/cloudnetservice/launcher/java8/Launcher.java
+++ b/launcher/java8/src/main/java/eu/cloudnetservice/launcher/java8/Launcher.java
@@ -26,7 +26,7 @@ public final class Launcher {
         .newInstance((Object) args);
     } else {
       // CHECKSTYLE.OFF: Launcher has no proper logger
-      System.err.println("CloudNet 4 requires Java 17 (or newer). Download it from https://adoptium.net/");
+      System.err.println("CloudNet requires Java 17 (or newer). Download it from https://adoptium.net/");
       System.exit(1);
       // CHECKSTYLE.ON
     }

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyLoginConfiguration.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyLoginConfiguration.java
@@ -53,17 +53,17 @@ public record SyncProxyLoginConfiguration(
       .targetGroup(targetGroup)
       .maxPlayers(100)
       .modifyMotd(motds -> motds.add(SyncProxyMotd.builder()
-        .firstLine("         &b&o■ &8┃ &3&lCloudNet &8● &cBlizzard &8&l» &7&ov4.0 &8┃ &b&o■")
+        .firstLine("         &b&o■ &8┃ &3&lCloudNet &8● &cBlizzard &8┃ &b&o■")
         .secondLine("              &7&onext &3&l&ogeneration &7&onetwork")
         .autoSlotDistance(1)
         .build()))
       .modifyMaintenanceMotd(motds -> motds.add(SyncProxyMotd.builder()
-        .firstLine("         &b&o■ &8┃ &3&lCloudNet &8● &cBlizzard &8&l» &7&ov4.0 &8┃ &b&o■")
+        .firstLine("         &b&o■ &8┃ &3&lCloudNet &8● &cBlizzard &8┃ &b&o■")
         .secondLine("     &3&lMaintenance &8&l» &7We are still in &3&lmaintenance")
         .autoSlotDistance(1)
         .playerInfo(new String[]{
           " ",
-          "&b&o■ &8┃ &3&lCloudNet &8● &cBlizzard &8&l» &7&ov4.0 &8┃ &b&o■",
+          "&b&o■ &8┃ &3&lCloudNet &8● &cBlizzard &8┃ &b&o■",
           "&7Discord &8&l» &bdiscord.cloudnetservice.eu",
           " "
         })

--- a/node/src/main/resources/files/bungee/config.yml
+++ b/node/src/main/resources/files/bungee/config.yml
@@ -26,7 +26,7 @@ servers:
     restricted: false
 listeners:
   - query_port: 25577
-    motd: '&bCloudNet &7v&b3 &8[&cBlizzard&8] &7BungeeCord &cProxy &7instance'
+    motd: '&bCloudNet 4 &8[&cBlizzard&8] &7BungeeCord &cProxy &7instance'
     tab_list: GLOBAL_PING
     query_enabled: false
     proxy_protocol: false

--- a/node/src/main/resources/files/bungee/config.yml
+++ b/node/src/main/resources/files/bungee/config.yml
@@ -26,7 +26,7 @@ servers:
     restricted: false
 listeners:
   - query_port: 25577
-    motd: '&bCloudNet 4 &8[&cBlizzard&8] &7BungeeCord &cProxy &7instance'
+    motd: '&bCloudNet &8[&cBlizzard&8] &7BungeeCord &cProxy &7instance'
     tab_list: GLOBAL_PING
     query_enabled: false
     proxy_protocol: false

--- a/node/src/main/resources/files/velocity/velocity.toml
+++ b/node/src/main/resources/files/velocity/velocity.toml
@@ -6,7 +6,7 @@ bind = "0.0.0.0:25577"
 
 # What should be the MOTD? This gets displayed when the player adds your server to
 # their server list. Legacy color codes and JSON are accepted.
-motd = "&bCloudNet 4 &8[&cBlizzard&8] &7Velocity &cProxy &7instance"
+motd = "&bCloudNet &8[&cBlizzard&8] &7Velocity &cProxy &7instance"
 
 # What should we display for the maximum number of players? (Velocity does not support a cap
 # on the number of players online.)

--- a/node/src/main/resources/files/velocity/velocity.toml
+++ b/node/src/main/resources/files/velocity/velocity.toml
@@ -6,7 +6,7 @@ bind = "0.0.0.0:25577"
 
 # What should be the MOTD? This gets displayed when the player adds your server to
 # their server list. Legacy color codes and JSON are accepted.
-motd = "&bCloudNet &7v&b3 &8[&cBlizzard&8] &7Velocity &cProxy &7instance"
+motd = "&bCloudNet 4 &8[&cBlizzard&8] &7Velocity &cProxy &7instance"
 
 # What should we display for the maximum number of players? (Velocity does not support a cap
 # on the number of players online.)

--- a/node/src/main/resources/files/waterdogpe/config.yml
+++ b/node/src/main/resources/files/waterdogpe/config.yml
@@ -10,7 +10,7 @@ servers: { }
 listener:
 
   # The Motd which will be displayed in the server tab of a player and returned during ping
-  motd: §bWaterdog§3PE
+  motd: §bCloudNet 4 §8[§cBlizzard§8] §7Velocity §cProxy §7instance
 
   # The server priority list. If not changed by plugins, the proxy will connect the player to the first of those servers
   priorities: [ ]

--- a/node/src/main/resources/files/waterdogpe/config.yml
+++ b/node/src/main/resources/files/waterdogpe/config.yml
@@ -10,7 +10,7 @@ servers: { }
 listener:
 
   # The Motd which will be displayed in the server tab of a player and returned during ping
-  motd: §bCloudNet 4 §8[§cBlizzard§8] §7Velocity §cProxy §7instance
+  motd: §bCloudNet §8[§cBlizzard§8] §7Velocity §cProxy §7instance
 
   # The server priority list. If not changed by plugins, the proxy will connect the player to the first of those servers
   priorities: [ ]

--- a/node/src/main/resources/files/waterdogpe/config.yml
+++ b/node/src/main/resources/files/waterdogpe/config.yml
@@ -10,7 +10,7 @@ servers: { }
 listener:
 
   # The Motd which will be displayed in the server tab of a player and returned during ping
-  motd: §bCloudNet §8[§cBlizzard§8] §7Velocity §cProxy §7instance
+  motd: §bCloudNet §8[§cBlizzard§8] §7WaterdogPE §cProxy §7instance
 
   # The server priority list. If not changed by plugins, the proxy will connect the player to the first of those servers
   priorities: [ ]


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
Currently our default proxy motds still say CloudNet v3.

### Modification
Changed the default motds to say CloudNet

### Result
The proxy motds do not contain CloudNet v3 anymore
