### PR TITLE
build: reduce repo dependency resolution failures

### DIFF
--- a/build-extensions/src/main/kotlin/extensions.kt
+++ b/build-extensions/src/main/kotlin/extensions.kt
@@ -17,6 +17,7 @@
 import net.kyori.indra.git.IndraGitExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier
 import org.gradle.api.plugins.JavaPluginExtension
@@ -63,6 +64,18 @@ fun Project.sourceSets(): SourceSetContainer = the<JavaPluginExtension>().source
 fun ProjectDependency.sourceSets(): SourceSetContainer = dependencyProject.sourceSets()
 
 fun Project.mavenRepositories(): Iterable<MavenArtifactRepository> = repositories.filterIsInstance<MavenArtifactRepository>()
+
+fun releasesOnly(repository: MavenArtifactRepository) {
+  repository.mavenContent {
+    releasesOnly()
+  }
+}
+
+fun snapshotsOnly(repository: MavenArtifactRepository) {
+  repository.mavenContent {
+    snapshotsOnly()
+  }
+}
 
 fun Project.exportLanguageFileInformation(): String {
   val file = project.buildDir.resolve("languages.txt")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,11 +31,14 @@ allprojects {
   description = "A modern application that can dynamically and easily deliver Minecraft oriented software"
 
   repositories {
-    mavenCentral()
-    maven("https://jitpack.io/")
+    releasesOnly(mavenCentral())
     // must be before sponge as they mirror some repos including that one (which leads to outdated dependencies)
-    maven("https://oss.sonatype.org/content/repositories/snapshots/")
+    snapshotsOnly(maven("https://oss.sonatype.org/content/repositories/snapshots/"))
     maven("https://repo.spongepowered.org/maven/")
+
+    // ensure that we use these repositories for snapshots/releases only (improves lookup times)
+    releasesOnly(maven("https://repository.derklaro.dev/releases/"))
+    snapshotsOnly(maven("https://repository.derklaro.dev/snapshots/"))
   }
 }
 

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -28,7 +28,6 @@ subprojects {
   }
 
   repositories {
-    maven("https://jitpack.io/")
     maven("https://repo.md-5.net/repository/releases/")
     maven("https://repo.waterdog.dev/artifactory/main/")
     maven("https://repo.opencollab.dev/maven-snapshots/")


### PR DESCRIPTION
### Motivation
The current dependency lookup chain is very slow as gradle tries to resolve each dependency from all defined repositories, even if there is no way that the repository contains the requested version (for example a snapshot dependency in maven central).

### Modification
Clearly mark the repositories which can be used for snapshots and for releases in the root build file, as there repositories get more calls than all other repositories.

### Result
Faster build time when a dependency lookup is required.
