### PR TITLE
chore: bump some dependencies which renovate isn't detecting

### DIFF
--- a/build-extensions/src/main/kotlin/Versions.kt
+++ b/build-extensions/src/main/kotlin/Versions.kt
@@ -21,5 +21,5 @@ object Versions {
   const val cloudNetCodeName = "Blizzard"
 
   // external tools
-  const val checkstyleTools = "10.3.3"
+  const val checkstyleTools = "10.3.4"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,9 +57,9 @@ sponge = "9.0.0"
 velocity = "3.1.1"
 waterdogpe = "1.2.1"
 nukkitX = "1.0-SNAPSHOT"
-minestom = "f5f323fef9"
+minestom = "b37bef427f"
 spigot = "1.8.8-R0.1-SNAPSHOT"
-bungeecord = "1.18-R0.1-SNAPSHOT"
+bungeecord = "1.19-R0.1-SNAPSHOT"
 
 # platform extensions
 vault = "1.7.1"


### PR DESCRIPTION
### Motivation
Some dependencies which renovate isn't detecting are outdated and we should update them.

### Modification
Update bungeecord to 1.19, minestom to the latest commit and checkstyle to 10.3.4

### Result
All dependencies are up-to-date.
