### PR TITLE
chore: remove gradle metadata as version catalogs are stable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,3 @@
-metadata.format.version = "1.1"
-
 [versions]
 
 # plugins


### PR DESCRIPTION
### Motivation
Version catalogs are stable now, therefore we don't have to set the gradle metadata.

### Modification
Removed the gradle metadata from the version catalog.

### Result
The metadata is removed.
