### PR TITLE
[ci skip] git: add fleet settings folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 .gradle/
 build/
 
+# fleet
+.fleet/
+
 # eclipse
 *.classpath
 *.project


### PR DESCRIPTION
### Motivation
Some users might get their hands on the fleet eap, but they shouldn't accidentally commit their fleet settings because we don't exclude them properly from git.

### Modification
Add the .fleet folder to the ignored folders.

### Result
No accidental commits of the fleet settings folder.
