### PR TITLE
chore: make our build setup less dependant on jitpack queue

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ lombok = "1.18.24"
 # console
 jansi = "2.4.0"
 jline = "3.21.0"
-cloud = "main-SNAPSHOT"
+cloud = "1.8.0-cn1"
 
 # databases
 h2 = "1.4.197" # do not update, leads to database incompatibility
@@ -65,8 +65,8 @@ bungeecord = "1.19-R0.1-SNAPSHOT"
 vault = "1.7.1"
 adventure = "4.11.0"
 modlauncher = "8.1.3"
+npcLib = "3.0.0-beta1"
 placeholderApi = "2.11.2"
-npcLib = "dev~v2-SNAPSHOT"
 
 # fabric platform special dependencies
 minecraft = "1.19.2"


### PR DESCRIPTION
### Motivation
Our current build is very dependant on jitpack build leading to build timeouts and even unmet dependencies when there is a new commit pushed to a repo we're dependening on.

### Modification
Replace the dependencies which are based off a branch with releases that are statically served by jitpack.

### Result
Hopefull less build timeouts and cloudnet start failures due to deleted artifacts.
