### PR TITLE
chore: improve cluster sync ux

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -256,6 +256,9 @@ public class Node extends CloudNetDriver {
     this.nodeServerProvider.localNode().state(NodeServerState.READY);
     this.nodeServerProvider.selectHeadNode();
 
+    // setup done - register the command handler
+    this.commandProvider.registerConsoleHandler(this.console);
+
     // print out some network information, more for debug reasons in normal cases
     LOGGER.info(I18n.trans("network-selected-transport", NettyUtil.selectedNettyTransport().displayName()));
     LOGGER.info(I18n.trans(
@@ -279,10 +282,9 @@ public class Node extends CloudNetDriver {
         .send();
     }
 
-    // enable console command handling
+    // register the default commands
     LOGGER.info(I18n.trans("start-commands"));
     this.commandProvider.registerDefaultCommands();
-    this.commandProvider.registerConsoleHandler(this.console);
     // start modules
     this.moduleProvider.startAll();
     // register listeners & post node startup finish

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/RemoteNodeServer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/RemoteNodeServer.java
@@ -128,23 +128,13 @@ public class RemoteNodeServer implements NodeServer {
 
   @Override
   public void syncClusterData(boolean force) {
-    var channelMessage = ChannelMessage.builder()
+    ChannelMessage.builder()
       .message("sync_cluster_data")
       .targetNode(this.info.uniqueId())
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
       .buffer(this.node.dataSyncRegistry().prepareClusterData(force))
-      .build();
-    // if the data sync is forced there is no need to wait for a response
-    if (force) {
-      channelMessage.send();
-    } else {
-      // send and await a response
-      var response = channelMessage.sendSingleQuery();
-      if (response != null && response.content().readBoolean()) {
-        // there was overridden data we need to handle
-        this.node.dataSyncRegistry().handle(response.content(), true);
-      }
-    }
+      .build()
+      .send();
   }
 
   @Override

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DefaultDataSyncRegistry.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DefaultDataSyncRegistry.java
@@ -142,7 +142,7 @@ public class DefaultDataSyncRegistry implements DataSyncRegistry {
             }
 
             // print out the possibilities the user has now
-            LOGGER.info(I18n.trans("cluster-sync-change-decision-question"));
+            LOGGER.warning(I18n.trans("cluster-sync-change-decision-question"));
             // wait for the decision and apply
             switch (this.waitForCorrectMergeInput(Node.instance().console())) {
               case 1 -> {
@@ -153,7 +153,7 @@ public class DefaultDataSyncRegistry implements DataSyncRegistry {
               case 2 -> {
                 // accept yours - check if we already have a result buf
                 if (result == null) {
-                  result = DataBuf.empty().writeBoolean(true);
+                  result = DataBuf.empty();
                 }
                 // write the current data to the result buf
                 this.serializeData(current, handler, result);
@@ -181,7 +181,7 @@ public class DefaultDataSyncRegistry implements DataSyncRegistry {
     // try to release the input buf
     input.release();
     // return the created result
-    return result == null ? force ? null : DataBuf.empty().writeBoolean(false) : result;
+    return result;
   }
 
   protected void serializeData(


### PR DESCRIPTION
### Motivation
The current cluster sync handling has some inconveniences which might cause trouble for some users which are using it. First, the user has to respond to all change accept/skip messages within 30 seconds if he wanted that a response is send to the other node (in case a change from the current node should get applied to the remote node). On the other hand, when the first question was shown, the command handlers weren't disabled correctly which would lead to command suggestions.

### Modification
Replace the query waiting for a response from the data sync (and therefore from a user response) with a separate message. This also removes the need to ensure that we answer all syncs if there are no changes to make on the publising node. Furthermore the command handler registration is now moved up, so disabling the handlers for the initial data sync handling now works as expected.

### Result
Better user experience when using the cluster sync functionality.
