### PR TITLE
chore: add sponge 1.19.2 to the template installer

### DIFF
--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -446,7 +446,20 @@
             },
             "fetchOverSpongeApi": true,
             "artifact": "spongevanilla",
-            "mcVersion": "1.18.2"
+            "mcVersion": "1.19.2"
+          }
+        },
+        {
+          "name": "1.19.2",
+          "properties": {
+            "copy": {
+              "libraries/.*": "/",
+              "launcher\\.conf": "/",
+              "spongevanilla\\.jar": "/"
+            },
+            "fetchOverSpongeApi": true,
+            "artifact": "spongevanilla",
+            "mcVersion": "1.19.2"
           }
         },
         {


### PR DESCRIPTION
### Motivation
Sponge released the first 1.19.2 builds (api 10) to the downloads api. As there are no breaking changes we can just add it to the version installer.

### Modification
Added sponge 1.19.2 to the template installer and bump `latest` to 1.19.2 as well.

### Result
Sponge 1.19.2 is available through the template installer.

##### Other context
![image](https://user-images.githubusercontent.com/40468651/195371927-25d914c8-865c-4347-979d-44f6c4e08266.png)
