### PR TITLE
fix: remove the process handle from the post process event

### DIFF
--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedService.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedService.java
@@ -38,6 +38,7 @@ import eu.cloudnetservice.modules.docker.config.DockerConfiguration;
 import eu.cloudnetservice.modules.docker.config.DockerImage;
 import eu.cloudnetservice.modules.docker.config.TaskDockerConfig;
 import eu.cloudnetservice.node.Node;
+import eu.cloudnetservice.node.event.service.CloudServicePostProcessStartEvent;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import eu.cloudnetservice.node.service.ServiceConfigurationPreparer;
 import eu.cloudnetservice.node.service.defaults.JVMService;
@@ -230,6 +231,8 @@ public class DockerizedService extends JVMService {
         .withTimestamps(false)
         .withFollowStream(true)
         .exec(new ServiceLogCacheAdapter());
+
+      this.eventManager.callEvent(new CloudServicePostProcessStartEvent(this));
     } catch (NotModifiedException | IOException exception) {
       // the container might be running already
       LOGGER.fine("Unable to start container", exception);

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostProcessStartEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostProcessStartEvent.java
@@ -21,14 +21,7 @@ import lombok.NonNull;
 
 public final class CloudServicePostProcessStartEvent extends CloudServiceEvent {
 
-  private final ProcessHandle processHandle;
-
-  public CloudServicePostProcessStartEvent(@NonNull CloudService service, @NonNull ProcessHandle processHandle) {
+  public CloudServicePostProcessStartEvent(@NonNull CloudService service) {
     super(service);
-    this.processHandle = processHandle;
-  }
-
-  public @NonNull ProcessHandle processHandle() {
-    return this.processHandle;
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
@@ -216,7 +216,7 @@ public class JVMService extends AbstractService {
   ) {
     try {
       this.process = new ProcessBuilder(arguments).directory(this.serviceDirectory.toFile()).start();
-      this.eventManager.callEvent(new CloudServicePostProcessStartEvent(this, this.process.toHandle()));
+      this.eventManager.callEvent(new CloudServicePostProcessStartEvent(this));
     } catch (IOException exception) {
       LOGGER.severe("Unable to start process in %s with command line %s",
         exception,


### PR DESCRIPTION
### Motivation
Currently the CloudServicePostProcessStartEvent contains a ProcessHandle which leads to problems with other service implementations like dockerized services.

### Modification
Removed the ProcessHandle from the event and made sure that docker services call the event too.

### Result
The event is now called for docker services too.