### PR TITLE
chore: increase default file chunk size to 50MB

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
@@ -39,7 +39,7 @@ import lombok.NonNull;
  */
 public abstract class DefaultChunkedPacketSenderBuilder implements ChunkedPacketSender.Builder {
 
-  public static final int DEFAULT_CHUNK_SIZE = 1024 * 1024;
+  public static final int DEFAULT_CHUNK_SIZE = 50 * 1024 * 1024;
 
   protected InputStream source;
   protected String transferChannel;


### PR DESCRIPTION
### Motivation
Currently a chunked file is sent by default with chunk sized of 1MB. This leads to a lot of calls to the FS and network layer, which can be reduced by increasing the default size to 50MB. This change shouldn't cause any memory issues at all.

### Modification
Bump the default file chunk size from 1MB to 50MB.

### Result
50MB file chunks, less network and file system calls.
