### PR TITLE
fix(node): correctly rewrite bungeecord listeners in the config

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
@@ -16,12 +16,12 @@
 
 package eu.cloudnetservice.node.service.defaults.config;
 
+import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.yaml.YamlFormat;
 import com.google.common.collect.Iterables;
 import eu.cloudnetservice.node.Node;
 import eu.cloudnetservice.node.service.CloudService;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import lombok.NonNull;
 
@@ -33,16 +33,16 @@ public class BungeeConfigurationPreparer extends AbstractServiceConfigurationPre
     if (this.shouldRewriteIp(nodeInstance, cloudService)) {
       var configFile = cloudService.directory().resolve("config.yml");
       try (var config = this.loadConfig(configFile, YamlFormat.defaultInstance(), "files/bungee/config.yml")) {
-        List<Map<String, Object>> listeners = config.get("listeners");
+        List<Config> listeners = config.get("listeners");
         // get the first registered listeners - editing all of them will result in bungee start failures
         // but removing other entries might break setups...
-        Map<String, Object> firstListener = Iterables.getFirst(listeners, null);
+        Config firstListener = Iterables.getFirst(listeners, null);
         Objects.requireNonNull(
           firstListener,
           "No listeners configured in bungee config - please fix your configuration!");
 
         // edit the listener and re-set the config entry
-        firstListener.put("host", String.format(
+        firstListener.valueMap().put("host", String.format(
           "%s:%d",
           cloudService.serviceConfiguration().hostAddress(),
           cloudService.serviceConfiguration().port()));

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
@@ -42,7 +42,7 @@ public class BungeeConfigurationPreparer extends AbstractServiceConfigurationPre
           "No listeners configured in bungee config - please fix your configuration!");
 
         // edit the listener and re-set the config entry
-        firstListener.valueMap().put("host", String.format(
+        firstListener.set("host", String.format(
           "%s:%d",
           cloudService.serviceConfiguration().hostAddress(),
           cloudService.serviceConfiguration().port()));


### PR DESCRIPTION
### Motivation
Currently we asume that we get the listeners in a map. That is not the case as it is wrapped into a SimpleConfig therefore our cast results in an exception.

### Modification
Use the wrapped configuration to modify the host instead of a map.

### Result
The bungeecord configuration is rewritten properly.
