### PR TITLE
ci: bump pr-target-branch action to 2.1

### DIFF
--- a/.github/workflows/prbranch.yml
+++ b/.github/workflows/prbranch.yml
@@ -8,7 +8,7 @@ jobs:
   check-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: Vankka/pr-target-branch-action@v2
+      - uses: Vankka/pr-target-branch-action@v2.1
         with:
           target: release
           exclude: nightly


### PR DESCRIPTION
### Motivation
The action is currently using node 12 which causes a deprecation message. An update for the action was pushed yesterday which bumps that requirement to node 16 and should resolve the issue.

### Modification
Bump Vankka/pr-target-branch-action to 2.1.

### Result
No more action deprecation messages.
