### PR TITLE
Fixed server kick

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
@@ -118,12 +118,16 @@ public final class BungeeCordPlayerManagementListener implements Listener {
   @EventHandler(priority = EventPriority.LOWEST)
   public void handle(@NonNull ServerKickEvent event) {
     if (event.getPlayer().isConnected()) {
-      if (event.getState() == ServerKickEvent.State.CONNECTING && event.getPlayer().getServer() != null) {
-        event.setCancelServer(event.getPlayer().getServer().getInfo());
+      // only notify the player if the player was kicked on login and is already connected to a server
+      var curServer = event.getPlayer().getServer();
+
+      if (event.getState() == ServerKickEvent.State.CONNECTING && curServer != null) {
+        event.setCancelServer(curServer.getInfo());
         event.setCancelled(true);
         this.sendKickMessage(event);
         return;
       }
+
       ServerInfo target = this.management.fallback(event.getPlayer(), event.getKickedFrom().getName())
         .map(service -> ProxyServer.getInstance().getServerInfo(service.name()))
         .orElse(null);
@@ -146,7 +150,7 @@ public final class BungeeCordPlayerManagementListener implements Listener {
 
   private void sendKickMessage(@NonNull ServerKickEvent event) {
     // extract the reason for the disconnect and wrap it
-    Locale playerLocale = event.getPlayer().getLocale();
+    var playerLocale = event.getPlayer().getLocale();
     var baseMessage = this.management.configuration().message(playerLocale, "error-connecting-to-server")
       .replace("%server%", event.getKickedFrom().getName())
       .replace("%reason%", BaseComponent.toLegacyText(event.getKickReasonComponent()));

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
@@ -43,7 +43,6 @@ import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.event.EventHandler;
 import net.md_5.bungee.event.EventPriority;
-import org.jetbrains.annotations.NotNull;
 
 public final class BungeeCordPlayerManagementListener implements Listener {
 
@@ -122,7 +121,7 @@ public final class BungeeCordPlayerManagementListener implements Listener {
       if (event.getState() == ServerKickEvent.State.CONNECTING && event.getPlayer().getServer() != null) {
         event.setCancelServer(event.getPlayer().getServer().getInfo());
         event.setCancelled(true);
-        sendKickMessage(event);
+        this.sendKickMessage(event);
         return;
       }
       ServerInfo target = this.management.fallback(event.getPlayer(), event.getKickedFrom().getName())
@@ -133,7 +132,7 @@ public final class BungeeCordPlayerManagementListener implements Listener {
       if (target != null) {
         event.setCancelled(true);
         event.setCancelServer(target);
-        sendKickMessage(event);
+        this.sendKickMessage(event);
       } else {
         // no lobby server - the player will disconnect
         event.setCancelled(false);
@@ -145,7 +144,7 @@ public final class BungeeCordPlayerManagementListener implements Listener {
     }
   }
 
-  private void sendKickMessage(@NotNull ServerKickEvent event) {
+  private void sendKickMessage(@NonNull ServerKickEvent event) {
     // extract the reason for the disconnect and wrap it
     Locale playerLocale = event.getPlayer().getLocale();
     var baseMessage = this.management.configuration().message(playerLocale, "error-connecting-to-server")

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
@@ -120,7 +120,13 @@ public final class BungeeCordPlayerManagementListener implements Listener {
     if (event.getPlayer().isConnected()) {
       ServerInfo target = this.management.fallback(event.getPlayer(), event.getKickedFrom().getName())
         .map(service -> ProxyServer.getInstance().getServerInfo(service.name()))
-        .orElse(null);
+        .orElseGet(() -> {
+          if (event.getState() == ServerKickEvent.State.CONNECTING && event.getPlayer().getServer() != null) {
+            return event.getPlayer().getServer().getInfo();
+          }
+          return null;
+        });
+
       // check if the server is present
       if (target != null) {
         event.setCancelled(true);

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityPlayerManagementListener.java
@@ -96,9 +96,9 @@ public final class VelocityPlayerManagementListener {
   public void handleServerKick(@NonNull KickedFromServerEvent event) {
     // check if the player is still active
     if (event.getPlayer().isActive()) {
+      // only notify the player if the player was kicked on login and is already connected to a server
       var curServer = event.getPlayer().getCurrentServer().orElse(null);
 
-      // only notify the player if the player was kicked on login and is already connected to a server
       if (curServer != null && event.kickedDuringServerConnect()) {
         // send the player a nice message - velocity will keep the connection to the current server
         event.setResult(KickedFromServerEvent.Notify.create(this.extractReasonComponent(event)));


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
When a server kicks a player while logging in and the player wants to join again the player will get kicked from the network stating that no lobby server could be found.

### Modification
<!-- Describe the modification you've done to the codebase -->
In Velocity I moved the notify result code so it runs before fallbacks are getting queried. In Bungeecord I tried to implement the same functionallity altough I haven't tested that yet and don't have much experience with the Bungeecord-API. 

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
This PR stops the player from getting kicked from the entire network as long as the player has an active connection to a server.

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->