### PR TITLE
fix: the template installer now installs the templates correctly

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
@@ -25,6 +25,7 @@ import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceLifeCycle;
 import eu.cloudnetservice.driver.service.ServiceRemoteInclusion;
 import eu.cloudnetservice.driver.service.ServiceTemplate;
+import java.util.Collection;
 import java.util.Queue;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
@@ -197,6 +198,33 @@ public interface SpecificCloudServiceProvider {
    * @throws NullPointerException if the given command line is null.
    */
   void runCommand(@NonNull String command);
+
+  /**
+   * Gets the templates that actually are installed on the service. If a template is present in the configuration
+   * {@link eu.cloudnetservice.driver.service.ServiceConfiguration} but wasn't pulled onto the service it won't appear
+   * in this collection.
+   *
+   * @return all installed templates of the service.
+   */
+  @NonNull Collection<ServiceTemplate> installedTemplates();
+
+  /**
+   * Gets the inclusions that actually are installed on the service. If an inclusion is present in the configuration
+   * {@link eu.cloudnetservice.driver.service.ServiceConfiguration} but wasn't pulled onto the service it won't appear
+   * in this collection.
+   *
+   * @return all installed inclusions of the service.
+   */
+  @NonNull Collection<ServiceRemoteInclusion> installedInclusions();
+
+  /**
+   * Gets the deployments that were actually executed for this service. If a deployment is present in the configuration
+   * {@link eu.cloudnetservice.driver.service.ServiceConfiguration} but wasn't executed until now it won't appear in this
+   * collection.
+   *
+   * @return all executed deployments of the service.
+   */
+  @NonNull Collection<ServiceDeployment> installedDeployments();
 
   /**
    * Copies all queued templates onto the service without further checks. Note that this can lead to errors if you try

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
@@ -381,29 +381,32 @@ public final class ServiceCommand {
     list.add("* Lifecycle: " + service.lifeCycle());
     list.add("* Groups: " + String.join(", ", service.configuration().groups()));
 
-    if (!service.configuration().inclusions().isEmpty()) {
+    var installedInclusions = service.provider().installedInclusions();
+    if (!installedInclusions.isEmpty()) {
       list.add(" ");
       list.add("* Includes:");
 
-      for (var inclusion : service.configuration().inclusions()) {
+      for (var inclusion : installedInclusions) {
         list.add("- " + inclusion.url() + " => " + inclusion.destination());
       }
     }
 
-    if (!service.configuration().templates().isEmpty()) {
+    var installedTemplates = service.provider().installedTemplates();
+    if (!installedTemplates.isEmpty()) {
       list.add(" ");
       list.add("* Templates:");
 
-      for (var template : service.configuration().templates()) {
+      for (var template : installedTemplates) {
         list.add("- " + template);
       }
     }
 
-    if (!service.configuration().deployments().isEmpty()) {
+    var installedDeployments = service.provider().installedDeployments();
+    if (!installedDeployments.isEmpty()) {
       list.add(" ");
       list.add("* Deployments:");
 
-      for (var deployment : service.configuration().deployments()) {
+      for (var deployment : installedDeployments) {
         list.add("- ");
         list.add("Template:  " + deployment.template());
         list.add("Excludes: " + deployment.excludes());

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostPrepareEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostPrepareEvent.java
@@ -19,7 +19,7 @@ package eu.cloudnetservice.node.event.service;
 import eu.cloudnetservice.node.service.CloudService;
 import lombok.NonNull;
 
-public class CloudServicePostPrepareEvent extends CloudServiceEvent {
+public final class CloudServicePostPrepareEvent extends CloudServiceEvent {
 
   public CloudServicePostPrepareEvent(@NonNull CloudService service) {
     super(service);

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostPrepareEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostPrepareEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.node.event.service;
+
+import eu.cloudnetservice.node.service.CloudService;
+import lombok.NonNull;
+
+public class CloudServicePostPrepareEvent extends CloudServiceEvent {
+
+  public CloudServicePostPrepareEvent(@NonNull CloudService service) {
+    super(service);
+  }
+}

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePrePrepareEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePrePrepareEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.node.event.service;
+
+import eu.cloudnetservice.node.service.CloudService;
+import lombok.NonNull;
+
+public final class CloudServicePrePrepareEvent extends CloudServiceEvent {
+
+  public CloudServicePrePrepareEvent(@NonNull CloudService service) {
+    super(service);
+  }
+}

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
@@ -677,6 +677,7 @@ public abstract class AbstractService implements CloudService {
     this.waitingDeployments.addAll(this.serviceConfiguration.deployments());
     this.waitingRemoteInclusions.addAll(this.serviceConfiguration.inclusions());
 
+    // initial service details are now ready, let the modules know that we're starting to prepare
     this.eventManager.callEvent(new CloudServicePrePrepareEvent(this));
 
     // load the inclusions

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
@@ -86,7 +86,6 @@ public class JVMService extends AbstractService {
 
   @Override
   protected void startProcess() {
-    // initial service details are now ready, let the modules know that we're starting to prepare
     this.eventManager.callEvent(new CloudServicePreProcessStartEvent(this));
     var environmentType = this.serviceConfiguration().serviceId().environment();
     // load the wrapper information if possible

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
@@ -86,6 +86,7 @@ public class JVMService extends AbstractService {
 
   @Override
   protected void startProcess() {
+    // initial service details are now ready, let the modules know that we're starting to prepare
     this.eventManager.callEvent(new CloudServicePreProcessStartEvent(this));
     var environmentType = this.serviceConfiguration().serviceId().environment();
     // load the wrapper information if possible

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/EmptySpecificCloudServiceProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/EmptySpecificCloudServiceProvider.java
@@ -24,6 +24,8 @@ import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceLifeCycle;
 import eu.cloudnetservice.driver.service.ServiceRemoteInclusion;
 import eu.cloudnetservice.driver.service.ServiceTemplate;
+import java.util.Collection;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingDeque;
 import lombok.NonNull;
@@ -88,6 +90,21 @@ public final class EmptySpecificCloudServiceProvider implements SpecificCloudSer
 
   @Override
   public void runCommand(@NonNull String command) {
+  }
+
+  @Override
+  public @NonNull Collection<ServiceTemplate> installedTemplates() {
+    return List.of();
+  }
+
+  @Override
+  public @NonNull Collection<ServiceRemoteInclusion> installedInclusions() {
+    return List.of();
+  }
+
+  @Override
+  public @NonNull Collection<ServiceDeployment> installedDeployments() {
+    return List.of();
   }
 
   @Override


### PR DESCRIPTION
### Motivation
The template installer of the smart module was not working correctly as we did not have any information about templates that were really installed or just provided in the configuration.

### Modification
Added new installed templates, deployments and inclusions collections that track all templates etc. that were installed onto the service. Using these installed templates the template installer of the smart module now works like intended.

### Result
The template installer works correctly.
