### PR TITLE
fix: Add http:// to default influx module config

### DIFF
--- a/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/InfluxModule.java
+++ b/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/InfluxModule.java
@@ -32,7 +32,7 @@ public final class InfluxModule extends DriverModule {
   public void start() {
     // read the config and connect to influx
     var conf = this.readConfig(InfluxConfiguration.class, () -> new InfluxConfiguration(
-      new HostAndPort("127.0.0.1", 8086),
+      new HostAndPort("http://127.0.0.1", 8086),
       "token",
       "org",
       "bucket",


### PR DESCRIPTION
### Motivation
The current default influxdb module config throws an InfluxException because the protocol is missing.

> Exception firing module task entry eu.cloudnetservice.driver.module.DefaultModuleTaskEntry@665522c2
> com.influxdb.exceptions.InfluxException: Unable to parse connection string 127.0.0.1:8086

### Modification
Added http:// to the default host

### Result
> Module eu.cloudnetservice.cloudnet:CloudNet-Influx:4.0.0-RC1 was started successfully