### PR TITLE
fix: leave closing the buffer to netty when a channel becomes inactive

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/VarInt32FrameDecoder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/VarInt32FrameDecoder.java
@@ -33,7 +33,6 @@ public final class VarInt32FrameDecoder extends ByteToMessageDecoder {
   protected void decode(@NonNull ChannelHandlerContext ctx, @NonNull Buffer in) {
     // ensure that the channel we're reading from is still open
     if (!ctx.channel().isActive()) {
-      in.close();
       return;
     }
 


### PR DESCRIPTION
### Motivation
When a channel is closed and a call to `VarInt32FrameDecoder#decode` happens, we're closing the buffer provided to the method. Netty on the other hand will try to close the buffer when the inactive event is called, causing a race which leads to an exception on either side (one will have an exception because the buffer is already closed).

### Modification
Leave the buffer close operation to netty and just ignore the input message.

### Result
No more exceptions caused by buffer drop races.
