### PR TITLE
Chat color config change

### DIFF
--- a/plugins/chat/src/main/resources/config.properties
+++ b/plugins/chat/src/main/resources/config.properties
@@ -1,13 +1,13 @@
 # Available placeholders:
 # %group%    - the name of the highest permission group of the player
-# %display%  - the display of the highest permission group of the player
 # %prefix%   - the prefix of the highest permission group of the player
 # %suffix%   - the suffix of the highest permission group of the player
 # %color%    - the color of the highest permission group of the player
-# %name%     - the name of the player
+# %display%  - the display name of the player
+# %name%     - the username of the player
 # %uniqueId% - the unique id of the player
 # %message%  - the message sent by the player
 
 # permission to use "&" in messages for color: cloudnet.chat.color
 
-format=%display%%color%%name% &8:&f %message%
+format=%display%%color%%name%%suffix% &8:&f %message%

--- a/plugins/chat/src/main/resources/config.properties
+++ b/plugins/chat/src/main/resources/config.properties
@@ -10,4 +10,4 @@
 
 # permission to use "&" in messages for color: cloudnet.chat.color
 
-format=%display%%name% &8:&f %message%
+format=%display%%color%%name% &8:&f %message%

--- a/plugins/chat/src/main/resources/config.yml
+++ b/plugins/chat/src/main/resources/config.yml
@@ -10,4 +10,4 @@
 
 # permission to use "&" in messages for color: cloudnet.chat.color
 
-format: "%display%%name% &8:&f %message%"
+format: "%display%%color%%name% &8:&f %message%"

--- a/plugins/chat/src/main/resources/config.yml
+++ b/plugins/chat/src/main/resources/config.yml
@@ -1,13 +1,13 @@
 # Available placeholders:
 # %group%    - the name of the highest permission group of the player
-# %display%  - the display of the highest permission group of the player
 # %prefix%   - the prefix of the highest permission group of the player
 # %suffix%   - the suffix of the highest permission group of the player
 # %color%    - the color of the highest permission group of the player
-# %name%     - the name of the player
+# %display%  - the display name of the player
+# %name%     - the username of the player
 # %uniqueId% - the unique id of the player
 # %message%  - the message sent by the player
 
 # permission to use "&" in messages for color: cloudnet.chat.color
 
-format: "%display%%color%%name% &8:&f %message%"
+format: "%display%%color%%name%%suffix$ &8:&f %message%"


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
See issue #926 . Default tab list formatting with SimpleNameTags doesn't match the default CloudNet-Chat formatting.

### Modification
<!-- Describe the modification you've done to the codebase -->
Changed the config.yml and config.properties to add color.

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
Chat is now formatting the same as the player list by default.

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
Fixes #926 

My first pull request to CloudNet! Hopefully I did this correctly.