### PR TITLE
feat(node): add a command to rename groups easily

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/GroupsCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/GroupsCommand.java
@@ -123,7 +123,7 @@ public final class GroupsCommand {
     if (this.groupProvider().groupConfiguration(newName) != null) {
       source.sendMessage(I18n.trans("command-groups-group-already-existing", newName));
     } else {
-      // create a copy with the new name and remove the old task
+      // create a copy with the new name and remove the old group
       this.groupProvider().removeGroupConfiguration(group);
       this.groupProvider().addGroupConfiguration(GroupConfiguration.builder(group).name(newName).build());
       source.sendMessage(I18n.trans("command-groups-rename-success", group.name(), newName));

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/GroupsCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/GroupsCommand.java
@@ -76,7 +76,7 @@ public final class GroupsCommand {
   @CommandMethod("groups create <name>")
   public void createGroup(@NonNull CommandSource source, @NonNull @Argument("name") String groupName) {
     if (this.groupProvider().groupConfiguration(groupName) != null) {
-      source.sendMessage(I18n.trans("command-groups-group-already-existing"));
+      source.sendMessage(I18n.trans("command-groups-group-already-existing", groupName));
     } else {
       this.groupProvider().addGroupConfiguration(GroupConfiguration.builder().name(groupName).build());
       source.sendMessage(I18n.trans("command-groups-create-success", groupName));
@@ -112,6 +112,22 @@ public final class GroupsCommand {
 
     TasksCommand.applyServiceConfigurationDisplay(messages, group);
     source.sendMessage(messages);
+  }
+
+  @CommandMethod("groups rename <oldName> <newName>")
+  public void renameGroup(
+    @NonNull CommandSource source,
+    @NonNull @Argument(value = "oldName") GroupConfiguration group,
+    @NonNull @Argument("newName") String newName
+  ) {
+    if (this.groupProvider().groupConfiguration(newName) != null) {
+      source.sendMessage(I18n.trans("command-groups-group-already-existing", newName));
+    } else {
+      // create a copy with the new name and remove the old task
+      this.groupProvider().removeGroupConfiguration(group);
+      this.groupProvider().addGroupConfiguration(GroupConfiguration.builder(group).name(newName).build());
+      source.sendMessage(I18n.trans("command-groups-rename-success", group.name(), newName));
+    }
   }
 
   @CommandMethod("groups group <name> add environment <environment>")

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -281,9 +281,10 @@ command-groups-add-collection-property=The {0$property$} {1$value$} was successf
 command-groups-remove-collection-property=The {0$property$} {1$value$} was successfully removed from the group {2$group$}
 command-groups-clear-property=The {0$property$} for the group {1$group$} were cleared successfully
 command-groups-delete-group=The group was successfully deleted
-command-groups-group-already-existing=That group already exists
+command-groups-group-already-existing=The group {0$group$} already exists
 command-groups-reload-success=The group configurations have been reloaded
 command-groups-create-success=The group {0$name$} was successfully created
+command-groups-rename-success=The group {0$group$} was successfully renamed to {1$new$}. &cKeep in mind that you might need to change the name in other configurations e.g. tasks
 #
 # Tasks
 #


### PR DESCRIPTION
### Motivation
Currently there is no way to rename groups from the cli, you would have to edit the files yourself.

### Modification
Added a command to rename groups.

### Result
Groups can be renamed using `groups rename <old> <new>`
