### PR TITLE
fix: resolve some small issues in the current npc bukkit implementation

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
@@ -136,7 +136,9 @@ public final class BukkitFunctionalityListener implements Listener {
 
     // we have to register each entity to the players scoreboard
     for (var entity : this.management.trackedEntities().values()) {
-      entity.registerScoreboardTeam(player.getScoreboard());
+      if (entity.spawned()) {
+        entity.registerScoreboardTeam(player.getScoreboard());
+      }
     }
   }
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitWorldListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitWorldListener.java
@@ -44,6 +44,8 @@ public final class BukkitWorldListener implements Listener {
     this.management.trackedEntities().values()
       .stream()
       .filter(npc -> !npc.spawned())
+      .filter(npc -> npc.location().getWorld() != null) // cannot use canSpawn as the chunk is not marked as loaded yet
+      .filter(npc -> npc.npc().location().world().equals(event.getWorld().getName()))
       .filter(npc -> {
         var chunkX = NumberConversions.floor(npc.location().getX()) >> 4;
         var chunkZ = NumberConversions.floor(npc.location().getZ()) >> 4;
@@ -58,6 +60,7 @@ public final class BukkitWorldListener implements Listener {
     this.management.trackedEntities().values()
       .stream()
       .filter(PlatformSelectorEntity::spawned)
+      .filter(npc -> npc.location().getWorld().getUID().equals(event.getWorld().getUID()))
       .filter(npc -> {
         var chunkX = NumberConversions.floor(npc.location().getX()) >> 4;
         var chunkZ = NumberConversions.floor(npc.location().getZ()) >> 4;


### PR DESCRIPTION
### Motivation
There were two smaller issues causing exceptions when using the npc module. The first one was caused by an attempt to add a not-spawned npc to a scoreboard team on join. The second one was caused by the npc lib, therefore there is no real fix for that in this pr.

### Modification
* Added a check which verifies that a npc is actually spawned before trying to add it to the scoreboard.
* Improved the handling of worlds within the npc module. Altough it didn't cause issues yet, especially the current Chunk Un-/Loading code is prone to cause issues on some servers.
* Added a check which verifies that changes to worlds a npc is located in are reflected into the `location()` and `canSpawn` methods.

### Result
The npc module should no longer throw exceptions on join and should handle world events much smoother.

##### Other context
Fixes #889
