### PR TITLE
feat: npc show ingame services in the inventory

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/NPC.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/NPC.java
@@ -50,6 +50,9 @@ public class NPC extends JsonDocPropertyHolder {
   private final boolean imitatePlayer;
   private final boolean usePlayerSkin;
 
+  private final boolean showIngameServices;
+  private final boolean showFullServices;
+
   private final boolean glowing;
   private final String glowingColor;
   
@@ -72,6 +75,8 @@ public class NPC extends JsonDocPropertyHolder {
     boolean lookAtPlayer,
     boolean imitatePlayer,
     boolean usePlayerSkin,
+    boolean showIngameServices,
+    boolean showFullServices,
     boolean glowing,
     @NonNull String glowingColor,
     boolean flyingWithElytra,
@@ -91,6 +96,8 @@ public class NPC extends JsonDocPropertyHolder {
     this.lookAtPlayer = lookAtPlayer;
     this.imitatePlayer = imitatePlayer;
     this.usePlayerSkin = usePlayerSkin;
+    this.showIngameServices = showIngameServices;
+    this.showFullServices = showFullServices;
     this.glowing = glowing;
     this.glowingColor = glowingColor;
     this.flyingWithElytra = flyingWithElytra;
@@ -114,6 +121,8 @@ public class NPC extends JsonDocPropertyHolder {
       .lookAtPlayer(npc.lookAtPlayer())
       .imitatePlayer(npc.imitatePlayer())
       .usePlayerSkin(npc.usePlayerSkin())
+      .showIngameServices(npc.showIngameServices())
+      .showFullServices(npc.showFullServices())
       .glowing(npc.glowing())
       .glowingColor(npc.glowingColor())
       .flyingWithElytra(npc.flyingWithElytra())
@@ -171,6 +180,14 @@ public class NPC extends JsonDocPropertyHolder {
 
   public boolean usePlayerSkin() {
     return this.usePlayerSkin;
+  }
+
+  public boolean showIngameServices() {
+    return this.showIngameServices;
+  }
+
+  public boolean showFullServices() {
+    return this.showFullServices;
   }
 
   public boolean glowing() {
@@ -236,6 +253,9 @@ public class NPC extends JsonDocPropertyHolder {
     private boolean imitatePlayer = true;
     private boolean usePlayerSkin = false;
 
+    private boolean showIngameServices = false;
+    private boolean showFullServices = false;
+
     private boolean glowing = false;
     private String glowingColor = "§f";
     
@@ -297,6 +317,16 @@ public class NPC extends JsonDocPropertyHolder {
       return this;
     }
 
+    public @NonNull Builder showIngameServices(boolean showIngameServices) {
+      this.showIngameServices = showIngameServices;
+      return this;
+    }
+
+    public @NonNull Builder showFullServices(boolean showFullServices) {
+      this.showFullServices = showFullServices;
+      return this;
+    }
+
     public @NonNull Builder glowing(boolean glowing) {
       this.glowing = glowing;
       return this;
@@ -351,6 +381,8 @@ public class NPC extends JsonDocPropertyHolder {
         this.lookAtPlayer,
         this.imitatePlayer,
         this.usePlayerSkin,
+        this.showIngameServices,
+        this.showFullServices,
         this.glowing,
         this.glowingColor,
         this.flyingWithElytra,

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/InventoryConfiguration.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/InventoryConfiguration.java
@@ -24,7 +24,6 @@ import lombok.NonNull;
 public record InventoryConfiguration(
   int inventorySize,
   boolean dynamicSize,
-  boolean showFullServices,
   @NonNull ItemLayoutHolder defaultItems,
   @NonNull Map<String, ItemLayoutHolder> perGroupLayouts,
   @NonNull Map<Integer, ItemLayout> fixedItems
@@ -38,7 +37,6 @@ public record InventoryConfiguration(
     return builder()
       .inventorySize(configuration.inventorySize())
       .dynamicSize(configuration.dynamicSize())
-      .showFullServices(configuration.showFullServices())
       .defaultItems(configuration.defaultItems())
       .perGroupLayouts(configuration.perGroupLayouts())
       .fixedItems(configuration.fixedItems());
@@ -64,7 +62,8 @@ public record InventoryConfiguration(
   public record ItemLayoutHolder(
     @NonNull ItemLayout emptyLayout,
     @NonNull ItemLayout onlineLayout,
-    @NonNull ItemLayout fullLayout
+    @NonNull ItemLayout fullLayout,
+    @NonNull ItemLayout ingameLayout
   ) {
 
   }
@@ -73,7 +72,6 @@ public record InventoryConfiguration(
 
     private int inventorySize = 54;
     private boolean dynamicSize = true;
-    private boolean showFullServices = true;
 
     private ItemLayoutHolder defaultItems = new ItemLayoutHolder(
       ItemLayout.builder()
@@ -102,6 +100,14 @@ public record InventoryConfiguration(
           "§8● §e%state%",
           "§8● §7%online_players%§8/§7%max_players%",
           "§8● §7%motd%"
+        )).build(),
+      ItemLayout.builder()
+        .material("REDSTONE")
+        .displayName("§7%name%")
+        .lore(Arrays.asList(
+          "§8● §eIngame",
+          "§8● §7%online_players%§8/§7%max_players%",
+          "§8● §7%motd%"
         )).build());
 
     private Map<Integer, ItemLayout> fixedItems = new HashMap<>();
@@ -114,11 +120,6 @@ public record InventoryConfiguration(
 
     public @NonNull Builder dynamicSize(boolean dynamicSize) {
       this.dynamicSize = dynamicSize;
-      return this;
-    }
-
-    public @NonNull Builder showFullServices(boolean showFullServices) {
-      this.showFullServices = showFullServices;
       return this;
     }
 
@@ -141,7 +142,6 @@ public record InventoryConfiguration(
       return new InventoryConfiguration(
         this.inventorySize,
         this.dynamicSize,
-        this.showFullServices,
         this.defaultItems,
         this.perGroupLayouts,
         this.fixedItems);

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
@@ -318,6 +318,16 @@ public final class NPCCommand extends BaseTabExecutor {
           }
         }
 
+        // if the npc should show ingame services in the inventory
+        case "sis", "showingameservices" -> {
+          updatedNpc = NPC.builder(npc).showIngameServices(this.parseBoolean(args[2])).build();
+        }
+
+        // if the npc should full services in the inventory
+        case "sfs", "showfullservices" -> {
+          updatedNpc = NPC.builder(npc).showIngameServices(this.parseBoolean(args[2])).build();
+        }
+
         // sets the glowing color
         case "gc", "glowingcolor" -> {
           // try to parse the color
@@ -635,6 +645,8 @@ public final class NPCCommand extends BaseTabExecutor {
           "lookatplayer",
           "imitateplayer",
           "useplayerskin",
+          "showingameservices",
+          "showfullservices",
           "glowingcolor",
           "flyingwithelytra",
           "burning",
@@ -653,7 +665,7 @@ public final class NPCCommand extends BaseTabExecutor {
         return switch (StringUtil.toLower(args[1])) {
           // true-false options
           case "lap", "lookatplayer", "ip", "imitateplayer", "ups", "useplayerskin",
-            "fwe", "flyingwithelytra", "burning" -> TRUE_FALSE;
+            "fwe", "flyingwithelytra", "burning", "sis", "showingameservices", "sfs", "showfullservices" -> TRUE_FALSE;
           // click action options
           case "lca", "leftclickaction", "rca", "rightclickaction" -> CLICK_ACTIONS;
           // color options

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
@@ -319,14 +319,12 @@ public final class NPCCommand extends BaseTabExecutor {
         }
 
         // if the npc should show ingame services in the inventory
-        case "sis", "showingameservices" -> {
+        case "sis", "showingameservices" ->
           updatedNpc = NPC.builder(npc).showIngameServices(this.parseBoolean(args[2])).build();
-        }
 
         // if the npc should full services in the inventory
-        case "sfs", "showfullservices" -> {
+        case "sfs", "showfullservices" ->
           updatedNpc = NPC.builder(npc).showIngameServices(this.parseBoolean(args[2])).build();
-        }
 
         // sets the glowing color
         case "gc", "glowingcolor" -> {

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -352,7 +352,7 @@ public abstract class BukkitPlatformSelectorEntity
       case DIRECT_CONNECT_RANDOM -> {
         var wrappers = this.serviceItems.values().stream()
           // make sure that we are allowed to connect to the service
-          .filter(wrapper -> wrapper.itemStack() != null)
+          .filter(ServiceItemWrapper::canConnectTo)
           .toList();
         // connect the player to the first element if present
         if (!wrappers.isEmpty()) {
@@ -361,12 +361,12 @@ public abstract class BukkitPlatformSelectorEntity
         }
       }
       case DIRECT_CONNECT_LOWEST_PLAYERS -> this.serviceItems.values().stream()
-        .filter(wrapper -> wrapper.itemStack() != null)
+        .filter(ServiceItemWrapper::canConnectTo)
         .map(ServiceItemWrapper::service)
         .min(Comparator.comparingInt(service -> BridgeServiceProperties.ONLINE_COUNT.readOr(service, 0)))
         .ifPresent(ser -> this.playerManager().playerExecutor(player.getUniqueId()).connect(ser.name()));
       case DIRECT_CONNECT_HIGHEST_PLAYERS -> this.serviceItems.values().stream()
-        .filter(wrapper -> wrapper.itemStack() != null)
+        .filter(ServiceItemWrapper::canConnectTo)
         .map(ServiceItemWrapper::service)
         .max(Comparator.comparingInt(service -> BridgeServiceProperties.ONLINE_COUNT.readOr(service, 0)))
         .ifPresent(ser -> this.playerManager().playerExecutor(player.getUniqueId()).connect(ser.name()));
@@ -452,7 +452,7 @@ public abstract class BukkitPlatformSelectorEntity
     }
     // add the service items
     for (var wrapper : this.serviceItems.values()) {
-      if (wrapper.itemStack() != null && !inventory.addItem(wrapper.itemStack()).isEmpty()) {
+      if (wrapper.canConnectTo() && !inventory.addItem(wrapper.itemStack()).isEmpty()) {
         // the inventory is full
         break;
       }
@@ -498,6 +498,10 @@ public abstract class BukkitPlatformSelectorEntity
 
     public void service(@NonNull ServiceInfoSnapshot serviceInfoSnapshot) {
       this.serviceInfoSnapshot = serviceInfoSnapshot;
+    }
+
+    public boolean canConnectTo() {
+      return this.itemStack != null;
     }
   }
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -370,7 +370,8 @@ public abstract class BukkitPlatformSelectorEntity
         .map(ServiceItemWrapper::service)
         .max(Comparator.comparingInt(service -> BridgeServiceProperties.ONLINE_COUNT.readOr(service, 0)))
         .ifPresent(ser -> this.playerManager().playerExecutor(player.getUniqueId()).connect(ser.name()));
-      default -> {}
+      default -> {
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
Currently you can only show full services in a npc, ingame services are hidden - always.

### Modification
Moved the show full services option in the npc so that users can change the setting per npc instead of per group.
Added the new show ingame services option to allow showing ingame services in the inventory.

### Result
Ingame services have their own layout and can be displayed in the npc inventory
