### PR TITLE
chore: improve cache keys for rpc method invocation

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/DefaultRPCHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/DefaultRPCHandler.java
@@ -95,7 +95,12 @@ public class DefaultRPCHandler extends DefaultRPCProvider implements RPCHandler 
     // now we try to find the associated method information to the given method name or try to read it
     var instance = inst; // pail
     var information = this.methodCache.get(
-      String.format("%d@%s", instance == null ? -1 : instance.hashCode(), context.methodName()),
+      String.format(
+        "%d@%s@%s@%d",
+        inst == null ? -1 : inst.hashCode(),
+        this.bindingClass.getCanonicalName(),
+        context.methodName(),
+        context.argumentCount()),
       $ -> MethodInformation.find(
         instance,
         this.bindingClass,

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/sender/DefaultRPCSender.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/sender/DefaultRPCSender.java
@@ -104,7 +104,7 @@ public class DefaultRPCSender extends DefaultRPCProvider implements RPCSender {
   public @NonNull RPC invokeMethod(@NonNull String methodName, Object... args) {
     // find the method information of the method we want to invoke
     var information = this.cachedMethodInformation.get(
-      methodName,
+      String.format("%s@%d", methodName, args.length),
       $ -> MethodInformation.find(null, this.targetClass, methodName, null, args.length));
     // generate the rpc from this information
     return new DefaultRPC(


### PR DESCRIPTION
### Motivation
The current RPC cache keys for method information are not 100% unique since we added the amount of parameters of the target method.

### Modification
Ensure that rpc invocation cache keys are always unique.

### Result
Rpc invocation cache keys are always unique.
