### PR TITLE
fix: resolve smart module regression causing invalid template inclusions

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
@@ -219,8 +219,8 @@ public interface SpecificCloudServiceProvider {
 
   /**
    * Gets the deployments that were actually executed for this service. If a deployment is present in the configuration
-   * {@link eu.cloudnetservice.driver.service.ServiceConfiguration} but wasn't executed until now it won't appear in this
-   * collection.
+   * {@link eu.cloudnetservice.driver.service.ServiceConfiguration} but wasn't executed until now it won't appear in
+   * this collection.
    *
    * @return all executed deployments of the service.
    */
@@ -229,8 +229,23 @@ public interface SpecificCloudServiceProvider {
   /**
    * Copies all queued templates onto the service without further checks. Note that this can lead to errors if you try
    * to override locked files or files which are in use (for example the application jar file).
+   * <p>
+   * This method forces the inclusion of all templates, see {@link #includeWaitingServiceTemplates(boolean)} for more
+   * information.
    */
   void includeWaitingServiceTemplates();
+
+  /**
+   * Copies all queued templates onto the service without further checks. Note that this can lead to errors if you try
+   * to override locked files or files which are in use (for example the application jar file).
+   * <p>
+   * This method only copies all templates to a service if the force option is set to {@code true}. If disabled the
+   * normal checks are made before trying to copy a template (for example if a template should be copied to a static
+   * service).
+   *
+   * @param force if the inclusions of the templates should be forced.
+   */
+  void includeWaitingServiceTemplates(boolean force);
 
   /**
    * Downloads and copies all waiting inclusions onto the service without further checks. Note that this can lead to
@@ -481,11 +496,29 @@ public interface SpecificCloudServiceProvider {
   /**
    * Copies all queued templates onto the service without further checks. Note that this can lead to errors if you try
    * to override locked files or files which are in use (for example the application jar file).
+   * <p>
+   * This method forces the inclusion of all templates, see {@link #includeWaitingServiceTemplates(boolean)} for more
+   * information.
    *
    * @return a task completed when the waiting service templates were included.
    */
   default @NonNull Task<Void> includeWaitingServiceTemplatesAsync() {
-    return Task.supply(this::includeWaitingServiceTemplates);
+    return Task.supply(() -> this.includeWaitingServiceTemplates());
+  }
+
+  /**
+   * Copies all queued templates onto the service without further checks. Note that this can lead to errors if you try
+   * to override locked files or files which are in use (for example the application jar file).
+   * <p>
+   * This method only copies all templates to a service if the force option is set to {@code true}. If disabled the
+   * normal checks are made before trying to copy a template (for example if a template should be copied to a static
+   * service).
+   *
+   * @param force if the inclusions of the templates should be forced.
+   * @return a task completed when the waiting service templates were included.
+   */
+  default @NonNull Task<Void> includeWaitingServiceTemplatesAsync(boolean force) {
+    return Task.supply(() -> this.includeWaitingServiceTemplates(force));
   }
 
   /**

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/EmptySpecificCloudServiceProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/EmptySpecificCloudServiceProvider.java
@@ -112,6 +112,10 @@ public final class EmptySpecificCloudServiceProvider implements SpecificCloudSer
   }
 
   @Override
+  public void includeWaitingServiceTemplates(boolean force) {
+  }
+
+  @Override
   public void includeWaitingServiceInclusions() {
   }
 


### PR DESCRIPTION
### Motivation
In RC3 (PR #880) there was an issue introduced causing invalid template inclusions for services forced by the smart module. This can happen in two different ways:
* the smart module always did pre-inclusion of templates (if `directTemplatesAndInclusionsSetup` was enabled) as a check was missing if the smart module is actually enabled for the task
* the smart module force-installed all templates to the service, even when that operation would be invalid normally. This could for example mean that a template which shouldn't get included to a static service get's included anyway.

### Modification
* Ensure that the smart module is enabled before executing the direct template and inclusion setup
* Only force-install templates when the service is started for the first time (default behaviour)
* Add api methods which give access to the `force` boolean of the `includeWaitingServiceTemplates` method

### Result
The template installation process of the smart module is no longer breaking existing setups and functions as expected.
