### PR TITLE
chore: rename the ColouredLogFormatter to ColoredLogFormatter

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/BootLogic.java
+++ b/node/src/main/java/eu/cloudnetservice/node/BootLogic.java
@@ -26,7 +26,7 @@ import eu.cloudnetservice.common.log.defaults.ThreadedLogRecordDispatcher;
 import eu.cloudnetservice.common.log.io.LogOutputStream;
 import eu.cloudnetservice.node.console.Console;
 import eu.cloudnetservice.node.console.JLine3Console;
-import eu.cloudnetservice.node.console.log.ColouredLogFormatter;
+import eu.cloudnetservice.node.console.log.ColoredLogFormatter;
 import java.nio.file.Path;
 import java.time.Instant;
 import lombok.NonNull;
@@ -51,7 +51,7 @@ public final class BootLogic {
 
   private static void initLoggerAndConsole(@NonNull Console console, @NonNull Logger logger) {
     var logFilePattern = Path.of(System.getProperty("cloudnet.log.path", "local/logs"), "cloudnet.%g.log");
-    var consoleFormatter = console.hasColorSupport() ? new ColouredLogFormatter() : DefaultLogFormatter.END_CLEAN;
+    var consoleFormatter = console.hasColorSupport() ? new ColoredLogFormatter() : DefaultLogFormatter.END_CLEAN;
 
     LoggingUtil.removeHandlers(logger);
 

--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -53,7 +53,7 @@ import eu.cloudnetservice.node.command.defaults.DefaultCommandProvider;
 import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.config.JsonConfiguration;
 import eu.cloudnetservice.node.console.Console;
-import eu.cloudnetservice.node.console.log.ColouredLogFormatter;
+import eu.cloudnetservice.node.console.log.ColoredLogFormatter;
 import eu.cloudnetservice.node.console.util.HeaderReader;
 import eu.cloudnetservice.node.database.AbstractDatabaseProvider;
 import eu.cloudnetservice.node.database.h2.H2DatabaseProvider;
@@ -137,7 +137,7 @@ public class Node extends CloudNetDriver {
 
     // add the log handler here to capture all log lines of the startup
     this.logHandler.setFormatter(console.hasColorSupport()
-      ? new ColouredLogFormatter()
+      ? new ColoredLogFormatter()
       : DefaultLogFormatter.END_LINE_SEPARATOR);
     rootLogger.addHandler(this.logHandler);
 

--- a/node/src/main/java/eu/cloudnetservice/node/console/ConsoleColor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/ConsoleColor.java
@@ -60,7 +60,7 @@ public enum ConsoleColor {
     this.ansiCode = ansiCode;
   }
 
-  public static @NonNull String toColouredString(char triggerChar, @NonNull String input) {
+  public static @NonNull String toColoredString(char triggerChar, @NonNull String input) {
     var contentBuilder = new StringBuilder(convertRGBColors(triggerChar, input));
 
     var breakIndex = contentBuilder.length() - 1;

--- a/node/src/main/java/eu/cloudnetservice/node/console/JLine3Console.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/JLine3Console.java
@@ -370,7 +370,7 @@ public final class JLine3Console implements Console {
   }
 
   private void updatePrompt() {
-    this.prompt = ConsoleColor.toColouredString('&', this.prompt)
+    this.prompt = ConsoleColor.toColoredString('&', this.prompt)
       .replace("%version%", VERSION)
       .replace("%user%", USER);
     this.lineReader.setPrompt(this.prompt);
@@ -401,7 +401,7 @@ public final class JLine3Console implements Console {
   }
 
   private @NonNull String formatText(@NonNull String input, @NonNull String ensureEndsWith) {
-    var content = this.ansiSupported ? ConsoleColor.toColouredString('&', input) : ConsoleColor.stripColor('&', input);
+    var content = this.ansiSupported ? ConsoleColor.toColoredString('&', input) : ConsoleColor.stripColor('&', input);
     if (!content.endsWith(ensureEndsWith)) {
       content += ensureEndsWith;
     }

--- a/node/src/main/java/eu/cloudnetservice/node/console/log/ColoredLogFormatter.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/log/ColoredLogFormatter.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import lombok.NonNull;
 
-public final class ColouredLogFormatter extends Formatter {
+public final class ColoredLogFormatter extends Formatter {
 
   private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd.MM HH:mm:ss.SSS");
 


### PR DESCRIPTION
### Motivation
In cloudnet we aim to be consistent about our class & method naming. We've choosen to use american english to name them, the `ColouredLogFormatter` is named using bri'ish english.

### Modification
Renamed the `ColouredLogFormatter` to `ColoredLogFormatter` in order to stick to american english.

### Result
We are using american english only
