### PR TITLE
chore: allow to disable bridge messages

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
@@ -26,11 +26,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 @ToString
 @EqualsAndHashCode(callSuper = false)
@@ -103,11 +105,43 @@ public final class BridgeConfiguration extends JsonDocPropertyHolder {
     return this.excludedGroups;
   }
 
-  public @NonNull String message(@Nullable Locale locale, @NonNull String key) {
-    return this.message(locale, key, true);
+  public void handleMessage(
+    @Nullable Locale locale,
+    @NonNull String key,
+    @NonNull Consumer<String> sender
+  ) {
+    this.handleMessage(locale, key, Function.identity(), sender, true);
   }
 
-  public @NonNull String message(@Nullable Locale locale, @NonNull String key, boolean withPrefix) {
+  public <C> void handleMessage(
+    @Nullable Locale locale,
+    @NonNull String key,
+    @NonNull Function<String, C> toComponentConverter,
+    @NonNull Consumer<C> sender
+  ) {
+    this.handleMessage(locale, key, toComponentConverter, sender, true);
+  }
+
+  public <C> void handleMessage(
+    @Nullable Locale locale,
+    @NonNull String key,
+    @NonNull Function<String, C> toComponentConverter,
+    @NonNull Consumer<C> sender,
+    boolean withPrefix
+  ) {
+    C component = this.findMessage(locale, key, toComponentConverter, null, withPrefix);
+    if (component != null) {
+      sender.accept(component);
+    }
+  }
+
+  public @UnknownNullability <C> C findMessage(
+    @Nullable Locale locale,
+    @NonNull String key,
+    @NonNull Function<String, C> toComponentConverter,
+    @Nullable C defaultValue,
+    boolean withPrefix
+  ) {
     String message = null;
     // don't bother resolving if no locale is present
     if (locale != null) {
@@ -119,15 +153,20 @@ public final class BridgeConfiguration extends JsonDocPropertyHolder {
       }
     }
 
-    // validate that there are registered messages for the locale, fall back to the default messages if not
+    // check if the message is available for the "default" locale
     if (message == null) {
-      message = Objects.requireNonNullElseGet(
-        this.resolveMessage(this.localizedMessages.get("default"), key),
-        () -> this.resolveMessage(DEFAULT_MESSAGES.get("default"), key));
+      message = this.resolveMessage(this.localizedMessages.get("default"), key);
+      if (message == null) {
+        return defaultValue;
+      }
     }
 
     // format the final message
-    return String.format("%s%s", withPrefix ? this.prefix : "", message);
+    var formattedMessage = String.format("%s%s", withPrefix ? this.prefix : "", message);
+    C component = toComponentConverter.apply(formattedMessage);
+
+    // check if the converter was able to convert the message
+    return component != null ? component : defaultValue;
   }
 
   private @Nullable String resolveMessage(@Nullable Map<String, String> messages, @NonNull String key) {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/network/NodePlayerChannelMessageListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/network/NodePlayerChannelMessageListener.java
@@ -40,6 +40,7 @@ import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
 import eu.cloudnetservice.modules.bridge.player.NetworkServiceInfo;
 import java.util.Locale;
 import lombok.NonNull;
+import net.kyori.adventure.text.Component;
 
 public final class NodePlayerChannelMessageListener {
 
@@ -70,10 +71,15 @@ public final class NodePlayerChannelMessageListener {
           var preLoginEvent = new LocalPlayerPreLoginEvent(info);
           // set the event cancelled by default if the player is already connected
           if (this.playerManager.onlinePlayer(info.uniqueId()) != null) {
-            preLoginEvent.result(LocalPlayerPreLoginEvent.Result.denied(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
-              this.bridgeManagement.configuration().message(
-                Locale.ENGLISH,
-                "already-connected"))));
+            preLoginEvent.result(this.bridgeManagement.configuration().findMessage(
+              Locale.ENGLISH,
+              "already-connected",
+              message -> {
+                var component = ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message);
+                return LocalPlayerPreLoginEvent.Result.denied(component);
+              },
+              LocalPlayerPreLoginEvent.Result.denied(Component.empty()),
+              true));
           }
           // publish the event
           var result = this.eventManager.callEvent(preLoginEvent).result();

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitPlayerManagementListener.java
@@ -51,18 +51,20 @@ public final class BukkitPlayerManagementListener implements Listener {
       // check if maintenance is activated
       if (task.maintenance() && !event.getPlayer().hasPermission("cloudnet.bridge.maintenance")) {
         event.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
-        event.setKickMessage(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           BukkitUtil.playerLocale(event.getPlayer()),
-          "server-join-cancel-because-maintenance"));
+          "server-join-cancel-because-maintenance",
+          event::setKickMessage);
         return;
       }
       // check if a custom permission is required to join
       var permission = task.properties().getString("requiredPermission");
       if (permission != null && !event.getPlayer().hasPermission(permission)) {
         event.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
-        event.setKickMessage(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           BukkitUtil.playerLocale(event.getPlayer()),
-          "server-join-cancel-because-permission"));
+          "server-join-cancel-because-permission",
+          event::setKickMessage);
       }
     }
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordCloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordCloudCommand.java
@@ -20,6 +20,7 @@ import static eu.cloudnetservice.modules.bridge.platform.bungeecord.BungeeCordHe
 
 import eu.cloudnetservice.driver.CloudNetDriver;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
