### PR TITLE
fix: correctly add the env variables property to groups

### DIFF
--- a/common/src/main/java/eu/cloudnetservice/common/document/gson/JsonDocument.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/gson/JsonDocument.java
@@ -276,7 +276,7 @@ public class JsonDocument implements Document<JsonDocument> {
   @Override
   public @UnknownNullability Object get(@NonNull String key, @Nullable Object def) {
     var element = this.object.get(key);
-    return element != null ? element : def;
+    return element == null || element.isJsonNull() ? def : element;
   }
 
   @Override

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeGroupConfigurationProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeGroupConfigurationProvider.java
@@ -73,13 +73,15 @@ public class NodeGroupConfigurationProvider implements GroupConfigurationProvide
         .currentGetter(group -> this.groupConfiguration(group.name()))
         .build());
 
+    // run the conversion of the old file
+    this.upgrade();
+
+    // load the groups
     if (Files.exists(GROUP_DIRECTORY_PATH)) {
       this.loadGroupConfigurations();
     } else {
       FileUtil.createDirectory(GROUP_DIRECTORY_PATH);
     }
-    // run the conversion of the old file
-    this.upgrade();
   }
 
   @Override
@@ -196,7 +198,8 @@ public class NodeGroupConfigurationProvider implements GroupConfigurationProvide
 
       // TODO: remove in 4.1
       // check if the task has environment variables
-      if (!document.contains("environmentVariables")) {
+      var variables = document.get("environmentVariables");
+      if (variables == null) {
         document.append("environmentVariables", new HashMap<>());
       }
 


### PR DESCRIPTION
### Motivation
The current group conversion system causes an issue as it sets the `environmentVariables` field to null and our upgrade code of old group definitions doesn't catch it as missing anymore.

### Modification
Rewrite the `environmentVariables` property to an empty map when the property is missing or null.

### Result
No more exceptions caused by the `environmentVariables` set to null.
