### PR TITLE
chore(sftp): don't ignore all exceptions when accessing the con. pool

### DIFF
--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -382,7 +382,10 @@ public class SFTPTemplateStorage implements TemplateStorage {
         return handler.apply(client);
       } catch (IllegalStateException exception) {
         if (exception.getCause() instanceof SSHException sshException) {
-          LOGGER.severe("Failed to retrieve a new client from the SFTP client pool: " + sshException.getMessage());
+          LOGGER.severe(
+            "Failed to retrieve a new client from the SFTP client pool: %s",
+            null,
+            sshException.getMessage());
         }
         // ignore other exceptions
       } catch (Exception exception) {

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -378,7 +378,7 @@ public class SFTPTemplateStorage implements TemplateStorage {
   protected <T> T executeWithClient(@NonNull ThrowableFunction<SFTPClient, T, Exception> handler, T def) {
     // only take a client & execute the action if the pool is still available
     if (this.pool.stillActive()) {
-      try (SFTPClient client = this.pool.takeClient()) {
+      try (var client = this.pool.takeClient()) {
         return handler.apply(client);
       } catch (IllegalStateException exception) {
         if (exception.getCause() instanceof SSHException sshException) {
@@ -387,7 +387,6 @@ public class SFTPTemplateStorage implements TemplateStorage {
             null,
             sshException.getMessage());
         }
-        // ignore other exceptions
       } catch (Exception exception) {
         LOGGER.fine("Exception executing sftp task", exception);
       }


### PR DESCRIPTION
### Motivation
We've experienced some issues where all commands regarding templates would take really long to execute. The issue was that the SFTP module was loaded and active but not configured properly and therefore the connection would fail each time. To make sure that users are aware of missing or wrong credentials this change was made.

### Modification
Added a check that makes sure that we re-print all SSHException messages instead of just ignoring them to make sure that users are aware of it.

### Result
No more wondering why some template commands are that slow.
