### PR TITLE
chore: bump netty to 5.0.0.Alpha5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ unirest = "4.0.0-RC2"
 nightConfig = "3.6.6"
 annotations = "23.0.0"
 influxClient = "6.5.0"
-netty = "5.0.0.Alpha5-SNAPSHOT"
+netty = "5.0.0.Alpha5"
 
 # platform api versions
 sponge = "9.0.0"


### PR DESCRIPTION
### Motivation
Netty 5.0.0.Alpha5 was released and we should move away from using the snapshot version unless there is a strict requirement for it.

### Modification
Bump netty to 5.0.0.Alpha5.

### Result
Netty is up-to-date on the latest release version.
