### PR TITLE
Gradle build adjustments

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'gradle'
 
       - name: Run build lifecycle
-        run: ./gradlew build checkLicenses test shadowJar genUpdaterInformation --no-daemon --stacktrace
+        run: ./gradlew build test shadowJar genUpdaterInformation --no-daemon --stacktrace
 
       - name: Publish updater metadata
         uses: s0/git-publish-subdir-action@develop

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,13 +1,16 @@
-Copyright 2019-2022 CloudNetService team & contributors
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import org.cadixdev.gradle.licenser.LicenseExtension
+import com.diffplug.gradle.spotless.SpotlessExtension
 
 plugins {
   id("cloudnet.parent-build-logic")
-  alias(libs.plugins.licenser)
+  alias(libs.plugins.spottless)
   alias(libs.plugins.nexusPublish)
   alias(libs.plugins.fabricLoom) apply false
 }
 
-defaultTasks("build", "checkLicenses", "test", "shadowJar")
+defaultTasks("build", "test", "shadowJar")
 
 allprojects {
   version = Versions.cloudNet
   group = "eu.cloudnetservice.cloudnet"
-  description = "The alternative Minecraft Java and Bedrock server management solution"
+  description = "A modern application that can dynamically and easily deliver Minecraft oriented software"
 
   repositories {
     mavenCentral()
@@ -58,7 +58,7 @@ subprojects {
 
   apply(plugin = "checkstyle")
   apply(plugin = "java-library")
-  apply(plugin = "org.cadixdev.licenser")
+  apply(plugin = "com.diffplug.spotless")
 
   dependencies {
     // the 'rootProject.libs.' prefix is needed here - see https://github.com/gradle/gradle/issues/16634
@@ -112,9 +112,10 @@ subprojects {
     toolVersion = Versions.checkstyleTools
   }
 
-  extensions.configure<LicenseExtension> {
-    include("**/*.java")
-    header(rootProject.file("LICENSE_HEADER"))
+  extensions.configure<SpotlessExtension> {
+    java {
+      licenseHeaderFile(rootProject.file("LICENSE_HEADER"))
+    }
   }
 
   tasks.register<org.gradle.jvm.tasks.Jar>("javadocJar") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ import com.diffplug.gradle.spotless.SpotlessExtension
 
 plugins {
   id("cloudnet.parent-build-logic")
-  alias(libs.plugins.spottless)
+  alias(libs.plugins.spotless)
   alias(libs.plugins.nexusPublish)
   alias(libs.plugins.fabricLoom) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ metadata.format.version = "1.1"
 shadow = "7.1.2"
 blossom = "1.3.1"
 juppiter = "0.3.3"
-licenser = "0.6.1"
+spottless = "6.11.0"
 fabricLoom = "1.0.4"
 nexusPublish = "1.1.0"
 
@@ -196,7 +196,7 @@ serverPlatform = ["spigot", "sponge", "nukkitX", "minestom"]
 
 blossom = { id = "net.kyori.blossom", version.ref = "blossom" }
 fabricLoom = { id = "fabric-loom", version.ref = "fabricLoom" }
-licenser = { id = "org.cadixdev.licenser", version.ref = "licenser" }
+spottless = { id = "com.diffplug.spotless", version.ref = "spottless" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
 juppiter = { id = "eu.cloudnetservice.juppiter", version.ref = "juppiter" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ metadata.format.version = "1.1"
 shadow = "7.1.2"
 blossom = "1.3.1"
 juppiter = "0.3.3"
-spottless = "6.11.0"
+spotless = "6.11.0"
 fabricLoom = "1.0.4"
 nexusPublish = "1.1.0"
 
@@ -196,7 +196,7 @@ serverPlatform = ["spigot", "sponge", "nukkitX", "minestom"]
 
 blossom = { id = "net.kyori.blossom", version.ref = "blossom" }
 fabricLoom = { id = "fabric-loom", version.ref = "fabricLoom" }
-spottless = { id = "com.diffplug.spotless", version.ref = "spottless" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
 juppiter = { id = "eu.cloudnetservice.juppiter", version.ref = "juppiter" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ metadata.format.version = "1.1"
 # plugins
 shadow = "7.1.2"
 blossom = "1.3.1"
-juppiter = "0.3.3"
+juppiter = "0.4.0"
 spotless = "6.11.0"
 fabricLoom = "1.0.4"
 nexusPublish = "1.1.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {


### PR DESCRIPTION
### Motivation
Our current gradle build configuration uses some deprecated features which makes the build incompatible with the upcoming 8.0 version of gradle.

### Modification
Fixed most of the deprecation warnings which we can currently fix:
 * replaced `licenser` with `spotless` as it gets more updates and isn't using deprecated gradle functions.
 * fixed the deprecation issues in juppiter and bumped the version of it to `0.4.0`
 * enabled the `STABLE_CONFIGURATION_CACHE` preview feature to ensure that our build is not using any conflicting features. See https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:stable for more information.

### Result
No more deprecation warnings that we can fix.
