### PR TITLE
[ci skip] chore: remove "dep" scope from renovate commit messages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -55,5 +55,5 @@
   "prHourlyLimit": 10,
   "rebaseLabel": "s: rebase",
   "stopUpdatingLabel": "s: stop updates",
-  "commitMessagePrefix": "chore(deps): "
+  "commitMessagePrefix": "chore: "
 }


### PR DESCRIPTION
### Motivation
We've moved away from providing a scope to commit messages, so there is no need that renovate commits still provide the "deps" scope.

### Modification
Remove the "deps" scope from the renovate commit message configuration.

### Result
Renovates doesn't use the "deps" commit scope anymore, aligning with all other commit messages.