### PR TITLE
chore: remove the connect host address from the json configuration

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
@@ -90,7 +90,6 @@ public final class JsonConfiguration implements Configuration {
 
   private String jvmCommand;
   private String hostAddress;
-  private String connectHostAddress;
   private Map<String, String> ipAliases;
 
   private RestConfiguration restConfiguration;
@@ -233,10 +232,6 @@ public final class JsonConfiguration implements Configuration {
 
     if (this.hostAddress == null) {
       this.hostAddress = ConfigurationUtil.get("cloudnet.config.hostAddress", NetworkUtil.localAddress());
-    }
-
-    if (this.connectHostAddress == null) {
-      this.connectHostAddress = ConfigurationUtil.get("cloudnet.config.connectHostAddress", this.hostAddress);
     }
 
     if (this.ipAliases == null) {


### PR DESCRIPTION
### Motivation
The connect host address is still present in the configuration of the node, but is not used at all as we have per task hosts now.

### Modification
Removed the connect host address field from the json configuration.

### Result
The connect host address is not part of the node config anymore.