+import eu.cloudnetservice.modules.bridge.platform.bungeecord.BungeeCordHelper;
 import lombok.NonNull;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -51,11 +52,11 @@ public final class BungeeCordCloudCommand extends Command implements TabExecutor
       CloudNetDriver.instance().clusterNodeProvider().consoleCommandAsync(args[0]).thenAcceptAsync(info -> {
         // check if the player has the required permission
         if (info == null || !sender.hasPermission(info.permission())) {
-          // no permission
-          sender.sendMessage(translateToComponent(this.management.configuration().message(
+          this.management.configuration().handleMessage(
             player.getLocale(),
-            "command-cloud-sub-command-no-permission"
-          ).replace("%command%", args[0])));
+            "command-cloud-sub-command-no-permission",
+            message -> BungeeCordHelper.translateToComponent(message.replace("%command%", args[0])),
+            sender::sendMessage);
         } else {
           // execute command
           this.executeNow(sender, commandLine);

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordHubCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordHubCommand.java
@@ -16,9 +16,8 @@
 
 package eu.cloudnetservice.modules.bridge.platform.bungeecord.command;
 
-import static eu.cloudnetservice.modules.bridge.platform.bungeecord.BungeeCordHelper.translateToComponent;
-
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
+import eu.cloudnetservice.modules.bridge.platform.bungeecord.BungeeCordHelper;
 import lombok.NonNull;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
@@ -44,9 +43,11 @@ public final class BungeeCordHubCommand extends Command {
     if (sender instanceof ProxiedPlayer player) {
       // check if the player is on a fallback already
       if (this.management.isOnAnyFallbackInstance(player)) {
-        player.sendMessage(translateToComponent(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           player.getLocale(),
-          "command-hub-already-in-hub")));
+          "command-hub-already-in-hub",
+          BungeeCordHelper::translateToComponent,
+          player::sendMessage);
       } else {
         // try to get a fallback for the player
         var hub = this.management.fallback(player)
@@ -57,15 +58,18 @@ public final class BungeeCordHubCommand extends Command {
           player.connect(hub, (result, ex) -> {
             // check if the connection was successful
             if (result && ex == null) {
-              player.sendMessage(translateToComponent(this.management.configuration().message(
+              this.management.configuration().handleMessage(
                 player.getLocale(),
-                "command-hub-success-connect"
-              ).replace("%server%", hub.getName())));
+                "command-hub-success-connect",
+                message -> BungeeCordHelper.translateToComponent(message.replace("%server%", hub.getName())),
+                player::sendMessage);
             } else {
               // the connection was not successful
-              player.sendMessage(translateToComponent(this.management.configuration().message(
+              this.management.configuration().handleMessage(
                 player.getLocale(),
-                "command-hub-no-server-found")));
+                "command-hub-no-server-found",
+                BungeeCordHelper::translateToComponent,
+                player::sendMessage);
             }
           }, Reason.COMMAND);
         }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomPlayerManagementListener.java
@@ -59,17 +59,21 @@ public final class MinestomPlayerManagementListener {
     if (task != null) {
       // check if maintenance is activated
       if (task.maintenance() && !player.hasPermission("cloudnet.bridge.maintenance")) {
-        player.kick(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           player.getLocale(),
-          "server-join-cancel-because-maintenance")));
+          "server-join-cancel-because-maintenance",
+          ComponentFormats.BUNGEE_TO_ADVENTURE::convert,
+          player::kick);
         return;
       }
       // check if a custom permission is required to join
       var permission = task.properties().getString("requiredPermission");
       if (permission != null && !player.hasPermission(permission)) {
-        player.kick(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           player.getLocale(),
-          "server-join-cancel-because-permission")));
+          "server-join-cancel-because-permission",
+          ComponentFormats.BUNGEE_TO_ADVENTURE::convert,
+          player::kick);
       }
     }
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitPlayerManagementListener.java
@@ -51,18 +51,20 @@ public final class NukkitPlayerManagementListener implements Listener {
       // check if maintenance is activated
       if (task.maintenance() && !event.getPlayer().hasPermission("cloudnet.bridge.maintenance")) {
         event.setCancelled(true);
-        event.setKickMessage(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           event.getPlayer().getLocale(),
-          "server-join-cancel-because-maintenance"));
+          "server-join-cancel-because-maintenance",
+          event::setKickMessage);
         return;
       }
       // check if a custom permission is required to join
       var permission = task.properties().getString("requiredPermission");
       if (permission != null && !event.getPlayer().hasPermission(permission)) {
         event.setCancelled(true);
-        event.setKickMessage(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           event.getPlayer().getLocale(),
-          "server-join-cancel-because-permission"));
+          "server-join-cancel-because-permission",
+          event::setKickMessage);
       }
     }
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongePlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongePlayerManagementListener.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.modules.bridge.platform.sponge;
 
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.helper.ServerPlatformHelper;
 import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
