### PR TITLE
chore: bump mysql-connector to 8.0.31

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ h2 = "1.4.197" # do not update, leads to database incompatibility
 xodus = "2.0.1"
 mongodb = "4.7.2"
 hikariCp = "5.0.1"
-mysqlConnector = "8.0.30"
+mysqlConnector = "8.0.31"
 
 # general
 asm = "9.4"
@@ -144,7 +144,7 @@ h2 = { group = "com.h2database", name = "h2", version.ref = "h2" }
 hikariCp = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikariCp" }
 mongodb = { group = "org.mongodb", name = "mongodb-driver-sync", version.ref = "mongodb" }
 xodus = { group = "org.jetbrains.xodus", name = "xodus-environment", version.ref = "xodus" }
-mysqlConnector = { group = "mysql", name = "mysql-connector-java", version.ref = "mysqlConnector" }
+mysqlConnector = { group = "com.mysql", name = "mysql-connector-j", version.ref = "mysqlConnector" }
 
 # platform api
 nukkitX = { group = "cn.nukkit", name = "nukkit", version.ref = "nukkitX" }


### PR DESCRIPTION
### Motivation
Bump the mysql connector version to 8.0.31 and changes the group/artifact id as announced in the [changelog](https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-31.html). The old artifacts might no longer get published soon. 

### Modification
Update mysql connector version and group/artifact id.

### Result
Updated mysql connector and no risk of not getting updates anymore due to an outdated group/artifiact id.
