### PR TITLE
fix: display the removed content when removing from a task collection

### DIFF
--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerCommand.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerCommand.java
@@ -95,7 +95,7 @@ public record DockerCommand(@NonNull DockerizedServicesModule module) {
     this.updateTaskDockerConfig(task, (config, builder) -> builder.binds(config.binds().stream()
       .filter(entry -> !entry.equals(bind))
       .collect(Collectors.toSet())));
-    source.sendMessage(I18n.trans("command-tasks-remove-collection-property", "bind", bind, task.name()));
+    source.sendMessage(I18n.trans("command-tasks-remove-collection-property", "bind", task.name(), bind));
   }
 
   @CommandMethod("docker task <task> add volume <volume>")
@@ -126,7 +126,7 @@ public record DockerCommand(@NonNull DockerizedServicesModule module) {
     this.updateTaskDockerConfig(task, (config, builder) -> builder.volumes(config.volumes().stream()
       .filter(entry -> !entry.equals(volume))
       .collect(Collectors.toSet())));
-    source.sendMessage(I18n.trans("command-tasks-remove-collection-property", "volume", volume, task.name()));
+    source.sendMessage(I18n.trans("command-tasks-remove-collection-property", "volume", task.name(), volume));
   }
 
   @CommandMethod("docker task <task> add port <port> [protocol]")
@@ -160,7 +160,7 @@ public record DockerCommand(@NonNull DockerizedServicesModule module) {
     this.updateTaskDockerConfig(task, (config, builder) -> builder.exposedPorts(config.exposedPorts().stream()
       .filter(entry -> entry.getPort() != port && (protocol == null || !protocol.equals(entry.getProtocol())))
       .collect(Collectors.toSet())));
-    source.sendMessage(I18n.trans("command-tasks-remove-collection-property", "exposedPort", port, task.name()));
+    source.sendMessage(I18n.trans("command-tasks-remove-collection-property", "exposedPort", task.name(), port));
   }
 
   @CommandMethod("docker config network <network>")

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -663,7 +663,7 @@ public final class TasksCommand {
       (builder, $) -> builder.modifyDeployments(col -> col.remove(deployment)),
       "command-tasks-remove-collection-property",
       "deployment",
-      null);
+      template);
   }
 
   @CommandMethod("tasks task <name> remove template <template>")
@@ -678,7 +678,7 @@ public final class TasksCommand {
       (builder, $) -> builder.modifyTemplates(col -> col.remove(template)),
       "command-tasks-remove-collection-property",
       "template",
-      null);
+      template);
   }
 
   @CommandMethod("tasks task <name> remove inclusion <url> <path>")
@@ -695,7 +695,7 @@ public final class TasksCommand {
       (builder, $) -> builder.modifyInclusions(col -> col.remove(inclusion)),
       "command-tasks-remove-collection-property",
       "inclusion",
-      null);
+      inclusion);
   }
 
   @CommandMethod("tasks task <name> remove jvmOption <options>")
@@ -711,7 +711,7 @@ public final class TasksCommand {
       (builder, $) -> builder.modifyJvmOptions(col -> col.removeAll(splittedOptions)),
       "command-tasks-remove-collection-property",
       "jvmOption",
-      null);
+      jvmOptions);
   }
 
   @CommandMethod("tasks task <name> remove processParameter <options>")
@@ -727,7 +727,7 @@ public final class TasksCommand {
       (builder, $) -> builder.modifyAssociatedNodes(col -> col.removeAll(splittedOptions)),
       "command-tasks-remove-collection-property",
       "processParameters",
-      null);
+      processParameters);
   }
 
   @CommandMethod("tasks task <name> remove group <group>")
@@ -742,7 +742,7 @@ public final class TasksCommand {
       (builder, $) -> builder.modifyGroups(col -> col.remove(group)),
       "command-tasks-remove-collection-property",
       "group",
-      null);
+      group);
   }
 
   @CommandMethod("tasks task <name> remove node <uniqueId>")
@@ -757,7 +757,7 @@ public final class TasksCommand {
       (builder, $) -> builder.modifyAssociatedNodes(col -> col.remove(node)),
       "command-tasks-remove-collection-property",
       "node",
-      null);
+      node);
   }
 
   @CommandMethod("tasks task <name> clear jvmOptions")


### PR DESCRIPTION
### Motivation
After updating some of the task command the removed value was not passed into the translation parameters and therefore was set to null. This leads to messages that don't contain the removed value.

### Modification
Added the removed value to the parameters.

### Result
All messages are correct now.

##### Other context
Fixes #917 #914
