### PR TITLE
fix: only use fallback with forced host on initial connect

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformBridgeManagement.java
@@ -247,7 +247,8 @@ public abstract class PlatformBridgeManagement<P, I> implements BridgeManagement
     // find all matching fallback configurations
     return config.fallbacks().stream()
       // check if a forced host is required
-      .filter(fallback -> fallback.forcedHost() == null || fallback.forcedHost().equals(virtualHost))
+      .filter(fallback -> fallback.forcedHost() == null
+        || (currentServerName == null && fallback.forcedHost().equalsIgnoreCase(virtualHost)))
       // check if the player has the permission to connect to the fallback
       .filter(fallback -> fallback.permission() == null || permissionTester.apply(fallback.permission()))
       // check if the fallback is available from the current group the player is on


### PR DESCRIPTION
### Motivation
Currently fallback configurations with a forced-host set will always be marked as a possible fallback for a player, as the proxy will keep the host which the player used to join. This is wrong as players are unable to connect to a different fallback after joining via a forced-host.

### Modification
Only use forced-host fallback configuration on initial connection.

### Result
Players can connect to a different fallback after joining using a forced host.
