### PR TITLE
chore: improve component convert between platforms

### DIFF
--- a/ext/adventure-helper/build.gradle.kts
+++ b/ext/adventure-helper/build.gradle.kts
@@ -17,6 +17,7 @@
 dependencies {
   "compileOnly"(libs.adventureApi)
   "compileOnly"(libs.adventureSerializerLegacy)
+  "compileOnly"(libs.bungeecordChat)
 }
 
 configurations {

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/adventure/AdventureSerializerUtil.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/adventure/AdventureSerializerUtil.java
@@ -16,10 +16,14 @@
 
 package eu.cloudnetservice.ext.adventure;
 
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import lombok.NonNull;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
+/**
+ * @deprecated use {@link ComponentFormats#BUNGEE_TO_ADVENTURE} instead.
+ */
+@Deprecated(forRemoval = true)
 public final class AdventureSerializerUtil {
 
   public static final char HEX_CHAR = '#';
@@ -27,67 +31,15 @@ public final class AdventureSerializerUtil {
   public static final char LEGACY_CHAR = '&';
   public static final char BUNGEE_HEX_CHAR = 'x';
 
-  private static final LegacyComponentSerializer SERIALIZER = LegacyComponentSerializer.builder()
-    .character(COLOR_CHAR)
-    .extractUrls()
-    .hexColors()
-    .build();
-
   private AdventureSerializerUtil() {
     throw new UnsupportedOperationException();
   }
 
   public static @NonNull String serializeToString(@NonNull String textToSerialize) {
-    var result = new StringBuilder();
-    // find all legacy chars
-    var chars = textToSerialize.toCharArray();
-    for (var i = 0; i < chars.length; i++) {
-      // check if there is at least one char following the current index
-      if (i < chars.length - 1) {
-        // check if the next char is a legacy color char
-        var next = chars[i + 1];
-        // check if the current char is a legacy text char
-        if (chars[i] == LEGACY_CHAR) {
-          // check if the next char is a legacy color char
-          if ((next >= '0' && next <= '9')
-            || (next >= 'a' && next <= 'f')
-            || (next >= 'k' && next <= 'o')
-            || next == 'r') {
-            result.append(COLOR_CHAR);
-            continue;
-          }
-          // check if the next char is a hex begin char
-          // 7 because of current hex_char 6_digit_hex (for example &#000fff)
-          if (next == HEX_CHAR && i + 7 < chars.length) {
-            result.append(COLOR_CHAR);
-            continue;
-          }
-        }
-        // check for the stupid bungee cord chat hex format - do this check for both formats, '&' and '§'
-        // 13 because of current hex_char 12_digit_hex (for example &x&0&0&0&f&f&f)
-        if ((chars[i] == COLOR_CHAR || chars[i] == LEGACY_CHAR) && next == BUNGEE_HEX_CHAR && i + 13 < chars.length) {
-          // open the modern hex format
-          result.append(COLOR_CHAR).append(HEX_CHAR);
-          // replace the terrible format
-          // begin at i+3 to skip the initial &x
-          // end at i+14 because the hex format is 14 chars long
-          // pos+=2 to skip each &
-          for (var pos = i + 3; pos < i + 14; pos += 2) {
-            result.append(chars[pos]);
-          }
-          // skip over the hex thing and continue there
-          i += 13;
-          continue;
-        }
-      }
-      // append just the char at the position
-      result.append(chars[i]);
-    }
-    return result.toString();
+    return ComponentFormats.BUNGEE_TO_ADVENTURE.convertText(textToSerialize);
   }
 
   public static @NonNull Component serialize(@NonNull String input) {
-    // serialize the text now
-    return SERIALIZER.deserialize(serializeToString(input));
+    return ComponentFormats.BUNGEE_TO_ADVENTURE.convert(input);
   }
 }

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/AdventureComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/AdventureComponentFormat.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.ext.component;
+
+import lombok.NonNull;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+
+final class AdventureComponentFormat extends JavaEditionComponentFormat<Component> {
+
+  private static final char HEX_CHAR = '#';
+  private static final int HEX_SEG_LENGTH = 8;
+
+  private static final LegacyComponentSerializer SERIALIZER = LegacyComponentSerializer.builder()
+    .character(COLOR_CHAR)
+    .extractUrls()
+    .hexColors()
+    .build();
+
+  @Override
+  public int hexSegmentLength() {
+    return HEX_SEG_LENGTH;
+  }
+
+  @Override
+  public char hexIndicationChar() {
+    return HEX_CHAR;
+  }
+
+  @Override
+  public boolean usesColorCharAsHexDelimiter() {
+    return false;
+  }
+
+  @Override
+  public boolean nextSegmentIsHexadecimalFormatting(char[] fullData, int pos, char current, char next) {
+    return (current == COLOR_CHAR || current == LEGACY_CHAR)
+      && next == HEX_CHAR
+      && (pos + HEX_SEG_LENGTH) < fullData.length;
+  }
+
+  @Override
+  public @NonNull Component encodeStringToComponent(@NonNull String text) {
+    return SERIALIZER.deserialize(text);
+  }
+}

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/BungeeComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/BungeeComponentFormat.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.ext.component;
+
+import lombok.NonNull;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+
+final class BungeeComponentFormat extends JavaEditionComponentFormat<BaseComponent[]> {
+
+  private static final char HEX_CHAR = 'x';
+  private static final int HEX_SEG_LENGTH = 14;
+
+  @Override
+  public int hexSegmentLength() {
+    return HEX_SEG_LENGTH;
+  }
+
+  @Override
+  public char hexIndicationChar() {
+    return HEX_CHAR;
+  }
+
+  @Override
+  public boolean usesColorCharAsHexDelimiter() {
+    return true;
+  }
+
+  @Override
+  public boolean nextSegmentIsHexadecimalFormatting(char[] fullData, int pos, char current, char next) {
+    return (current == COLOR_CHAR || current == LEGACY_CHAR)
+      && next == HEX_CHAR
+      && (pos + HEX_SEG_LENGTH) < fullData.length;
+  }
+
+  @Override
+  public @NonNull BaseComponent[] encodeStringToComponent(@NonNull String text) {
+    return TextComponent.fromLegacyText(text);
+  }
+}

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentConverter.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentConverter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.ext.component;
+
+import lombok.NonNull;
+
+public class ComponentConverter<C> {
+
+  final ComponentFormat<?> source;
+  final ComponentFormat<C> target;
+
+  ComponentConverter(@NonNull ComponentFormat<?> source, @NonNull ComponentFormat<C> target) {
+    this.source = source;
+    this.target = target;
+  }
+
+  public @NonNull C convert(@NonNull String input) {
+    var convertedText = this.convertText(input);
+    return this.target.encodeStringToComponent(convertedText);
+  }
+
+  public @NonNull String convertText(@NonNull String input) {
+    var result = new StringBuilder();
+    // find all legacy chars
+    var chars = input.toCharArray();
+    for (var i = 0; i < chars.length; i++) {
+      // check if there is at least one char following the current index
+      if (i < chars.length - 1) {
+        // check if the next char is a legacy color char
+        var curr = chars[i];
+        var next = chars[i + 1];
+
+        // check if the next segment is holding legacy color info
+        if (this.source.nextSegmentIsLegacyFormatting(chars, i, curr, next)) {
+          // legacy formatting segment:
+          //   1: append the color indication char of the target format
+          //   2: append the legacy color char which is following the current indication char
+          //   3: skip the next character of the string (the color char)
+          result.append(this.target.colorIndicationChar()).append(next);
+          i++;
+          continue;
+        }
+
+        // check if the segment is holding hex color info
+        if (this.source.nextSegmentIsHexadecimalFormatting(chars, i, curr, next)) {
+          var sourceHexDel = this.source.usesColorCharAsHexDelimiter();
+          var targetHexDel = this.target.usesColorCharAsHexDelimiter();
+          // hex formatting segment:
+          //   1: append the information indicting that a hex format is following
+          result.append(this.target.colorIndicationChar()).append(this.target.hexIndicationChar());
+          //   2: loop over the chars (skip the color & hex indication chars)
+          //   3: skip over all hex delimiter chars as we don't need to worry about them
+          //   4: append the char at the current position, prefixed by the hex delimiter if the target has one
+          for (var pos = i + 2; pos < i + this.source.hexSegmentLength(); pos++) {
+            char c = chars[pos];
+            // skip over delimiter chars - we don't need them
+            if (sourceHexDel && this.source.charIsValidColorIndicationChar(chars, pos, c)) {
+              continue;
+            }
+
+            // append the hex char to the target builder, prefixed by the delimiter char if needed
+            if (targetHexDel) {
+              result.append(this.target.colorIndicationChar());
+            }
+            result.append(c);
+          }
+
+          //   5: move the cursor the next section of the string
+          i += (this.source.hexSegmentLength() - 1);
+          continue;
+        }
+      }
+
+      // no special char, just append it
+      result.append(chars[i]);
+    }
+
+    // build the final string
+    return result.toString();
+  }
+
+  public @NonNull <T> ComponentConverter<T> andThen(@NonNull ComponentConverter<T> downstream) {
+    return new MappingConverter<>(this, downstream);
+  }
+}

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormat.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.ext.component;
+
+import lombok.NonNull;
+
+public interface ComponentFormat<C> {
+
+  int hexSegmentLength();
+
+  char hexIndicationChar();
+
+  char colorIndicationChar();
+
+  boolean usesColorCharAsHexDelimiter();
+
+  boolean charIsValidColorIndicationChar(char[] fullData, int pos, char current);
+
+  boolean nextSegmentIsLegacyFormatting(char[] fullData, int pos, char current, char next);
+
+  boolean nextSegmentIsHexadecimalFormatting(char[] fullData, int pos, char current, char next);
+
+  @NonNull C encodeStringToComponent(@NonNull String text);
+
+  @NonNull <T> ComponentConverter<T> converterTo(@NonNull ComponentFormat<T> targetFormat);
+}

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormats.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormats.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.ext.component;
+
+import net.kyori.adventure.text.Component;
+import net.md_5.bungee.api.chat.BaseComponent;
+
+public final class ComponentFormats {
+
+  public static final ComponentFormat<Component> ADVENTURE = new AdventureComponentFormat();
+  public static final ComponentFormat<BaseComponent[]> BUNGEE = new BungeeComponentFormat();
+
+  public static final ComponentConverter<BaseComponent[]> BUNGEE_TO_BUNGEE = BUNGEE.converterTo(BUNGEE);
+  public static final ComponentConverter<BaseComponent[]> ADVENTURE_TO_BUNGEE = ADVENTURE.converterTo(BUNGEE)
+    .andThen(BUNGEE_TO_BUNGEE);
+
+  public static final ComponentConverter<Component> ADVENTURE_TO_ADVENTURE = ADVENTURE.converterTo(ADVENTURE);
+  public static final ComponentConverter<Component> BUNGEE_TO_ADVENTURE = BUNGEE.converterTo(ADVENTURE)
+    .andThen(ADVENTURE_TO_ADVENTURE);
+
+  private ComponentFormats() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/JavaEditionComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/JavaEditionComponentFormat.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.ext.component;
+
+import lombok.NonNull;
+
+abstract class JavaEditionComponentFormat<C> implements ComponentFormat<C> {
+
+  protected static final char COLOR_CHAR = '§';
+  protected static final char LEGACY_CHAR = '&';
+
+  @Override
+  public char colorIndicationChar() {
+    return COLOR_CHAR;
+  }
+
+  @Override
+  public boolean charIsValidColorIndicationChar(char[] fullData, int pos, char current) {
+    return current == COLOR_CHAR || current == LEGACY_CHAR;
+  }
+
+  @Override
+  public boolean nextSegmentIsLegacyFormatting(char[] fullData, int pos, char current, char next) {
+    return (current == COLOR_CHAR || current == LEGACY_CHAR)
+      && ((next >= '0' && next <= '9')
+      || (next >= 'a' && next <= 'f')
+      || (next >= 'k' && next <= 'o')
+      || next == 'r');
+  }
+
+  @Override
+  public @NonNull <T> ComponentConverter<T> converterTo(@NonNull ComponentFormat<T> targetFormat) {
+    return new ComponentConverter<>(this, targetFormat);
+  }
+}

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/MappingConverter.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/MappingConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.ext.component;
+
+import lombok.NonNull;
+
+final class MappingConverter<C> extends ComponentConverter<C> {
+
+  private final ComponentConverter<?> original;
+  private final ComponentConverter<C> downstream;
+
+  MappingConverter(
+    @NonNull ComponentConverter<?> original,
+    @NonNull ComponentConverter<C> downstream
+  ) {
+    super(downstream.source, downstream.target);
+    this.original = original;
+    this.downstream = downstream;
+  }
+
+  @Override
+  public @NonNull String convertText(@NonNull String input) {
+    var convertedInput = this.original.convertText(input);
+    return this.downstream.convertText(convertedInput);
+  }
+
+  @Override
+  public @NonNull C convert(@NonNull String input) {
+    var convertedInput = this.original.convertText(input);
+    return this.downstream.convert(convertedInput);
+  }
+}

--- a/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/component/ComponentFormatsTest.java
+++ b/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/component/ComponentFormatsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.ext.component;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ComponentFormatsTest {
+
+  @Test
+  void testBasicConversion() {
+    // Hello World
+    var input = "&cHello &bW&6orld&r";
+
+    var outputBungee = ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(input);
+    var outputAdventure = ComponentFormats.BUNGEE_TO_ADVENTURE.convertText(input);
+
+    Assertions.assertEquals("§cHello §bW§6orld§r", outputBungee);
+    Assertions.assertEquals("§cHello §bW§6orld§r", outputAdventure);
+  }
+
+  @Test
+  void testHexFormatFromAdventureToBungee() {
+    // Hello World
+    var input = "&#084cfbH&#1a5ffbe&#2d71fbl&#3f84fcl&#5196fco &#64a9fcW&#76bbfco&#88cefdr&#9be0fdl&#adf3fdd";
+    var bungee = "§x§0§8§4§c§f§bH§x§1§a§5§f§f§be§x§2§d§7§1§f§bl§x§3§f§8§4§f§cl§x§5§1§9§6§f§co "
+      + "§x§6§4§a§9§f§cW§x§7§6§b§b§f§co§x§8§8§c§e§f§dr§x§9§b§e§0§f§dl§x§a§d§f§3§f§dd";
+
+    var convertedToBungee = ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(input);
+    var convertedToAdventure = ComponentFormats.BUNGEE_TO_ADVENTURE.convertText(input);
+
+    Assertions.assertEquals(bungee, convertedToBungee);
+    Assertions.assertEquals(input.replace('&', '§'), convertedToAdventure);
+  }
+
+  @Test
+  void testHexFormatFromBungeeToAdventure() {
+    // Hello World
+    var input = "&x&0&8&4&c&f&bH&x&1&a&5&f&f&be&x&2&d&7&1&f&bl&x&3&f&8&4&f&cl&x&5&1&9&6&f&co "
+      + "&x&6&4&a&9&f&cW&x&7&6&b&b&f&co&x&8&8&c&e&f&dr&x&9&b&e&0&f&dl&x&a&d&f&3&f&dd";
+    var adventure = "§#084cfbH§#1a5ffbe§#2d71fbl§#3f84fcl§#5196fco §#64a9fcW§#76bbfco§#88cefdr§#9be0fdl§#adf3fdd";
+
+    var convertedToBungee = ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(input);
+    var convertedToAdventure = ComponentFormats.BUNGEE_TO_ADVENTURE.convertText(input);
+
+    Assertions.assertEquals(adventure, convertedToAdventure);
+    Assertions.assertEquals(input.replace('&', '§'), convertedToBungee);
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -166,6 +166,7 @@ npcLib = { group = "com.github.juliarn.NPC-Lib", name = "bukkit", version.ref = 
 npcLibLabymod = { group = "com.github.juliarn.NPC-Lib", name = "labymod", version.ref = "npcLib" }
 modLauncher = { group = "cpw.mods", name = "modlauncher", version.ref = "modlauncher" }
 placeholderApi = { group = "me.clip", name = "placeholderapi", version.ref = "placeholderApi" }
+bungeecordChat = { group = "net.md-5", name = "bungeecord-chat", version.ref = "bungeecord" }
 
 # fabric platform special dependencies
 minecraft = { group = "com.mojang", name = "minecraft", version.ref = "minecraft" }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
@@ -28,7 +28,7 @@ import eu.cloudnetservice.common.Nameable;
 import eu.cloudnetservice.common.language.I18n;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.BridgeServiceProperties;
 import eu.cloudnetservice.modules.bridge.node.player.NodePlayerManager;
 import eu.cloudnetservice.modules.bridge.player.CloudOfflinePlayer;
@@ -211,7 +211,9 @@ public class PlayersCommand {
     @Nullable @Greedy @Argument("reason") String reason,
     @Flag("force") boolean force
   ) {
-    var reasonComponent = reason == null ? Component.empty() : AdventureSerializerUtil.serialize(reason);
+    var reasonComponent = reason == null
+      ? Component.empty()
+      : ComponentFormats.BUNGEE_TO_ADVENTURE.convert(reason);
     player.playerExecutor().kick(reasonComponent);
 
     source.sendMessage(I18n.trans("module-bridge-command-players-kick-player",
@@ -232,7 +234,7 @@ public class PlayersCommand {
     @NonNull @Argument("player") CloudPlayer player,
     @NonNull @Greedy @Argument("message") String message
   ) {
-    player.playerExecutor().sendChatMessage(AdventureSerializerUtil.serialize(message));
+    player.playerExecutor().sendChatMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message));
     source.sendMessage(
       I18n.trans("module-bridge-command-players-send-player-message", player.name(), player.uniqueId()));
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/network/NodePlayerChannelMessageListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/network/NodePlayerChannelMessageListener.java
@@ -21,7 +21,7 @@ import eu.cloudnetservice.driver.event.EventListener;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.event.events.channel.ChannelMessageReceiveEvent;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.BridgeManagement;
 import eu.cloudnetservice.modules.bridge.event.BridgeDeleteCloudOfflinePlayerEvent;
 import eu.cloudnetservice.modules.bridge.event.BridgeProxyPlayerDisconnectEvent;
@@ -70,7 +70,7 @@ public final class NodePlayerChannelMessageListener {
           var preLoginEvent = new LocalPlayerPreLoginEvent(info);
           // set the event cancelled by default if the player is already connected
           if (this.playerManager.onlinePlayer(info.uniqueId()) != null) {
-            preLoginEvent.result(LocalPlayerPreLoginEvent.Result.denied(AdventureSerializerUtil.serialize(
+            preLoginEvent.result(LocalPlayerPreLoginEvent.Result.denied(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
               this.bridgeManagement.configuration().message(
                 Locale.ENGLISH,
                 "already-connected"))));

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordHelper.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordHelper.java
@@ -17,7 +17,7 @@
 package eu.cloudnetservice.modules.bridge.platform.bungeecord;
 
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.net.InetSocketAddress;
@@ -26,7 +26,6 @@ import lombok.NonNull;
 import net.md_5.bungee.api.ProxyConfig;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 
 public final class BungeeCordHelper {
@@ -87,7 +86,7 @@ public final class BungeeCordHelper {
   }
 
   public static @NonNull BaseComponent[] translateToComponent(@NonNull String input) {
-    return TextComponent.fromLegacyText(AdventureSerializerUtil.serializeToString(input));
+    return ComponentFormats.ADVENTURE_TO_BUNGEE.convert(input);
   }
 
   private static @NonNull ServerInfo constructServerInfo(@NonNull ServiceInfoSnapshot snapshot) {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomPlayerManagementListener.java
@@ -16,7 +16,7 @@
 
 package eu.cloudnetservice.modules.bridge.platform.minestom;
 
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.helper.ServerPlatformHelper;
 import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
@@ -59,7 +59,7 @@ public final class MinestomPlayerManagementListener {
     if (task != null) {
       // check if maintenance is activated
       if (task.maintenance() && !player.hasPermission("cloudnet.bridge.maintenance")) {
-        player.kick(AdventureSerializerUtil.serialize(this.management.configuration().message(
+        player.kick(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
           player.getLocale(),
           "server-join-cancel-because-maintenance")));
         return;
@@ -67,7 +67,7 @@ public final class MinestomPlayerManagementListener {
       // check if a custom permission is required to join
       var permission = task.properties().getString("requiredPermission");
       if (permission != null && !player.hasPermission(permission)) {
-        player.kick(AdventureSerializerUtil.serialize(this.management.configuration().message(
+        player.kick(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
           player.getLocale(),
           "server-join-cancel-because-permission")));
       }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityPlayerManagementListener.java
@@ -16,8 +16,6 @@
 
 package eu.cloudnetservice.modules.bridge.platform.velocity;
 
-import static eu.cloudnetservice.ext.adventure.AdventureSerializerUtil.serialize;
-
 import com.velocitypowered.api.event.PostOrder;
 import com.velocitypowered.api.event.ResultedEvent;
 import com.velocitypowered.api.event.Subscribe;
@@ -29,6 +27,7 @@ import com.velocitypowered.api.event.player.ServerPostConnectEvent;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.ServerConnection;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.helper.ProxyPlatformHelper;
 import eu.cloudnetservice.modules.bridge.player.NetworkPlayerProxyInfo;
@@ -62,17 +61,19 @@ public final class VelocityPlayerManagementListener {
     if (task != null) {
       // check if maintenance is activated
       if (task.maintenance() && !event.getPlayer().hasPermission("cloudnet.bridge.maintenance")) {
-        event.setResult(ResultedEvent.ComponentResult.denied(serialize(this.management.configuration().message(
-          Locale.ENGLISH,
-          "proxy-join-cancel-because-maintenance"))));
+        event.setResult(ResultedEvent.ComponentResult.denied(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
+          this.management.configuration().message(
+            Locale.ENGLISH,
+            "proxy-join-cancel-because-maintenance"))));
         return;
       }
       // check if a custom permission is required to join
       var permission = task.properties().getString("requiredPermission");
       if (permission != null && !event.getPlayer().hasPermission(permission)) {
-        event.setResult(ResultedEvent.ComponentResult.denied(serialize(this.management.configuration().message(
-          Locale.ENGLISH,
-          "proxy-join-cancel-because-permission"))));
+        event.setResult(ResultedEvent.ComponentResult.denied(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
+          this.management.configuration().message(
+            Locale.ENGLISH,
+            "proxy-join-cancel-because-permission"))));
         return;
       }
     }
@@ -109,9 +110,10 @@ public final class VelocityPlayerManagementListener {
             return KickedFromServerEvent.RedirectPlayer.create(server, this.extractReasonComponent(event));
           }
         })
-        .orElse(KickedFromServerEvent.DisconnectPlayer.create(serialize(this.management.configuration().message(
-          event.getPlayer().getEffectiveLocale(),
-          "proxy-join-disconnect-because-no-hub")))));
+        .orElse(KickedFromServerEvent.DisconnectPlayer.create(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
+          this.management.configuration().message(
+            event.getPlayer().getEffectiveLocale(),
+            "proxy-join-disconnect-because-no-hub")))));
     }
   }
 
@@ -173,7 +175,7 @@ public final class VelocityPlayerManagementListener {
           .replace("%server%", event.getServer().getServerInfo().getName())
           .replace("%reason%", LegacyComponentSerializer.legacySection().serialize(message));
         // format the message
-        return serialize(baseMessage);
+        return ComponentFormats.BUNGEE_TO_ADVENTURE.convert(baseMessage);
       }
     }
     // render the base message without a reason
@@ -181,6 +183,6 @@ public final class VelocityPlayerManagementListener {
       .replace("%server%", event.getServer().getServerInfo().getName())
       .replace("%reason%", "§cUnknown");
     // format the message
-    return serialize(baseMessage);
+    return ComponentFormats.BUNGEE_TO_ADVENTURE.convert(baseMessage);
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
@@ -16,13 +16,12 @@
 
 package eu.cloudnetservice.modules.bridge.platform.velocity.commands;
 
-import static eu.cloudnetservice.ext.adventure.AdventureSerializerUtil.serialize;
-
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.proxy.ConsoleCommandSource;
 import com.velocitypowered.api.proxy.Player;
 import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import java.util.List;
 import java.util.Locale;
@@ -43,7 +42,8 @@ public final class VelocityCloudCommand implements SimpleCommand {
     var arguments = invocation.arguments();
     if (arguments.length == 0) {
       // <prefix> /cloudnet <command>
-      invocation.source().sendMessage(serialize(this.management.configuration().prefix() + "/cloudnet <command>"));
+      invocation.source().sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
+        this.management.configuration().prefix() + "/cloudnet <command>"));
       return;
     }
     // get the full command line
@@ -58,12 +58,13 @@ public final class VelocityCloudCommand implements SimpleCommand {
         // check if the sender has the required permission to execute the command
         if (info == null || !invocation.source().hasPermission(info.permission())) {
           // no permission to execute the command
-          invocation.source().sendMessage(serialize(this.management.configuration().message(
-            invocation.source() instanceof Player
-              ? ((Player) invocation.source()).getEffectiveLocale()
-              : Locale.ENGLISH,
-            "command-cloud-sub-command-no-permission"
-          ).replace("%command%", arguments[0])));
+          invocation.source().sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
+            this.management.configuration().message(
+              invocation.source() instanceof Player
+                ? ((Player) invocation.source()).getEffectiveLocale()
+                : Locale.ENGLISH,
+              "command-cloud-sub-command-no-permission"
+            ).replace("%command%", arguments[0])));
         } else {
           // execute the command
           this.executeNow(invocation.source(), commandLine);
@@ -74,7 +75,8 @@ public final class VelocityCloudCommand implements SimpleCommand {
 
   private void executeNow(@NonNull CommandSource source, @NonNull String commandLine) {
     for (var output : CloudNetDriver.instance().clusterNodeProvider().sendCommandLine(commandLine)) {
-      source.sendMessage(serialize(this.management.configuration().prefix() + output));
+      source.sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
+        this.management.configuration().prefix() + output));
     }
   }
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityHubCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityHubCommand.java
@@ -19,7 +19,7 @@ package eu.cloudnetservice.modules.bridge.platform.velocity.commands;
 import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import java.util.List;
 import lombok.NonNull;
@@ -39,7 +39,7 @@ public final class VelocityHubCommand implements SimpleCommand {
     if (invocation.source() instanceof Player player) {
       // check if the player is on a fallback already
       if (this.management.isOnAnyFallbackInstance(player)) {
-        player.sendMessage(AdventureSerializerUtil.serialize(this.management.configuration().message(
+        player.sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
           player.getEffectiveLocale(),
           "command-hub-already-in-hub")));
       } else {
@@ -52,13 +52,13 @@ public final class VelocityHubCommand implements SimpleCommand {
           player.createConnectionRequest(hub).connectWithIndication().whenComplete((result, ex) -> {
             // check if the connection was successful
             if (result && ex == null) {
-              player.sendMessage(AdventureSerializerUtil.serialize(this.management.configuration().message(
+              player.sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
                 player.getEffectiveLocale(),
                 "command-hub-success-connect"
               ).replace("%server%", hub.getServerInfo().getName())));
             } else {
               // the connection was not successful
-              player.sendMessage(AdventureSerializerUtil.serialize(this.management.configuration().message(
+              player.sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
                 player.getEffectiveLocale(),
                 "command-hub-no-server-found")));
             }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEDirectPlayerExecutor.java
@@ -16,7 +16,7 @@
 
 package eu.cloudnetservice.modules.bridge.platform.waterdog;
 
-import static eu.cloudnetservice.ext.adventure.AdventureSerializerUtil.serializeToString;
+import static eu.cloudnetservice.ext.component.ComponentFormats.ADVENTURE_TO_BUNGEE;
 import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
 
 import dev.waterdog.waterdogpe.ProxyServer;
@@ -97,14 +97,14 @@ final class WaterDogPEDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
 
   @Override
   public void kick(@NonNull Component message) {
-    this.forEach(player -> player.disconnect(serializeToString(legacySection().serialize(message))));
+    this.forEach(player -> player.disconnect(ADVENTURE_TO_BUNGEE.convertText(legacySection().serialize(message))));
   }
 
   @Override
   public void sendChatMessage(@NonNull Component message, @Nullable String permission) {
     this.forEach(player -> {
       if (permission == null || player.hasPermission(permission)) {
-        player.sendMessage(serializeToString(legacySection().serialize(message)));
+        player.sendMessage(ADVENTURE_TO_BUNGEE.convertText(legacySection().serialize(message)));
       }
     });
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPECloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPECloudCommand.java
@@ -16,13 +16,12 @@
 
 package eu.cloudnetservice.modules.bridge.platform.waterdog.command;
 
-import static eu.cloudnetservice.ext.adventure.AdventureSerializerUtil.serializeToString;
-
 import dev.waterdog.waterdogpe.command.Command;
 import dev.waterdog.waterdogpe.command.CommandSender;
 import dev.waterdog.waterdogpe.command.CommandSettings;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import java.util.Locale;
 import lombok.NonNull;
@@ -45,7 +44,8 @@ public final class WaterDogPECloudCommand extends Command {
     // check if any arguments are provided
     if (args.length == 0) {
       // <prefix> /cloudnet <command>
-      sender.sendMessage(serializeToString(this.management.configuration().prefix() + "/cloudnet <command>"));
+      sender.sendMessage(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(
+        this.management.configuration().prefix() + "/cloudnet <command>"));
       return true;
     }
     // get the full command line
@@ -57,7 +57,7 @@ public final class WaterDogPECloudCommand extends Command {
         // check if the player has the required permission
         if (info == null || !sender.hasPermission(info.permission())) {
           // no permission
-          sender.sendMessage(serializeToString(this.management.configuration().message(
+          sender.sendMessage(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(this.management.configuration().message(
             Locale.ENGLISH,
             "command-cloud-sub-command-no-permission"
           ).replace("%command%", args[0])));
@@ -75,7 +75,8 @@ public final class WaterDogPECloudCommand extends Command {
 
   private void executeNow(@NonNull CommandSender sender, @NonNull String commandLine) {
     for (var output : CloudNetDriver.instance().clusterNodeProvider().sendCommandLine(commandLine)) {
-      sender.sendMessage(serializeToString(this.management.configuration().prefix() + output));
+      sender.sendMessage(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(
+        this.management.configuration().prefix() + output));
     }
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPEHubCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPEHubCommand.java
@@ -16,13 +16,12 @@
 
 package eu.cloudnetservice.modules.bridge.platform.waterdog.command;
 
-import static eu.cloudnetservice.ext.adventure.AdventureSerializerUtil.serializeToString;
-
 import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.command.Command;
 import dev.waterdog.waterdogpe.command.CommandSender;
 import dev.waterdog.waterdogpe.command.CommandSettings;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import java.util.Locale;
 import lombok.NonNull;
@@ -45,7 +44,7 @@ public final class WaterDogPEHubCommand extends Command {
     if (sender instanceof ProxiedPlayer player) {
       // check if the player is on a fallback already
       if (this.management.isOnAnyFallbackInstance(player)) {
-        player.sendMessage(serializeToString(this.management.configuration().message(
+        player.sendMessage(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(this.management.configuration().message(
           Locale.ENGLISH,
           "command-hub-already-in-hub")));
       } else {
@@ -56,7 +55,7 @@ public final class WaterDogPEHubCommand extends Command {
         // check if a fallback was found
         if (hub != null) {
           player.connect(hub);
-          player.sendMessage(serializeToString(this.management.configuration().message(
+          player.sendMessage(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(this.management.configuration().message(
             Locale.ENGLISH,
             "command-hub-success-connect"
           ).replace("%server%", hub.getServerName())));

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomPlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomPlatformSign.java
@@ -18,8 +18,8 @@ package eu.cloudnetservice.modules.signs.platform.minestom;
 
 import eu.cloudnetservice.common.collection.Pair;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
 import eu.cloudnetservice.ext.adventure.AdventureTextFormatLookup;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.configuration.SignLayout;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -42,7 +42,7 @@ public class MinestomPlatformSign extends PlatformSign<Player, String> {
 
   public MinestomPlatformSign(@NonNull Sign base) {
     super(base, input -> {
-      var coloredComponent = AdventureSerializerUtil.serialize(input);
+      var coloredComponent = ComponentFormats.BUNGEE_TO_ADVENTURE.convert(input);
       return GsonComponentSerializer.gson().serialize(coloredComponent);
     });
   }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongePlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongePlatformSign.java
@@ -17,7 +17,7 @@
 package eu.cloudnetservice.modules.signs.platform.sponge;
 
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.configuration.SignLayout;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -41,7 +41,7 @@ final class SpongePlatformSign extends PlatformSign<ServerPlayer, Component> {
   private ServerLocation signLocation;
 
   public SpongePlatformSign(@NonNull Sign base) {
-    super(base, AdventureSerializerUtil::serialize);
+    super(base, ComponentFormats.BUNGEE_TO_ADVENTURE::convert);
   }
 
   @Override

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyListener.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyListener.java
@@ -16,14 +16,12 @@
 
 package eu.cloudnetservice.modules.syncproxy.platform.velocity;
 
-import static eu.cloudnetservice.ext.adventure.AdventureSerializerUtil.serialize;
-import static eu.cloudnetservice.ext.adventure.AdventureSerializerUtil.serializeToString;
-
 import com.velocitypowered.api.event.ResultedEvent;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.LoginEvent;
 import com.velocitypowered.api.event.proxy.ProxyPingEvent;
 import com.velocitypowered.api.proxy.server.ServerPing;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
@@ -61,7 +59,7 @@ public final class VelocitySyncProxyListener {
       var version = event.getPing().getVersion();
       // check if a protocol text is specified in the config
       if (protocolText != null) {
-        version = new ServerPing.Version(1, serializeToString(protocolText));
+        version = new ServerPing.Version(1, ComponentFormats.BUNGEE_TO_ADVENTURE.convertText(protocolText));
       }
 
       var builder = ServerPing.builder()
@@ -76,7 +74,8 @@ public final class VelocitySyncProxyListener {
               s.replace("&", "§"),
               UUID.randomUUID()
             )).toArray(ServerPing.SamplePlayer[]::new) : new ServerPing.SamplePlayer[0])
-        .description(serialize(motd.format(motd.firstLine() + "\n" + motd.secondLine(), onlinePlayers, maxPlayers)));
+        .description(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
+          motd.format(motd.firstLine() + "\n" + motd.secondLine(), onlinePlayers, maxPlayers)));
 
       event.getPing().getFavicon().ifPresent(builder::favicon);
       event.getPing().getModinfo().ifPresent(builder::mods);
@@ -93,7 +92,7 @@ public final class VelocitySyncProxyListener {
       if (loginConfiguration.maintenance()) {
         // the player is either whitelisted or has the permission to join during maintenance, ignore him
         if (!this.syncProxyManagement.checkPlayerMaintenance(player)) {
-          var reason = serialize(
+          var reason = ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
             this.syncProxyManagement.configuration().message("player-login-not-whitelisted", null));
           event.setResult(ResultedEvent.ComponentResult.denied(reason));
         }
@@ -101,7 +100,7 @@ public final class VelocitySyncProxyListener {
         // check if the proxy is full and if the player is allowed to join or not
         if (this.syncProxyManagement.onlinePlayerCount() >= loginConfiguration.maxPlayers()
           && !player.hasPermission("cloudnet.syncproxy.fulljoin")) {
-          var reason = serialize(
+          var reason = ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
             this.syncProxyManagement.configuration().message("player-login-full-server", null));
           event.setResult(ResultedEvent.ComponentResult.denied(reason));
         }

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyManagement.java
@@ -16,11 +16,10 @@
 
 package eu.cloudnetservice.modules.syncproxy.platform.velocity;
 
-import static eu.cloudnetservice.ext.adventure.AdventureSerializerUtil.serialize;
-
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.syncproxy.platform.PlatformSyncProxyManagement;
 import java.util.Collection;
 import java.util.UUID;
@@ -67,20 +66,20 @@ public final class VelocitySyncProxyManagement extends PlatformSyncProxyManageme
       player.getTabList().clearHeaderAndFooter();
     } else {
       player.sendPlayerListHeaderAndFooter(
-        serialize(this.replaceTabPlaceholder(header, player)),
-        serialize(this.replaceTabPlaceholder(footer, player)));
+        ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.replaceTabPlaceholder(header, player)),
+        ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.replaceTabPlaceholder(footer, player)));
     }
   }
 
   @Override
   public void disconnectPlayer(@NonNull Player player, @NonNull String message) {
-    player.disconnect(serialize(message));
+    player.disconnect(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message));
   }
 
   @Override
   public void messagePlayer(@NonNull Player player, @Nullable String message) {
     if (message != null) {
-      player.sendMessage(serialize(message));
+      player.sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message));
     }
   }
 

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyManagement.java
@@ -19,7 +19,7 @@ package eu.cloudnetservice.modules.syncproxy.platform.waterdog;
 import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.syncproxy.platform.PlatformSyncProxyManagement;
 import java.util.Collection;
 import java.util.UUID;
@@ -67,13 +67,13 @@ public final class WaterDogPESyncProxyManagement extends PlatformSyncProxyManage
 
   @Override
   public void disconnectPlayer(@NonNull ProxiedPlayer player, @NonNull String message) {
-    player.disconnect(AdventureSerializerUtil.serializeToString(message));
+    player.disconnect(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(message));
   }
 
   @Override
   public void messagePlayer(@NonNull ProxiedPlayer player, @Nullable String message) {
     if (message != null) {
-      player.sendMessage(AdventureSerializerUtil.serializeToString(message));
+      player.sendMessage(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(message));
     }
   }
 

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/MinestomChatExtension.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/MinestomChatExtension.java
@@ -16,7 +16,7 @@
 
 package eu.cloudnetservice.plugins.chat;
 
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Properties;
@@ -68,7 +68,7 @@ public class MinestomChatExtension extends Extension {
     if (format == null) {
       event.setCancelled(true);
     } else {
-      event.setChatFormat($ -> AdventureSerializerUtil.serialize(format));
+      event.setChatFormat($ -> ComponentFormats.BUNGEE_TO_ADVENTURE.convert(format));
     }
   }
 

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/SpongeChatPlugin.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/SpongeChatPlugin.java
@@ -19,7 +19,7 @@ package eu.cloudnetservice.plugins.chat;
 import com.google.inject.Inject;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -85,7 +85,7 @@ public class SpongeChatPlugin {
     if (format == null) {
       event.setCancelled(true);
     } else {
-      event.setChatFormatter(($, $1, $2, $3) -> Optional.of(AdventureSerializerUtil.serialize(format)));
+      event.setChatFormatter(($, $1, $2, $3) -> Optional.of(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(format)));
     }
   }
 }

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/minestom/MinestomSimpleNameTagsManager.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/minestom/MinestomSimpleNameTagsManager.java
@@ -18,8 +18,8 @@ package eu.cloudnetservice.plugins.simplenametags.minestom;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import eu.cloudnetservice.driver.permission.PermissionGroup;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
 import eu.cloudnetservice.ext.adventure.AdventureTextFormatLookup;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.plugins.simplenametags.SimpleNameTagsManager;
 import java.util.Collection;
 import java.util.UUID;
@@ -73,8 +73,8 @@ final class MinestomSimpleNameTagsManager extends SimpleNameTagsManager<Player> 
       .findFirst()
       .orElseGet(() -> MinecraftServer.getTeamManager().createBuilder(name).build());
     // set the default team attributes
-    team.setPrefix(AdventureSerializerUtil.serialize(group.prefix()));
-    team.setSuffix(AdventureSerializerUtil.serialize(group.suffix()));
+    team.setPrefix(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(group.prefix()));
+    team.setSuffix(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(group.suffix()));
     // set the team color if possible
     var teamColor = AdventureTextFormatLookup.findColor(this.getColorChar(group));
     if (teamColor != null) {

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/sponge/SpongeSimpleNameTagsManager.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/sponge/SpongeSimpleNameTagsManager.java
@@ -17,8 +17,8 @@
 package eu.cloudnetservice.plugins.simplenametags.sponge;
 
 import eu.cloudnetservice.driver.permission.PermissionGroup;
-import eu.cloudnetservice.ext.adventure.AdventureSerializerUtil;
 import eu.cloudnetservice.ext.adventure.AdventureTextFormatLookup;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.plugins.simplenametags.SimpleNameTagsManager;
 import java.util.Collection;
 import java.util.UUID;
@@ -50,7 +50,7 @@ final class SpongeSimpleNameTagsManager extends SimpleNameTagsManager<ServerPlay
 
   @Override
   public void displayName(@NonNull ServerPlayer player, @NonNull String displayName) {
-    player.displayName().set(AdventureSerializerUtil.serialize(displayName));
+    player.displayName().set(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(displayName));
   }
 
   @Override
@@ -74,8 +74,8 @@ final class SpongeSimpleNameTagsManager extends SimpleNameTagsManager<ServerPlay
       return newTeam;
     });
     // set the default team attributes
-    team.setPrefix(AdventureSerializerUtil.serialize(group.prefix()));
-    team.setSuffix(AdventureSerializerUtil.serialize(group.suffix()));
+    team.setPrefix(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(group.prefix()));
+    team.setSuffix(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(group.suffix()));
     // set the team color if possible
     var teamColor = AdventureTextFormatLookup.findColor(this.getColorChar(group));
     if (teamColor != null) {


### PR DESCRIPTION
### Motivation
The current component convert process isn't taking full action when converting components from the config files into components which are processable by specific platforms.

### Modification
Modify the component convert process to allow correct converting a component based on the target platform (for example: `bungee config entry -> adventure component`).

### Result
All text entries of different platform targets can now be used for all platforms.
