### PR TITLE
fix: correctly fire root http handlers

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerHandler.java
@@ -137,9 +137,7 @@ final class NettyHttpServerHandler extends SimpleChannelInboundHandler<HttpReque
     var fullPath = uri.getPath();
 
     // make the path understandable for the handlers
-    if (fullPath.isEmpty()) {
-      fullPath = "/";
-    } else if (fullPath.endsWith("/")) {
+    if (!fullPath.equals("/") && fullPath.endsWith("/")) {
       fullPath = fullPath.substring(0, fullPath.length() - 1);
     }
 

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/http/NettyHttpServerTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/http/NettyHttpServerTest.java
@@ -138,6 +138,27 @@ public class NettyHttpServerTest extends NetworkTestCase {
   }
 
   @Test
+  @Order(25)
+  @Timeout(20)
+  void testRootHandler() throws Exception {
+    var port = this.randomFreePort();
+    HttpServer server = new NettyHttpServer();
+
+    server.registerHandler("/", new HttpHandler() {
+      @Override
+      public void handle(String path, HttpContext context) {
+        context.response().status(HttpResponseCode.OK).context().cancelNext(true);
+      }
+    });
+
+    Assertions.assertEquals(1, server.httpHandlers().size());
+    Assertions.assertDoesNotThrow(() -> server.addListener(port).join());
+
+    Assertions.assertEquals(200, connectTo(port, "").getResponseCode());
+    Assertions.assertEquals(404, connectTo(port, "test").getResponseCode());
+  }
+
+  @Test
   @Order(30)
   void testRequestPathParameters() throws Exception {
     var port = this.randomFreePort();


### PR DESCRIPTION
### Motivation
HTTP handlers which are registered to the root path (`/`) are not fired correctly. This is due to the reason that the incoming request uri can never be blank: `[...] if none is present in the original URI, it MUST be given as "/" (the server root)` from: [RFC2616, Section 5.1.2](https://www.rfc-editor.org/rfc/rfc2616#section-5.1.2).

### Modification
Correctly check if the request we received is send against the root path before trimming off the leading slash.

### Result
Handlers added to the root path are called correctly.
