### PR TITLE
[ci skip] chore: lowercase "update" for renovate commits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -55,5 +55,6 @@
   "prHourlyLimit": 10,
   "rebaseLabel": "s: rebase",
   "stopUpdatingLabel": "s: stop updates",
-  "commitMessagePrefix": "chore: "
+  "commitMessagePrefix": "chore: ",
+  "commitMessageAction": "update"
 }


### PR DESCRIPTION
### Motivation
Lowercases the action of renovate PRs to match all other commit messages.

### Modification
Explicitly lowercase the update actions of renovate PRs.

### Result
Commit messages of renovate look now like: `chore: Update dependency ...` and will now look like: `chore: update dependency ...`.
