### PR TITLE
fix: copy jvmArguments and processArguments always into linked sets

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.driver.service;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -149,7 +148,7 @@ public record ProcessConfiguration(
      * @throws NullPointerException if the given options collection is null.
      */
     public @NonNull Builder jvmOptions(@NonNull Collection<String> jvmOptions) {
-      this.jvmOptions = new HashSet<>(jvmOptions);
+      this.jvmOptions = new LinkedHashSet<>(jvmOptions);
       return this;
     }
 
@@ -183,7 +182,7 @@ public record ProcessConfiguration(
      * @throws NullPointerException if the given parameters' collection is null.
      */
     public @NonNull Builder processParameters(@NonNull Collection<String> processParameters) {
-      this.processParameters = new HashSet<>(processParameters);
+      this.processParameters = new LinkedHashSet<>(processParameters);
       return this;
     }
 

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfigurationBase.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfigurationBase.java
@@ -165,7 +165,7 @@ public abstract class ServiceConfigurationBase extends JsonDocPropertyHolder {
      * @throws NullPointerException if the given options collection is null.
      */
     public @NonNull B jvmOptions(@NonNull Collection<String> jvmOptions) {
-      this.jvmOptions = new HashSet<>(jvmOptions);
+      this.jvmOptions = new LinkedHashSet<>(jvmOptions);
       return this.self();
     }
 
@@ -199,7 +199,7 @@ public abstract class ServiceConfigurationBase extends JsonDocPropertyHolder {
      * @throws NullPointerException if the given parameters' collection is null.
      */
     public @NonNull B processParameters(@NonNull Collection<String> processParameters) {
-      this.processParameters = new HashSet<>(processParameters);
+      this.processParameters = new LinkedHashSet<>(processParameters);
       return this.self();
     }
 
@@ -300,10 +300,10 @@ public abstract class ServiceConfigurationBase extends JsonDocPropertyHolder {
     }
 
     /**
-     * Modifies the inclusions which should get loaded onto a service created based on the service configuration before it
-     * starts. Inclusions get cached based on their download url. If you need a clean copy of your inclusion you should
-     * change the download url of it. If the node is unable to download an inclusion based on the given url it will be
-     * ignored and a warning gets printed into the console.
+     * Modifies the inclusions which should get loaded onto a service created based on the service configuration before
+     * it starts. Inclusions get cached based on their download url. If you need a clean copy of your inclusion you
+     * should change the download url of it. If the node is unable to download an inclusion based on the given url it
+     * will be ignored and a warning gets printed into the console.
      *
      * @param modifier the modifier to be applied to the already added inclusions of this builder.
      * @return the same instance as used to call the method, for chaining.


### PR DESCRIPTION
### Motivation
The jvmOptions and processArguments should get copied into a LinkedHashSet rather than a normal HashSet to prevent the set from moving the elements internally.

### Modification
Replace creations of HashSet instances to copy process & jvm arguments with a LinkedHashSet.

### Result
No more element moving during set creation.

##### Other context
Fixes #868
