### PR TITLE
fix: make sure that we only try to invalidate existing npc item wrappers

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -402,17 +402,19 @@ public abstract class BukkitPlatformSelectorEntity
   }
 
   protected void unregisterItem(
-    @NonNull ServiceItemWrapper wrapper,
+    @Nullable ServiceItemWrapper wrapper,
     @NonNull ServiceInfoSnapshot service,
     @NonNull InventoryConfiguration configuration
   ) {
-    // reset the ItemStack in the wrapper as we currently don't have an item to display
-    wrapper.itemStack(null);
-    // update the service and rebuild the inventory & infoline
-    wrapper.service(service);
+    if (wrapper != null) {
+      // reset the ItemStack in the wrapper as we currently don't have an item to display
+      wrapper.itemStack(null);
+      // update the service and rebuild the inventory & infoline
+      wrapper.service(service);
 
-    this.rebuildInfoLines();
-    this.rebuildInventory(configuration);
+      this.rebuildInfoLines();
+      this.rebuildInventory(configuration);
+    }
   }
 
   protected void rebuildInfoLines() {


### PR DESCRIPTION
### Motivation
Recently an issue regarding null wrappers was reported.

### Modification
Allowed wrappers to be nullable in the item unregistration method and added a null check before proceeding to unregister it.

### Result
The reported issue regarding null wrappers is fixed.
