### PR TITLE
fix: correctly convert npcs and ensure correct scoreboards

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
@@ -125,7 +125,19 @@ public class CloudNetNPCModule extends DriverModule {
       var database = Node.instance().databaseProvider().database(DATABASE_NAME);
       database.documents().stream()
         .filter(doc -> doc.contains("displayName"))
-        .map(doc -> NPC.builder(doc.toInstanceOf(NPC.class)).inventoryName(doc.getString("displayName")).build())
+        .map(doc -> {
+          var displayName = doc.getString("displayName");
+          var npc = doc.toInstanceOf(NPC.class);
+          var npcBuilder = NPC.builder(npc).inventoryName(displayName);
+
+          // make the old display name - if present - the first (0th) info line
+          if (displayName != null) {
+            npc.infoLines().add(0, displayName);
+            npcBuilder.infoLines(npc.infoLines());
+          }
+
+          return npcBuilder.build();
+        })
         .forEach(npc -> database.insert(NodeNPCManagement.documentKey(npc.location()), JsonDocument.newDocument(npc)));
     }
   }

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/CloudNetServiceListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/CloudNetServiceListener.java
@@ -24,9 +24,9 @@ import lombok.NonNull;
 
 final class CloudNetServiceListener {
 
-  private final PlatformNPCManagement<?, ?, ?, ?> management;
+  private final PlatformNPCManagement<?, ?, ?, ?, ?> management;
 
-  public CloudNetServiceListener(@NonNull PlatformNPCManagement<?, ?, ?, ?> management) {
+  public CloudNetServiceListener(@NonNull PlatformNPCManagement<?, ?, ?, ?, ?> management) {
     this.management = management;
   }
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class PlatformNPCManagement<L, P, M, I> extends AbstractNPCManagement {
+public abstract class PlatformNPCManagement<L, P, M, I, S> extends AbstractNPCManagement {
 
   public static final String NPC_CREATE = "npcs_npc_create";
   public static final String NPC_DELETE = "npcs_npc_delete";
@@ -49,7 +49,7 @@ public abstract class PlatformNPCManagement<L, P, M, I> extends AbstractNPCManag
   public static final String NPC_SET_CONFIG = "npcs_update_npc_config";
 
   protected final Map<UUID, ServiceInfoSnapshot> trackedServices = new ConcurrentHashMap<>();
-  protected final Map<WorldPosition, PlatformSelectorEntity<L, P, M, I>> trackedEntities = new ConcurrentHashMap<>();
+  protected final Map<WorldPosition, PlatformSelectorEntity<L, P, M, I, S>> trackedEntities = new ConcurrentHashMap<>();
 
   public PlatformNPCManagement() {
     super(loadNPCConfiguration());
@@ -236,11 +236,11 @@ public abstract class PlatformNPCManagement<L, P, M, I> extends AbstractNPCManag
     }
   }
 
-  public @NonNull Map<WorldPosition, PlatformSelectorEntity<L, P, M, I>> trackedEntities() {
+  public @NonNull Map<WorldPosition, PlatformSelectorEntity<L, P, M, I, S>> trackedEntities() {
     return this.trackedEntities;
   }
 
-  protected abstract @NonNull PlatformSelectorEntity<L, P, M, I> createSelectorEntity(@NonNull NPC base);
+  protected abstract @NonNull PlatformSelectorEntity<L, P, M, I, S> createSelectorEntity(@NonNull NPC base);
 
   protected abstract @NonNull WorldPosition toWorldPosition(@NonNull L location, @NonNull String group);
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformSelectorEntity.java
@@ -21,7 +21,7 @@ import eu.cloudnetservice.modules.npc.NPC;
 import java.util.Set;
 import lombok.NonNull;
 
-public interface PlatformSelectorEntity<L, P, M, I> {
+public interface PlatformSelectorEntity<L, P, M, I, S> {
 
   void spawn();
 
@@ -42,6 +42,8 @@ public interface PlatformSelectorEntity<L, P, M, I> {
   @NonNull I selectorInventory();
 
   void handleInventoryInteract(@NonNull I inv, @NonNull P player, @NonNull M clickedItem);
+
+  void registerScoreboardTeam(@NonNull S scoreboard);
 
   @NonNull NPC npc();
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -50,14 +50,12 @@ public class BukkitPlatformNPCManagement extends
 
   protected final Plugin plugin;
   protected final Platform<World, Player, ItemStack, Plugin> npcPlatform;
-  protected final Scoreboard scoreboard;
   protected final BukkitTask knockBackTask;
 
   protected volatile BukkitTask npcEmoteTask;
 
   public BukkitPlatformNPCManagement(@NonNull Plugin plugin) {
     this.plugin = plugin;
-    this.scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
 
     // npc pool init
     var entry = this.applicableNPCConfigurationEntry();
@@ -182,10 +180,6 @@ public class BukkitPlatformNPCManagement extends
     super.handleInternalNPCConfigUpdate(configuration);
     // re-schedule the emote task if it's not yet running
     this.startEmoteTask(false);
-  }
-
-  public @NonNull Scoreboard scoreboard() {
-    return this.scoreboard;
   }
 
   public @NonNull Platform<World, Player, ItemStack, Plugin> npcPlatform() {

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -45,7 +45,8 @@ import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.util.NumberConversions;
 
-public class BukkitPlatformNPCManagement extends PlatformNPCManagement<Location, Player, ItemStack, Inventory> {
+public class BukkitPlatformNPCManagement extends
+  PlatformNPCManagement<Location, Player, ItemStack, Inventory, Scoreboard> {
 
   protected final Plugin plugin;
   protected final Platform<World, Player, ItemStack, Plugin> npcPlatform;
@@ -136,9 +137,10 @@ public class BukkitPlatformNPCManagement extends PlatformNPCManagement<Location,
     }, 20, 5);
   }
 
-  @NonNull
   @Override
-  protected PlatformSelectorEntity<Location, Player, ItemStack, Inventory> createSelectorEntity(@NonNull NPC base) {
+  protected @NonNull PlatformSelectorEntity<Location, Player, ItemStack, Inventory, Scoreboard> createSelectorEntity(
+    @NonNull NPC base
+  ) {
     return base.npcType() == NPC.NPCType.ENTITY
       ? new EntityBukkitPlatformSelectorEntity(this, this.plugin, base)
       : new NPCBukkitPlatformSelector(this, this.plugin, base, this.npcPlatform);

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -270,7 +270,7 @@ public abstract class BukkitPlatformSelectorEntity
 
   @Override
   public void registerScoreboardTeam(@NonNull Scoreboard scoreboard) {
-    // check if a team for the glowing color is already registered
+    // check if a team for this entity is already created
     var team = scoreboard.getTeam(this.scoreboardTeamName);
     if (team == null) {
       team = scoreboard.registerNewTeam(this.scoreboardTeamName);

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -103,6 +103,10 @@ public abstract class BukkitPlatformSelectorEntity
       for (var player : Bukkit.getOnlinePlayers()) {
         this.registerScoreboardTeam(player.getScoreboard());
       }
+      // let the entity glow!
+      if (this.npc.glowing()) {
+        this.addGlowingEffect();
+      }
       // spawn the info lines
       for (var i = this.npc.infoLines().size() - 1; i >= 0; i--) {
         var armorStand = (ArmorStand) this.npcLocation.getWorld().spawnEntity(
@@ -282,8 +286,6 @@ public abstract class BukkitPlatformSelectorEntity
       if (color != null) {
         SET_COLOR.invoke(team, color);
       }
-      // let the entity glow!
-      this.addGlowingEffect();
     }
   }
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
@@ -34,10 +34,11 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scoreboard.Scoreboard;
 
 public class NPCBukkitPlatformSelector extends BukkitPlatformSelectorEntity {
 
-  public static final NpcFlag<PlatformSelectorEntity<Location, Player, ItemStack, Inventory>> SELECTOR_ENTITY = NpcFlag.flag(
+  public static final NpcFlag<PlatformSelectorEntity<Location, Player, ItemStack, Inventory, Scoreboard>> SELECTOR_ENTITY = NpcFlag.flag(
     "cloudnet_selector_entity",
     null);
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
@@ -124,9 +124,20 @@ public final class BukkitFunctionalityListener implements Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.LOWEST)
+  @EventHandler(priority = EventPriority.MONITOR)
   public void handle(@NonNull PlayerJoinEvent event) {
-    event.getPlayer().setScoreboard(this.management.scoreboard());
+    var player = event.getPlayer();
+
+    // create a new scoreboard for the player if the player uses the main scoreboard
+    var manager = player.getServer().getScoreboardManager();
+    if (manager != null && player.getScoreboard().equals(manager.getMainScoreboard())) {
+      player.setScoreboard(manager.getNewScoreboard());
+    }
+
+    // we have to register each entity to the players scoreboard
+    for (var entity : this.management.trackedEntities().values()) {
+      entity.registerScoreboardTeam(player.getScoreboard());
+    }
   }
 
   @EventHandler(priority = EventPriority.HIGHEST)


### PR DESCRIPTION
### Motivation
The current migration attempt does not consider that the display name the user used now is not displayed anymore at all. Therefore we should take the display name and set it as first info line. Furthermore we did not ensure that the player has a scoreboard just for himself, which might lead to issues with other plugins working with bukkit scoreboards.

### Modification
Added the display name into the migration process. Ensured that each player has it's own scoreboard and we don't replace any other scoreboards

### Result
The migration is now correct and the scoreboards of other plugins are not replaced.
