### PR TITLE
chore: use new instanceof check to get effective player locale

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
@@ -59,9 +59,7 @@ public final class VelocityCloudCommand implements SimpleCommand {
         if (info == null || !invocation.source().hasPermission(info.permission())) {
           // no permission to execute the command
           this.management.configuration().handleMessage(
-            invocation.source() instanceof Player
-              ? ((Player) invocation.source()).getEffectiveLocale()
-              : Locale.ENGLISH,
+            invocation.source() instanceof Player player ? player.getEffectiveLocale() : Locale.ENGLISH,
             "command-cloud-sub-command-no-permission",
             message -> ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message.replace("%command%", arguments[0])),
             invocation.source()::sendMessage);


### PR DESCRIPTION
### Motivation
We can use a new instanceof check to check if a command sender is a player. This reduces the line length and read complexity a lot.

### Modification
Use a new instanceof check to verify if a command sender is a player.

### Result
Cleaner code.
