### PR TITLE
[ci skip] fix: correctly specify the command to use to install server jars

### DIFF
--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -79,7 +79,7 @@ stop-delete-temp=Deleting temporary files...
 #
 # Services
 #
-cloudnet-service-jar-file-not-found-error=No application file found for CloudService [uniqueId={0$id$} task={1$task$} name={2$name$}]! Please check the availability of this file. Via "t install" a version can be installed into a template.
+cloudnet-service-jar-file-not-found-error=No application file found for CloudService [uniqueId={0$id$} task={1$task$} name={2$name$}]! Please check the availability of this file. Using the "version" command a version can be installed.
 cloudnet-service-manager-cpu-usage-to-high-error=The CPU load is too high to create a new service! The system will try to start this service as soon as there are enough resources.
 cloudnet-service-manager-max-memory-error=The maximum allocatable memory has been reached (of CloudNet, other system resources might still be available)! The limit has to be increased or other services need to be stopped.
 cloudnet-service-networking-connected=CloudService [uniqueId={0$id$} task={1$task$} name={2$name$}] was successfully connected to the channel [serverAddress={3$serverAddress$} clientAddress={4$clientAddress$}]


### PR DESCRIPTION
### Motivation
Currently the message that a service file is missing refers to the `t install` command, which we've moved to the `version` command.

### Modification
Addressed the message to refer to the `version` command.

### Result
The message refers to the correct command.