### PR TITLE
fix: correctly reset fallback profiles when keeping server connection

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityPlayerManagementListener.java
@@ -104,6 +104,8 @@ public final class VelocityPlayerManagementListener {
           var curServer = event.getPlayer().getCurrentServer().map(ServerConnection::getServerInfo).orElse(null);
           if (event.kickedDuringServerConnect() && curServer != null && curServer.equals(server.getServerInfo())) {
             // send the player a nice message - velocity will keep the connection to the current server
+            // therefore we need to reset the fallback profile as no ServerPostConnectEvent will be called
+            this.management.handleFallbackConnectionSuccess(event.getPlayer());
             return KickedFromServerEvent.Notify.create(this.extractReasonComponent(event));
           } else {
             // redirect the player to the next available hub server


### PR DESCRIPTION
### Motivation
When a player connection to the current lobby server is kept due to a server connection issue, the fallback profile of the player is not cleared properly, which causes the fallback server to be ignored when trying the connection again. This leads to the player being disconnected from the proxy.

### Modification
Clear the fallback profile of the player when the connection to the current server is kept open.

### Result
No more disconnects of players when the fallback connection is kept open.
