### PR TITLE
fix: correctly download sftp templates into the root service directory

### DIFF
--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -144,7 +144,12 @@ public class SFTPTemplateStorage implements TemplateStorage {
   @Override
   public boolean pull(@NonNull ServiceTemplate template, @NonNull Path directory) {
     return this.executeWithClient(client -> {
-      client.get(this.constructRemotePath(template), new FileSystemFile(directory.toFile()));
+      // we cannot call "get" directly as that would cause a download of the file into a directory
+      // which is called the same way the template is called
+      var target = new FileSystemFile(directory.toFile());
+      for (var fileInfo : client.ls(this.constructRemotePath(template))) {
+        client.get(fileInfo.getPath(), target);
+      }
       return true;
     }, false);
   }


### PR DESCRIPTION
### Motivation
Templates downloaded from the SFTP template storage were (for whatever reason) located inside a folder which was named the same way as the template:
![image](https://user-images.githubusercontent.com/40468651/199821184-237f171d-7340-4021-b88a-6ed33f2d971b.png)

### Modification
Ensure that we download the files into the root service directory rather than a separate one.

### Result
The service templates from the sftp storage are pulled correctly into the service directory:
![image](https://user-images.githubusercontent.com/40468651/199821364-2563c244-d5a2-437b-8c3b-24c41cf4d099.png)