@@ -23,7 +24,6 @@ import eu.cloudnetservice.wrapper.Wrapper;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
-import net.kyori.adventure.text.Component;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
@@ -54,18 +54,22 @@ public final class SpongePlayerManagementListener {
       // check if maintenance is activated
       if (task.maintenance() && !user.hasPermission("cloudnet.bridge.maintenance")) {
         event.setCancelled(true);
-        event.setMessage(Component.text(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           Locale.ENGLISH,
-          "server-join-cancel-because-maintenance")));
+          "server-join-cancel-because-maintenance",
+          ComponentFormats.BUNGEE_TO_ADVENTURE::convert,
+          event::setMessage);
         return;
       }
       // check if a custom permission is required to join
       var permission = task.properties().getString("requiredPermission");
       if (permission != null && !user.hasPermission(permission)) {
         event.setCancelled(true);
-        event.setMessage(Component.text(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           Locale.ENGLISH,
-          "server-join-cancel-because-permission")));
+          "server-join-cancel-because-permission",
+          ComponentFormats.BUNGEE_TO_ADVENTURE::convert,
+          event::setMessage);
       }
     }
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
@@ -58,13 +58,13 @@ public final class VelocityCloudCommand implements SimpleCommand {
         // check if the sender has the required permission to execute the command
         if (info == null || !invocation.source().hasPermission(info.permission())) {
           // no permission to execute the command
-          invocation.source().sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
-            this.management.configuration().message(
-              invocation.source() instanceof Player
-                ? ((Player) invocation.source()).getEffectiveLocale()
-                : Locale.ENGLISH,
-              "command-cloud-sub-command-no-permission"
-            ).replace("%command%", arguments[0])));
+          this.management.configuration().handleMessage(
+            invocation.source() instanceof Player
+              ? ((Player) invocation.source()).getEffectiveLocale()
+              : Locale.ENGLISH,
+            "command-cloud-sub-command-no-permission",
+            message -> ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message.replace("%command%", arguments[0])),
+            invocation.source()::sendMessage);
         } else {
           // execute the command
           this.executeNow(invocation.source(), commandLine);

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityHubCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityHubCommand.java
@@ -39,9 +39,11 @@ public final class VelocityHubCommand implements SimpleCommand {
     if (invocation.source() instanceof Player player) {
       // check if the player is on a fallback already
       if (this.management.isOnAnyFallbackInstance(player)) {
-        player.sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           player.getEffectiveLocale(),
-          "command-hub-already-in-hub")));
+          "command-hub-already-in-hub",
+          ComponentFormats.BUNGEE_TO_ADVENTURE::convert,
+          player::sendMessage);
       } else {
         // try to get a fallback for the player
         var hub = this.management.fallback(player)
@@ -52,15 +54,19 @@ public final class VelocityHubCommand implements SimpleCommand {
           player.createConnectionRequest(hub).connectWithIndication().whenComplete((result, ex) -> {
             // check if the connection was successful
             if (result && ex == null) {
-              player.sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
+              this.management.configuration().handleMessage(
                 player.getEffectiveLocale(),
-                "command-hub-success-connect"
-              ).replace("%server%", hub.getServerInfo().getName())));
+                "command-hub-success-connect",
+                message -> ComponentFormats.BUNGEE_TO_ADVENTURE.convert(
+                  message.replace("%server%", hub.getServerInfo().getName())),
+                player::sendMessage);
             } else {
               // the connection was not successful
-              player.sendMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(this.management.configuration().message(
+              this.management.configuration().handleMessage(
                 player.getEffectiveLocale(),
-                "command-hub-no-server-found")));
+                "command-hub-no-server-found",
+                ComponentFormats.BUNGEE_TO_ADVENTURE::convert,
+                player::sendMessage);
             }
           });
         }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEHandlers.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEHandlers.java
