### PR TITLE
chore: prevent possible invalid cast when using DataBuf#readString

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyImmutableDataBuf.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyImmutableDataBuf.java
@@ -144,7 +144,7 @@ public class NettyImmutableDataBuf implements DataBuf {
   public @NonNull String readString() {
     return this.hotRead(buf -> {
       var length = NettyUtil.readVarInt(buf);
-      return (String) buf.readCharSequence(length, StandardCharsets.UTF_8);
+      return buf.readCharSequence(length, StandardCharsets.UTF_8).toString();
     });
   }
 


### PR DESCRIPTION
### Motivation
The method `Buffer#readCharSequence` by netty which we're currently using to read a string from a buffer returns (as the name suggest) a CharSequence and not a string. Currently the method (when using UTF8 as the charset) only returns string instances, but there is no guarantee for that in the future. Therefore casting the CharSequence to a string might cause exceptions if netty changes the implementation.

### Modification
Call `toString` on the returned CharSequence object to convert to a string rather than casting. The specification (https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/CharSequence.html#toString()) specifies that a correct string with the same chars as the sequence contains is returned.

### Result
Removed one possible unsafe cast and update pitfall.
