### PR TITLE
fix: correctly set permissions for sponge system subject

### DIFF
--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/CloudPermsPermissionService.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/CloudPermsPermissionService.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.driver.permission.PermissionManagement;
 import eu.cloudnetservice.modules.cloudperms.sponge.service.memory.InMemorySubjectCollection;
 import eu.cloudnetservice.modules.cloudperms.sponge.service.permissible.group.CloudGroupCollection;
 import eu.cloudnetservice.modules.cloudperms.sponge.service.permissible.user.CloudUserCollection;
+import eu.cloudnetservice.modules.cloudperms.sponge.service.system.SystemSubjectCollection;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,6 +47,7 @@ public final class CloudPermsPermissionService implements PermissionService {
   public CloudPermsPermissionService(@NonNull PermissionManagement management) {
     this.collections.put(SUBJECTS_USER, new CloudUserCollection(SUBJECTS_USER, this, management));
     this.collections.put(SUBJECTS_GROUP, new CloudGroupCollection(SUBJECTS_GROUP, this, management));
+    this.collections.put(SUBJECTS_SYSTEM, new SystemSubjectCollection(SUBJECTS_SYSTEM, this));
 
     this.collections.put(SUBJECTS_DEFAULT, new InMemorySubjectCollection(SUBJECTS_DEFAULT, this));
     this.defaultSubject = this.collections.get(SUBJECTS_DEFAULT).loadSubject("default").join();

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubject.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubject.java
@@ -28,7 +28,7 @@ import org.spongepowered.api.service.permission.SubjectData;
 import org.spongepowered.api.service.permission.SubjectReference;
 import org.spongepowered.api.util.Tristate;
 
-final class InMemorySubject implements Subject {
+public class InMemorySubject implements Subject {
 
   private static final Set<Context> CHECK = Collections.singleton(new Context("cause", "perm_check"));
 

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubjectCollection.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubjectCollection.java
@@ -33,7 +33,7 @@ import org.spongepowered.api.service.permission.SubjectCollection;
 import org.spongepowered.api.service.permission.SubjectReference;
 import org.spongepowered.api.util.Tristate;
 
-public final class InMemorySubjectCollection implements SubjectCollection {
+public class InMemorySubjectCollection implements SubjectCollection {
 
   private final String identifier;
   private final PermissionService service;

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/system/SystemSubject.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/system/SystemSubject.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.modules.cloudperms.sponge.service.system;
+
+import eu.cloudnetservice.modules.cloudperms.sponge.service.memory.InMemorySubject;
+import java.util.Set;
+import org.spongepowered.api.service.context.Context;
+import org.spongepowered.api.service.permission.SubjectCollection;
+import org.spongepowered.api.util.Tristate;
+
+public final class SystemSubject extends InMemorySubject implements org.spongepowered.api.SystemSubject {
+
+  public SystemSubject(String identifier, SubjectCollection owner) {
+    super(identifier, owner);
+  }
+
+  @Override
+  public Tristate permissionValue(String permission, Set<Context> contexts) {
+    return Tristate.TRUE;
+  }
+}

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/system/SystemSubjectCollection.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/system/SystemSubjectCollection.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.modules.cloudperms.sponge.service.system;
+
+import eu.cloudnetservice.modules.cloudperms.sponge.service.memory.InMemorySubjectCollection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.spongepowered.api.service.permission.PermissionService;
+import org.spongepowered.api.service.permission.Subject;
+
+public final class SystemSubjectCollection extends InMemorySubjectCollection {
+
+  public SystemSubjectCollection(String identifier, PermissionService service) {
+    super(identifier, service);
+  }
+
+  @Override
+  public CompletableFuture<? extends Subject> loadSubject(String identifier) {
+    return CompletableFuture.completedFuture(new SystemSubject(identifier, this));
+  }
+
+  @Override
+  public Optional<? extends Subject> subject(String identifier) {
+    return Optional.of(new SystemSubject(identifier, this));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> hasSubject(String identifier) {
+    return CompletableFuture.completedFuture(Boolean.TRUE);
+  }
+
+  @Override
+  public CompletableFuture<? extends Map<String, ? extends Subject>> loadSubjects(Iterable<String> identifiers) {
+    return CompletableFuture.completedFuture(StreamSupport.stream(identifiers.spliterator(), false)
+      .collect(Collectors.toMap(
+        Function.identity(),
+        id -> new SystemSubject(id, this))));
+  }
+}


### PR DESCRIPTION
### Motivation
The sponge system subjects weren't handled correctly leading (for example) to the console not having any permissions to execute commands.

### Modification
Correctly handle system subjects and grant them all permissions.

### Result
The console and other sponge system subjects do have all permissions.