@@ -48,9 +48,13 @@ final class WaterDogPEHandlers implements IForcedHostHandler, IReconnectHandler 
     @NonNull String kickMessage
   ) {
     // send the player the reason for the disconnect
-    player.sendMessage(this.management.configuration().message(Locale.ENGLISH, "error-connecting-to-server")
-      .replace("%server%", oldServer.getServerName())
-      .replace("%reason%", kickMessage));
+    this.management.configuration().handleMessage(
+      Locale.ENGLISH,
+      "error-connecting-to-server",
+      message -> message
+        .replace("%server%", oldServer.getServerName())
+        .replace("%reason%", kickMessage),
+      player::sendMessage);
     // filter the next fallback for the player
     return this.management.fallback(player, oldServer.getServerName())
       .map(server -> ProxyServer.getInstance().getServerInfo(server.name()))

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEPlayerManagementListener.java
@@ -54,18 +54,20 @@ public final class WaterDogPEPlayerManagementListener {
       // check if maintenance is activated
       if (task.maintenance() && !event.getPlayer().hasPermission("cloudnet.bridge.maintenance")) {
         event.setCancelled(true);
-        event.setCancelReason(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           Locale.ENGLISH,
-          "proxy-join-cancel-because-maintenance"));
+          "proxy-join-cancel-because-maintenance",
+          event::setCancelReason);
         return;
       }
       // check if a custom permission is required to join
       var permission = task.properties().getString("requiredPermission");
       if (permission != null && !event.getPlayer().hasPermission(permission)) {
         event.setCancelled(true);
-        event.setCancelReason(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           Locale.ENGLISH,
-          "proxy-join-cancel-because-permission"));
+          "proxy-join-cancel-because-permission",
+          event::setCancelReason);
         return;
       }
     }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPECloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPECloudCommand.java
@@ -57,10 +57,11 @@ public final class WaterDogPECloudCommand extends Command {
         // check if the player has the required permission
         if (info == null || !sender.hasPermission(info.permission())) {
           // no permission
-          sender.sendMessage(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(this.management.configuration().message(
+          this.management.configuration().handleMessage(
             Locale.ENGLISH,
-            "command-cloud-sub-command-no-permission"
-          ).replace("%command%", args[0])));
+            "command-cloud-sub-command-no-permission",
+            message -> message.replace("%command%", args[0]),
+            sender::sendMessage);
         } else {
           // execute command
           this.executeNow(sender, commandLine);

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPEHubCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPEHubCommand.java
@@ -44,9 +44,11 @@ public final class WaterDogPEHubCommand extends Command {
     if (sender instanceof ProxiedPlayer player) {
       // check if the player is on a fallback already
       if (this.management.isOnAnyFallbackInstance(player)) {
-        player.sendMessage(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(this.management.configuration().message(
+        this.management.configuration().handleMessage(
           Locale.ENGLISH,
-          "command-hub-already-in-hub")));
+          "command-hub-already-in-hub",
+          ComponentFormats.ADVENTURE_TO_BUNGEE::convertText,
+          player::sendMessage);
       } else {
         // try to get a fallback for the player
         var hub = this.management.fallback(player)
@@ -55,10 +57,12 @@ public final class WaterDogPEHubCommand extends Command {
         // check if a fallback was found
         if (hub != null) {
           player.connect(hub);
-          player.sendMessage(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(this.management.configuration().message(
+          this.management.configuration().handleMessage(
             Locale.ENGLISH,
-            "command-hub-success-connect"
-          ).replace("%server%", hub.getServerName())));
+            "command-hub-success-connect",
+            message -> ComponentFormats.BUNGEE_TO_ADVENTURE.convertText(
+              message.replace("%server%", hub.getServerName())),
+            player::sendMessage);
         }
       }
     }


### PR DESCRIPTION
### Motivation
At the moment there is no possiblity to disable a bridge message, setting them to `null` will result in the default message rather than no message. Some users wanted to change that behaviour and requested a way to disable messages.

### Modification
Allow to disable messages by setting them to `null`, use a default value in some specific cases.

### Result
Bridge messages can now be disabled by setting them to `null`.
