### PR TITLE
chore(node): make toggle an alias for `service <service> screen`

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
@@ -249,7 +249,7 @@ public final class ServiceCommand {
     }
   }
 
-  @CommandMethod(value = "service|ser <name> toggle", requiredSender = ConsoleCommandSource.class)
+  @CommandMethod(value = "service|ser <name> screen|toggle", requiredSender = ConsoleCommandSource.class)
   public void toggleScreens(
     @NonNull CommandSource source,
     @NonNull @Argument("name") Collection<ServiceInfoSnapshot> matchedServices


### PR DESCRIPTION
### Motivation
Currently there is the `ser <service> toggle` command, this naming is not great because it does not really indicate what the command does.

### Modification
Changes the static literal to `screen` and added `toggle` as alias.

### Result
Its more clear what the desired command does.
