### PR TITLE
chore(bridge): handle cloud service removes for remote services as well

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/BridgeLocalProxyPlayerDisconnectListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/BridgeLocalProxyPlayerDisconnectListener.java
@@ -19,6 +19,7 @@ package eu.cloudnetservice.modules.bridge.node.listener;
 import com.google.common.collect.Iterables;
 import eu.cloudnetservice.driver.CloudNetDriver;
 import eu.cloudnetservice.driver.event.EventListener;
+import eu.cloudnetservice.driver.event.events.service.CloudServiceLifecycleChangeEvent;
 import eu.cloudnetservice.driver.event.events.service.CloudServiceUpdateEvent;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
@@ -66,7 +67,14 @@ public final class BridgeLocalProxyPlayerDisconnectListener {
   }
 
   @EventListener
-  public void handle(@NonNull CloudServicePostLifecycleEvent event) {
+  public void handleLocalServiceLifecycleChange(@NonNull CloudServicePostLifecycleEvent event) {
+    if (event.newLifeCycle() == ServiceLifeCycle.STOPPED || event.newLifeCycle() == ServiceLifeCycle.DELETED) {
+      this.handleCloudServiceRemove(event.serviceInfo());
+    }
+  }
+
+  @EventListener
+  public void handleClusterServiceLifecycleChange(@NonNull CloudServiceLifecycleChangeEvent event) {
     if (event.newLifeCycle() == ServiceLifeCycle.STOPPED || event.newLifeCycle() == ServiceLifeCycle.DELETED) {
       this.handleCloudServiceRemove(event.serviceInfo());
     }


### PR DESCRIPTION
### Motivation
If a service on a remote node get's stopped or a node disconnects from the cluster, we should run the same service remove routine on the local node as if a service get's removed on the local node.

### Modification
Call `handleCloudServiceRemove` for removed cluster services as well.

### Result
Better handling of removed cluster services, for example caused by a disconnect.
