### PR TITLE
chore: migrate wrapper to use dependency injection

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleProviderHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleProviderHandler.java
@@ -34,6 +34,8 @@ import eu.cloudnetservice.driver.event.events.module.ModulePreStartEvent;
 import eu.cloudnetservice.driver.event.events.module.ModulePreStopEvent;
 import eu.cloudnetservice.driver.event.events.module.ModulePreUnloadEvent;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import lombok.NonNull;
 
 /**
@@ -42,6 +44,7 @@ import lombok.NonNull;
  * @see ModuleProviderHandler
  * @since 4.0
  */
+@Singleton
 public class DefaultModuleProviderHandler implements ModuleProviderHandler {
 
   private static final Logger LOGGER = LogManager.logger(DefaultModuleProviderHandler.class);
@@ -50,6 +53,7 @@ public class DefaultModuleProviderHandler implements ModuleProviderHandler {
   protected final ModuleProvider moduleProvider;
   protected final ServiceRegistry serviceRegistry;
 
+  @Inject
   protected DefaultModuleProviderHandler(
     @NonNull EventManager eventManager,
     @NonNull ModuleProvider moduleProvider,

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCFactory.java
@@ -21,6 +21,7 @@ import eu.cloudnetservice.driver.network.buffer.DataBufFactory;
 import eu.cloudnetservice.driver.network.rpc.exception.ClassCreationException;
 import eu.cloudnetservice.driver.network.rpc.generation.ChainInstanceFactory;
 import eu.cloudnetservice.driver.network.rpc.generation.GenerationContext;
+import eu.cloudnetservice.driver.network.rpc.generation.InstanceFactory;
 import eu.cloudnetservice.driver.network.rpc.object.ObjectMapper;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
@@ -96,7 +97,9 @@ public interface RPCFactory {
    * @throws NullPointerException   if the given base class or generation context is null.
    * @throws ClassCreationException if the generator is unable to generate an implementation of the class.
    */
-  @NonNull <T> T generateRPCBasedApi(@NonNull Class<T> baseClass, @NonNull GenerationContext context);
+  @NonNull <T> InstanceFactory<T> generateRPCBasedApi(
+    @NonNull Class<T> baseClass,
+    @NonNull GenerationContext context);
 
   /**
    * Generates an api implementation for the given base class, invoking all of its method using a chained rpc call. The

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ApiImplementationGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ApiImplementationGenerator.java
@@ -34,7 +34,9 @@ import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V1_8;
 
+import com.google.common.collect.ObjectArrays;
 import dev.derklaro.reflexion.Reflexion;
+import dev.derklaro.reflexion.matcher.ConstructorMatcher;
 import eu.cloudnetservice.common.StringUtil;
 import eu.cloudnetservice.common.concurrent.Task;
 import eu.cloudnetservice.driver.network.NetworkChannel;
@@ -46,8 +48,11 @@ import eu.cloudnetservice.driver.network.rpc.annotation.RPCIgnore;
 import eu.cloudnetservice.driver.network.rpc.annotation.RPCNoResult;
 import eu.cloudnetservice.driver.network.rpc.exception.ClassCreationException;
 import eu.cloudnetservice.driver.network.rpc.generation.GenerationContext;
+import eu.cloudnetservice.driver.network.rpc.generation.InstanceFactory;
 import eu.cloudnetservice.driver.util.asm.AsmHelper;
 import eu.cloudnetservice.driver.util.define.ClassDefiners;
+import jakarta.inject.Inject;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
@@ -57,6 +62,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
@@ -84,9 +90,7 @@ public final class ApiImplementationGenerator {
     Type.getType(RPC.class),
     Type.getType(String.class),
     Type.getType(Object[].class));
-  private static final String CONSTRUCTOR_SENDER_DESC = Type.getMethodDescriptor(
-    Type.VOID_TYPE,
-    Type.getType(RPCSender.class));
+  static final String INJECT_ANNOTATION_DESC = Type.getDescriptor(Inject.class);
   // executable stuff
   static final String EXECUTABLE_NAME = Type.getInternalName(RPCExecutable.class);
   static final String EXECUTABLE_FIRE_FORGET = Type.getMethodDescriptor(Type.VOID_TYPE);
@@ -126,7 +130,7 @@ public final class ApiImplementationGenerator {
    */
   // Suppresses ConstantConditions as IJ is dumb
   @SuppressWarnings({"unchecked"})
-  public static @NonNull <T> Supplier<Object> generateApiImplementation(
+  public static @NonNull <T> InstanceFactory<T> generateApiImplementation(
     @NonNull Class<T> baseClass,
     @NonNull GenerationContext context,
     @NonNull RPCSender sender
@@ -151,30 +155,50 @@ public final class ApiImplementationGenerator {
       // add the sender field
       cw.visitField(ACC_PRIVATE | ACC_FINAL, "sender", SENDER_DESC, null, null).visitEnd();
       cw.visitField(ACC_PRIVATE | ACC_FINAL, "channelSupplier", SUPPLIER_DESC, null, null).visitEnd();
+
+      // check if the class has a constructor with a rpc sender instance, use that prioritized
+      var targetConstructorArgs = ChainedApiImplementationGenerator.findSuperConstructorTypes(context.extendingClass());
+      var superDesc = targetConstructorArgs.stream().map(Type::getDescriptor).collect(Collectors.joining());
+
       // generate the constructor
       MethodVisitor mv;
-      mv = cw.visitMethod(ACC_PUBLIC, "<init>", String.format("(%s%s)V", SENDER_DESC, SUPPLIER_DESC), null, null);
-      // generate the constructor
-      // check if the class has a constructor with a rpc sender instance, use that prioritized
-      var useSenderConstructor = false;
-      if (context.extendingClass() != null) {
-        try {
-          context.extendingClass().getDeclaredConstructor(RPCSender.class);
-          useSenderConstructor = true;
-        } catch (NoSuchMethodException ignored) {
-          // proceed as the class has only a no-args constructor
-        }
-      }
-
+      mv = cw.visitMethod(
+        ACC_PUBLIC,
+        "<init>",
+        String.format(
+          "(%s%s%s)V",
+          SENDER_DESC,
+          SUPPLIER_DESC,
+          superDesc),
+        null,
+        null);
+      mv.visitAnnotation(INJECT_ANNOTATION_DESC, true);
       mv.visitCode();
+
       // visit super
       mv.visitVarInsn(ALOAD, 0);
-      if (useSenderConstructor) {
-        mv.visitVarInsn(ALOAD, 1);
-        mv.visitMethodInsn(INVOKESPECIAL, superName, "<init>", CONSTRUCTOR_SENDER_DESC, false);
-      } else {
+      if (targetConstructorArgs.isEmpty()) {
         mv.visitMethodInsn(INVOKESPECIAL, superName, "<init>", "()V", false);
+      } else {
+        // load all parameters to the stack
+        for (int i = 0; i < targetConstructorArgs.size(); i++) {
+          var argumentType = targetConstructorArgs.get(i);
+
+          if (i == 0 && argumentType.equals(RPCSender.class)) {
+            // argument is the provided sender
+            mv.visitVarInsn(ALOAD, 1);
+          } else if ((i == 0 || i == 1) && argumentType.equals(Supplier.class)) {
+            // argument is the provided channel supplier
+            mv.visitVarInsn(ALOAD, 2);
+          } else {
+            var type = Type.getType(argumentType);
+            mv.visitVarInsn(type.getOpcode(ILOAD), 3 + i); // 0 = this, 1 = sender, 2 = channel supplier
+          }
+        }
+
+        mv.visitMethodInsn(INVOKESPECIAL, superName, "<init>", superDesc, false);
       }
+
       // write the sender field
       mv.visitVarInsn(ALOAD, 0);
       mv.visitVarInsn(ALOAD, 1);
@@ -205,13 +229,23 @@ public final class ApiImplementationGenerator {
       }
       // finish the class
       cw.visitEnd();
+
       // define & select the correct constructor for the class
-      var accessor = Reflexion
-        .on(ClassDefiners.current().defineClass(className, parentClass, cw.toByteArray()))
-        .findConstructor(RPCSender.class, Supplier.class)
-        .orElseThrow();
+      var definedClass = ClassDefiners.current().defineClass(className, parentClass, cw.toByteArray());
+      var constructorMatcher = ConstructorMatcher.newMatcher()
+        .exactType(Constructor::getDeclaringClass, definedClass)
+        .exactTypeAt(Constructor::getParameterTypes, RPCSender.class, 0)
+        .exactTypeAt(Constructor::getParameterTypes, Supplier.class, 1);
+
       // instantiate the new class
-      return () -> (T) accessor.invokeWithArgs(sender, context.channelSupplier()).getOrThrow();
+      var accessor = Reflexion.on(definedClass).findConstructor(constructorMatcher).orElseThrow();
+      return constructorArgs -> {
+        var arguments = ObjectArrays.concat(
+          new Object[]{sender, context.channelSupplier()},
+          constructorArgs,
+          Object.class);
+        return (T) accessor.invokeWithArgs(arguments).getOrThrow();
+      };
     } catch (Exception exception) {
       throw new ClassCreationException(String.format(
         "Unable to generate api class implementation for class %s",

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ChainedApiImplementationGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ChainedApiImplementationGenerator.java
@@ -210,7 +210,7 @@ public final class ChainedApiImplementationGenerator {
     }
   }
 
-  private static @NonNull List<Class<?>> findSuperConstructorTypes(@Nullable Class<?> extendingClass) {
+  static @NonNull List<Class<?>> findSuperConstructorTypes(@Nullable Class<?> extendingClass) {
     if (extendingClass == null) {
       return List.of();
     }

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/generation/InstanceFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/generation/InstanceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.rpc.generation;
+
+import lombok.NonNull;
+
+/**
+ * Represents the factory which can be used to obtain new instances of generated rpc classes.
+ *
+ * @param <T> the type of the generated class.
+ * @since 4.0
+ */
+@FunctionalInterface
+public interface InstanceFactory<T> {
+
+  /**
+   * Constructs a new instance of the underlying class, using the given arguments for the constructor invocation of the
+   * class.
+   *
+   * @param args the arguments for the constructor.
+   * @return a new instance of the underlying class.
+   * @throws NullPointerException if the given arguments are null.
+   */
+  @NonNull T newInstance(@NonNull Object... args);
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/VarHandleUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/VarHandleUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.util;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Small utility to make internal work with var handles easier.
+ *
+ * @since 4.0
+ */
+@ApiStatus.Internal
+public final class VarHandleUtil {
+
+  private VarHandleUtil() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Finds a var handle for the field with the given name and type in the given class.
+   *
+   * @param lookup         the lookup for the class to find the handle in.
+   * @param declaringClass the declaring class of the field to find the handle for.
+   * @param name           the name of the field to find the handle for.
+   * @param fieldType      the type of the field to find the handle for.
+   * @return a var handle for the given field in the given class.
+   * @throws NullPointerException  if the given lookup, declaring class, field name or field type is null.
+   * @throws IllegalStateException if the target field is unknown or the given lookup instance has no access to it.
+   */
+  public static @NonNull VarHandle lookup(
+    @NonNull MethodHandles.Lookup lookup,
+    @NonNull Class<?> declaringClass,
+    @NonNull String name,
+    @NonNull Class<?> fieldType
+  ) {
+    try {
+      return lookup.findVarHandle(declaringClass, name, fieldType);
+    } catch (NoSuchFieldException | IllegalAccessException exception) {
+      throw new IllegalStateException(String.format(
+        "Unable to get VarHandle for field %s in %s",
+        name,
+        declaringClass.getName()));
+    }
+  }
+}

--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -146,8 +146,6 @@ public class Node extends CloudNetDriver {
     this.nodeServerProvider = null; //new DefaultNodeServerProvider(this);
 
     // language management init
-    I18n.loadFromLangPath(Node.class);
-    //I18n.language(this.configuration.language());
 
     this.clusterNodeProvider = null; //new NodeClusterNodeProvider(this);
     this.cloudServiceProvider = null;
@@ -265,6 +263,13 @@ public class Node extends CloudNetDriver {
     // could look out of place in the normal logging context
     System.setErr(LogOutputStream.forSevere(rootLogger).toPrintStream());
     System.setOut(LogOutputStream.forInformative(rootLogger).toPrintStream());
+  }
+
+  @Inject
+  @Order(0)
+  private void initLanguage(@NonNull Configuration configuration) {
+    I18n.loadFromLangPath(Node.class);
+    I18n.language(configuration.language());
   }
 
   @Inject

--- a/node/src/main/java/eu/cloudnetservice/node/boot/Bootstrap.java
+++ b/node/src/main/java/eu/cloudnetservice/node/boot/Bootstrap.java
@@ -21,7 +21,6 @@ import dev.derklaro.aerogel.Bindings;
 import dev.derklaro.aerogel.Element;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
-import eu.cloudnetservice.driver.DriverEnvironment;
 import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.node.Node;
 import io.leangen.geantyref.TypeFactory;
@@ -44,7 +43,6 @@ public final class Bootstrap {
     bootInjectLayer.installAutoConfigureBindings(Bootstrap.class.getClassLoader(), "driver");
 
     // initial bindings which we cannot (or it makes no sense to) construct
-    bootInjectLayer.install(Bindings.fixed(Element.forType(DriverEnvironment.class), DriverEnvironment.NODE));
     bootInjectLayer.install(Bindings.fixed(Element.forType(Instant.class).requireName("startInstant"), startInstant));
     bootInjectLayer.install(Bindings.fixed(Element.forType(Logger.class).requireName("root"), LogManager.rootLogger()));
 

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/RemoteNodeServer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/RemoteNodeServer.java
@@ -85,7 +85,8 @@ public class RemoteNodeServer implements NodeServer {
     this.cloudServiceProvider = cloudServiceProvider;
     this.serviceFactory = rpcFactory.generateRPCBasedApi(
       CloudServiceFactory.class,
-      GenerationContext.forClass(CloudServiceFactory.class).channelSupplier(this::channel).build());
+      GenerationContext.forClass(CloudServiceFactory.class).channelSupplier(this::channel).build()
+    ).newInstance();
   }
 
   @Override

--- a/node/src/main/java/eu/cloudnetservice/node/config/Configuration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/Configuration.java
@@ -21,10 +21,12 @@ import eu.cloudnetservice.driver.network.HostAndPort;
 import eu.cloudnetservice.driver.network.cluster.NetworkCluster;
 import eu.cloudnetservice.driver.network.cluster.NetworkClusterNode;
 import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
+import jakarta.inject.Singleton;
 import java.util.Collection;
 import java.util.Map;
 import lombok.NonNull;
 
+@Singleton
 public interface Configuration {
 
   boolean fileExists();

--- a/wrapper-jvm/build.gradle.kts
+++ b/wrapper-jvm/build.gradle.kts
@@ -50,6 +50,10 @@ tasks.withType<ShadowJar> {
   }
 }
 
+tasks.withType<JavaCompile> {
+  options.compilerArgs = listOf("-AaerogelAutoFileName=autoconfigure/wrapper.aero")
+}
+
 dependencies {
   "api"(projects.driver)
   "api"(projects.ext.modlauncher)
@@ -58,6 +62,9 @@ dependencies {
   "implementation"(libs.asm)
   "implementation"(libs.gson)
   "implementation"(libs.guava)
+
+  // processing
+  "annotationProcessor"(libs.aerogelAuto)
 }
 
 applyJarMetadata(

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/ShutdownHandler.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/ShutdownHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper;
+
+import eu.cloudnetservice.driver.module.ModuleProvider;
+import eu.cloudnetservice.driver.network.NetworkClient;
+import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+
+@Singleton
+final class ShutdownHandler implements Runnable {
+
+  private final NetworkClient networkClient;
+  private final ModuleProvider moduleProvider;
+  private final ServiceRegistry serviceRegistry;
+
+  @Inject
+  public ShutdownHandler(
+    @NonNull NetworkClient networkClient,
+    @NonNull ModuleProvider moduleProvider,
+    @NonNull ServiceRegistry serviceRegistry
+  ) {
+    this.networkClient = networkClient;
+    this.moduleProvider = moduleProvider;
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @Override
+  public void run() {
+    try {
+      this.networkClient.close();
+    } catch (Exception ignored) {
+    }
+
+    this.moduleProvider.unloadAll();
+    this.serviceRegistry.unregisterAll();
+  }
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
@@ -17,64 +17,52 @@
 package eu.cloudnetservice.wrapper;
 
 import com.google.common.collect.Lists;
-import eu.cloudnetservice.common.document.gson.JsonDocument;
+import dev.derklaro.aerogel.Order;
+import eu.cloudnetservice.common.language.I18n;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
+import eu.cloudnetservice.common.log.LoggingUtil;
+import eu.cloudnetservice.common.log.defaults.DefaultFileHandler;
+import eu.cloudnetservice.common.log.defaults.DefaultLogFormatter;
+import eu.cloudnetservice.common.log.defaults.ThreadedLogRecordDispatcher;
 import eu.cloudnetservice.driver.CloudNetDriver;
 import eu.cloudnetservice.driver.CloudNetVersion;
 import eu.cloudnetservice.driver.DriverEnvironment;
-import eu.cloudnetservice.driver.channel.ChannelMessage;
-import eu.cloudnetservice.driver.database.DatabaseProvider;
+import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.module.DefaultModuleProviderHandler;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
+import eu.cloudnetservice.driver.module.ModuleProvider;
+import eu.cloudnetservice.driver.network.NetworkClient;
 import eu.cloudnetservice.driver.network.chunk.defaults.factory.EventChunkHandlerFactory;
 import eu.cloudnetservice.driver.network.chunk.network.ChunkedPacketListener;
 import eu.cloudnetservice.driver.network.def.NetworkConstants;
-import eu.cloudnetservice.driver.network.netty.client.NettyNetworkClient;
-import eu.cloudnetservice.driver.network.rpc.generation.GenerationContext;
 import eu.cloudnetservice.driver.permission.PermissionManagement;
-import eu.cloudnetservice.driver.provider.CloudServiceFactory;
-import eu.cloudnetservice.driver.provider.CloudServiceProvider;
-import eu.cloudnetservice.driver.provider.ClusterNodeProvider;
-import eu.cloudnetservice.driver.provider.GroupConfigurationProvider;
-import eu.cloudnetservice.driver.provider.ServiceTaskProvider;
-import eu.cloudnetservice.driver.service.ProcessSnapshot;
-import eu.cloudnetservice.driver.service.ServiceConfiguration;
-import eu.cloudnetservice.driver.service.ServiceId;
-import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
-import eu.cloudnetservice.driver.service.ServiceLifeCycle;
-import eu.cloudnetservice.driver.template.TemplateStorageProvider;
-import eu.cloudnetservice.wrapper.configuration.DocumentWrapperConfiguration;
 import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
-import eu.cloudnetservice.wrapper.database.DefaultWrapperDatabaseProvider;
 import eu.cloudnetservice.wrapper.event.ApplicationPostStartEvent;
 import eu.cloudnetservice.wrapper.event.ApplicationPreStartEvent;
-import eu.cloudnetservice.wrapper.event.ServiceInfoSnapshotConfigureEvent;
-import eu.cloudnetservice.wrapper.network.NetworkClientChannelHandler;
+import eu.cloudnetservice.wrapper.holder.ServiceInfoHolder;
+import eu.cloudnetservice.wrapper.log.InternalPrintStreamLogHandler;
 import eu.cloudnetservice.wrapper.network.chunk.TemplateStorageCallbackListener;
 import eu.cloudnetservice.wrapper.network.listener.PacketAuthorizationResponseListener;
 import eu.cloudnetservice.wrapper.network.listener.PacketServerChannelMessageListener;
 import eu.cloudnetservice.wrapper.network.listener.message.GroupChannelMessageListener;
 import eu.cloudnetservice.wrapper.network.listener.message.ServiceChannelMessageListener;
 import eu.cloudnetservice.wrapper.network.listener.message.TaskChannelMessageListener;
-import eu.cloudnetservice.wrapper.permission.WrapperPermissionManagement;
-import eu.cloudnetservice.wrapper.provider.WrapperCloudServiceProvider;
-import eu.cloudnetservice.wrapper.provider.WrapperMessenger;
-import eu.cloudnetservice.wrapper.provider.WrapperTemplateStorageProvider;
 import eu.cloudnetservice.wrapper.transform.TransformerRegistry;
 import eu.cloudnetservice.wrapper.transform.bukkit.BukkitCommodoreTransformer;
 import eu.cloudnetservice.wrapper.transform.bukkit.BukkitJavaVersionCheckTransformer;
 import eu.cloudnetservice.wrapper.transform.bukkit.PaperConfigTransformer;
 import eu.cloudnetservice.wrapper.transform.netty.OldEpollDisableTransformer;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.LockSupport;
 import java.util.jar.JarFile;
 import lombok.NonNull;
 
@@ -84,16 +72,9 @@ import lombok.NonNull;
  *
  * @since 4.0
  */
-public class Wrapper extends CloudNetDriver {
+public final class Wrapper extends CloudNetDriver { // todo: make package private
 
-  private static final Path WORKING_DIRECTORY = Path.of("");
   private static final Logger LOGGER = LogManager.logger(Wrapper.class);
-
-  private final Thread mainThread = Thread.currentThread();
-  private final WrapperConfiguration config = DocumentWrapperConfiguration.load();
-
-  private ServiceInfoSnapshot lastServiceInfoSnapShot = this.config.serviceInfoSnapshot();
-  private ServiceInfoSnapshot currentServiceInfoSnapshot = this.config.serviceInfoSnapshot();
 
   /**
    * Constructs a new CloudNet wrapper instance. This constructor shouldn't be used directly and is only accessible for
@@ -103,51 +84,9 @@ public class Wrapper extends CloudNetDriver {
    * @param args the command line arguments which were supplied to the wrapper when starting.
    * @throws NullPointerException if the given arguments are null.
    */
-  protected Wrapper(@NonNull String[] args) {
+  private Wrapper() {
     super(CloudNetVersion.fromPackage(Wrapper.class.getPackage()), Lists.newArrayList(args), DriverEnvironment.WRAPPER);
-
     instance(this);
-
-    //super.networkClient = new NettyNetworkClient(NetworkClientChannelHandler::new, this.config.sslConfiguration());
-    super.messenger = new WrapperMessenger(this);
-
-    // auto generated providers
-    super.clusterNodeProvider = this.rpcFactory.generateRPCBasedApi(
-      ClusterNodeProvider.class,
-      GenerationContext.forClass(ClusterNodeProvider.class).component(this.networkClient).build());
-    super.serviceTaskProvider = this.rpcFactory.generateRPCBasedApi(
-      ServiceTaskProvider.class,
-      GenerationContext.forClass(ServiceTaskProvider.class).component(this.networkClient).build());
-    super.groupConfigurationProvider = this.rpcFactory.generateRPCBasedApi(
-      GroupConfigurationProvider.class,
-      GenerationContext.forClass(GroupConfigurationProvider.class).component(this.networkClient).build());
-    super.cloudServiceFactory = this.rpcFactory().generateRPCBasedApi(
-      CloudServiceFactory.class,
-      GenerationContext.forClass(CloudServiceFactory.class).component(this.networkClient).build());
-
-    // these contain some methods which we cannot auto generate directly
-    super.templateStorageProvider = this.rpcFactory.generateRPCBasedApi(
-      TemplateStorageProvider.class,
-      GenerationContext.forClass(WrapperTemplateStorageProvider.class).component(this.networkClient).build());
-    super.databaseProvider = this.rpcFactory.generateRPCBasedApi(
-      DatabaseProvider.class,
-      GenerationContext.forClass(DefaultWrapperDatabaseProvider.class).component(this.networkClient).build());
-    super.cloudServiceProvider = this.rpcFactory.generateRPCBasedApi(
-      CloudServiceProvider.class,
-      GenerationContext.forClass(WrapperCloudServiceProvider.class).component(this.networkClient).build());
-
-    // channel message listeners for downstream event calls
-    this.eventManager.registerListener(new TaskChannelMessageListener(this.eventManager));
-    this.eventManager.registerListener(new GroupChannelMessageListener(this.eventManager));
-    this.eventManager.registerListener(new ServiceChannelMessageListener(this.eventManager));
-
-    //super.moduleProvider.moduleProviderHandler(new DefaultModuleProviderHandler());
-    super.moduleProvider.moduleDirectoryPath(Path.of(".wrapper", "modules"));
-
-    var management = this.rpcFactory.generateRPCBasedApi(
-      PermissionManagement.class,
-      GenerationContext.forClass(WrapperPermissionManagement.class).component(this.networkClient).build());
-    super.permissionManagement(management);
   }
 
   /**
@@ -157,6 +96,7 @@ public class Wrapper extends CloudNetDriver {
    *
    * @return the current, jvm static wrapper instance.
    */
+  @Deprecated(forRemoval = true)
   public static @NonNull Wrapper instance() {
     return CloudNetDriver.instance();
   }
@@ -166,41 +106,6 @@ public class Wrapper extends CloudNetDriver {
    */
   @Override
   protected void start(@NonNull Instant startInstant) throws Exception {
-    // load & enable the modules
-    this.moduleProvider.loadAll().startAll();
-
-    // register our default class transformers
-    this.transformerRegistry().registerTransformer(
-      "org/bukkit/craftbukkit",
-      "Commodore",
-      new BukkitCommodoreTransformer());
-    this.transformerRegistry().registerTransformer(
-      "org/bukkit/craftbukkit",
-      "Main",
-      new BukkitJavaVersionCheckTransformer());
-    this.transformerRegistry().registerTransformer(
-      "org/github/paperspigot",
-      "PaperSpigotConfig",
-      new PaperConfigTransformer());
-    // This prevents shadow from renaming io/netty to eu/cloudnetservice/io/netty
-    this.transformerRegistry().registerTransformer(
-      String.join("/", "io", "netty", "channel", "epoll"),
-      "Epoll",
-      new OldEpollDisableTransformer());
-
-    // connect to the node
-    this.connectToNode();
-
-    // initialize
-    this.permissionManagement.init();
-    this.eventManager.registerListener(new TemplateStorageCallbackListener());
-
-    Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
-
-    // start the application
-    if (!this.startApplication()) {
-      System.exit(-1);
-    }
   }
 
   /**
@@ -208,15 +113,6 @@ public class Wrapper extends CloudNetDriver {
    */
   @Override
   public void stop() {
-    try {
-      this.networkClient.close();
-    } catch (Exception exception) {
-      LOGGER.severe("Exception while closing the network client", exception);
-    }
-
-    this.scheduler.shutdownNow();
-    this.moduleProvider.unloadAll();
-    this.serviceRegistry.unregisterAll();
   }
 
   /**
@@ -224,7 +120,7 @@ public class Wrapper extends CloudNetDriver {
    */
   @Override
   public @NonNull String componentName() {
-    return this.serviceId().name();
+    return "";
   }
 
   /**
@@ -232,209 +128,148 @@ public class Wrapper extends CloudNetDriver {
    */
   @Override
   public @NonNull String nodeUniqueId() {
-    return this.serviceId().nodeUniqueId();
+    return "";
   }
 
-  /**
-   * Get the id of the service this wrapper is associated with.
-   *
-   * @return the id of the service this wrapper is associated with.
-   */
-  public @NonNull ServiceId serviceId() {
-    return this.serviceConfiguration().serviceId();
+  @Inject
+  @Order(50)
+  private void setupLogger(@NonNull @Named("root") Logger logger) {
+    LoggingUtil.removeHandlers(logger);
+    var logFilePattern = Path.of(".wrapper", "logs", "wrapper.%g.log");
+
+    logger.setLevel(LoggingUtil.defaultLogLevel());
+    logger.logRecordDispatcher(ThreadedLogRecordDispatcher.forLogger(logger));
+
+    logger.addHandler(InternalPrintStreamLogHandler.forSystemStreams().withFormatter(DefaultLogFormatter.END_CLEAN));
+    logger.addHandler(DefaultFileHandler
+      .newInstance(logFilePattern, false)
+      .withFormatter(DefaultLogFormatter.END_LINE_SEPARATOR));
   }
 
-  /**
-   * Get the service configuration which was used to create this service instance.
-   *
-   * @return the service configuration which was used to create this service instance.
-   */
-  public @NonNull ServiceConfiguration serviceConfiguration() {
-    return this.config.serviceConfiguration();
+  @Inject
+  @Order(100)
+  private void initI18n() {
+    I18n.loadFromLangPath(Wrapper.class);
+    I18n.language(System.getProperty("cloudnet.wrapper.messages.language", "en_US"));
   }
 
-  /**
-   * Creates a new service snapshot of this service, copying over the properties of the current service info snapshot.
-   * Only the creation time and process snapshot of the new snapshot differ from the old snapshot.
-   *
-   * @return the newly created service snapshot for this service.
-   */
-  public @NonNull ServiceInfoSnapshot createServiceInfoSnapshot() {
-    return this.createServiceInfoSnapshot(this.currentServiceInfoSnapshot.properties());
+  @Inject
+  @Order(150)
+  private void initProviderAndLoadModules(
+    @NonNull ModuleProvider moduleProvider,
+    @NonNull DefaultModuleProviderHandler moduleProviderHandler
+  ) {
+    // init the provider
+    moduleProvider.moduleProviderHandler(moduleProviderHandler);
+    moduleProvider.moduleDirectoryPath(Path.of(".wrapper", "modules"));
+
+    // load the modules
+    moduleProvider.loadAll().startAll();
   }
 
-  /**
-   * Creates a new service snapshot of this service using the provided properties for the new snapshot.
-   * Only the creation time and process snapshot and properties of the new snapshot differ from the old snapshot.
-   * <p>
-   * Changes made to the current service snapshot (like modifying the properties of it) will not reflect into the
-   * snapshot returned by this method.
-   *
-   * @return the newly created service snapshot for this service.
-   */
-  public @NonNull ServiceInfoSnapshot createServiceInfoSnapshot(@NonNull JsonDocument properties) {
-    return new ServiceInfoSnapshot(
-      System.currentTimeMillis(),
-      this.currentServiceInfoSnapshot.address(),
-      ProcessSnapshot.self(),
-      this.serviceConfiguration(),
-      this.currentServiceInfoSnapshot.connectedTime(),
-      ServiceLifeCycle.RUNNING,
-      properties.clone());
-  }
+  @Inject
+  @Order(200)
+  private void connectToNode(
+    @NonNull EventManager eventManager,
+    @NonNull NetworkClient networkClient,
+    @NonNull WrapperConfiguration configuration,
+    @NonNull ServiceInfoHolder serviceInfoHolder
+  ) {
+    // create a new condition and the auth listener
+    var currentThread = Thread.currentThread();
+    var listener = new PacketAuthorizationResponseListener(currentThread);
 
-  /**
-   * Creates a new service snapshot of this service, copying over the properties of the current service info snapshot,
-   * then configuring it using the registered listeners of the {@code ServiceInfoSnapshotConfigureEvent}.
-   * <p>
-   * Changes made to the current service snapshot (like modifying the properties of it) will not reflect into the
-   * snapshot returned by this method.
-   * <p>
-   * This method will (unlike the {@code createServiceInfoSnapshot} method) change the current and old service snapshot
-   * to the newly created and configured one.
-   * <p>
-   * This method call is equivalent to {@code wrapper.configureServiceInfoSnapshot(wrapper.createServiceInfoSnapshot)}.
-   *
-   * @return the newly created service snapshot for this service.
-   */
-  public @NonNull ServiceInfoSnapshot configureServiceInfoSnapshot() {
-    var serviceInfoSnapshot = this.createServiceInfoSnapshot();
-    this.configureServiceInfoSnapshot(serviceInfoSnapshot);
-    return serviceInfoSnapshot;
-  }
+    // register the listener to the packet registry and connect to the target listener
+    networkClient.packetRegistry().addListener(NetworkConstants.INTERNAL_AUTHORIZATION_CHANNEL, listener);
+    networkClient
+      .connect(configuration.targetListener())
+      .exceptionally(ex -> {
+        // log and exit, we're not connected
+        LOGGER.severe("Unable to establish a connection to the target node listener", ex);
+        System.exit(-1);
+        // returns void
+        return null;
+      }).join();
 
-  /**
-   * Configures the given service info snapshot and updates the current and old service snapshot.
-   *
-   * @param serviceInfoSnapshot the service snapshot to configure.
-   * @throws NullPointerException if the given snapshot is null.
-   */
-  private void configureServiceInfoSnapshot(@NonNull ServiceInfoSnapshot serviceInfoSnapshot) {
-    this.eventManager.callEvent(new ServiceInfoSnapshotConfigureEvent(serviceInfoSnapshot));
-
-    this.lastServiceInfoSnapShot = this.currentServiceInfoSnapshot;
-    this.currentServiceInfoSnapshot = serviceInfoSnapshot;
-  }
-
-  /**
-   * Creates a new service snapshot, configures it, updates the current and old one and sends an update to all
-   * components which are currently registered within the CloudNet network.
-   */
-  public void publishServiceInfoUpdate() {
-    this.publishServiceInfoUpdate(this.createServiceInfoSnapshot());
-  }
-
-  /**
-   * Updates the given service snapshot to all components which are currently registered within the CloudNet network.
-   * This method will configure the given snapshot if it belongs to the current wrapper instance.
-   *
-   * @param serviceInfoSnapshot the service snapshot to update.
-   * @throws NullPointerException if the given service snapshot is null.
-   */
-  public void publishServiceInfoUpdate(@NonNull ServiceInfoSnapshot serviceInfoSnapshot) {
-    // add configuration stuff when updating the current service snapshot
-    if (this.currentServiceInfoSnapshot.serviceId().equals(serviceInfoSnapshot.serviceId())) {
-      this.configureServiceInfoSnapshot(serviceInfoSnapshot);
+    // wait for the authentication response
+    LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(30));
+    if (!listener.wasAuthSuccessful()) {
+      throw new IllegalStateException("Unable to authorize wrapper with node");
     }
 
-    // send the update to all nodes and services
-    ChannelMessage.builder()
-      .targetAll()
-      .message("update_service_info")
-      .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeObject(serviceInfoSnapshot))
-      .build()
-      .send();
+    // set a new current snapshot with the connected time
+    serviceInfoHolder.setup();
+
+    // remove the auth listener
+    networkClient.packetRegistry().removeListeners(NetworkConstants.INTERNAL_AUTHORIZATION_CHANNEL);
+
+    // add the runtime packet listeners
+    networkClient.packetRegistry().addListener(
+      NetworkConstants.CHUNKED_PACKET_COM_CHANNEL,
+      new ChunkedPacketListener(EventChunkHandlerFactory.withEventManager(eventManager)));
+    networkClient.packetRegistry().addListener(
+      NetworkConstants.CHANNEL_MESSAGING_CHANNEL,
+      PacketServerChannelMessageListener.class);
   }
 
-  /**
-   * Connects this wrapper with the node which started this service, allowing a maximum of 30 seconds for the connection
-   * to establish completely (including the node authorization process).
-   * <p>
-   * If the connection was successful a new service snapshot with the connection time will be created, and the channel
-   * of the node connection will be setup to receive and send packets.
-   *
-   * @throws InterruptedException  if the calling thread was interrupted while waiting for the connection to be ready.
-   * @throws IllegalStateException if the node authorization failed for some reason (including timeout).
-   */
-  private void connectToNode() throws InterruptedException {
-    Lock lock = new ReentrantLock();
-
-    try {
-      // acquire the lock on the current thread
-      lock.lock();
-      // create a new condition and the auth listener
-      var condition = lock.newCondition();
-      var listener = new PacketAuthorizationResponseListener(lock, condition);
-      // register the listener to the packet registry and connect to the target listener
-      this.networkClient.packetRegistry().addListener(NetworkConstants.INTERNAL_AUTHORIZATION_CHANNEL, listener);
-      this.networkClient
-        .connect(this.config.targetListener())
-        .exceptionally(ex -> {
-          // log and exit, we're not connected
-          LOGGER.severe("Unable to connect", ex);
-          System.exit(-1);
-          // returns void
-          return null;
-        }).join();
-
-      // wait for the authentication response
-      var wasDone = condition.await(30, TimeUnit.SECONDS);
-      // check if the auth was successful - explode if not
-      if (!wasDone || !listener.wasAuthSuccessful()) {
-        throw new IllegalStateException("Unable to authorize wrapper with node");
-      }
-
-      // set a new current snapshot with the connected time
-      this.currentServiceInfoSnapshot = new ServiceInfoSnapshot(
-        System.currentTimeMillis(),
-        this.currentServiceInfoSnapshot.address(),
-        ProcessSnapshot.self(),
-        this.serviceConfiguration(),
-        System.currentTimeMillis(),
-        ServiceLifeCycle.RUNNING,
-        this.currentServiceInfoSnapshot.properties());
-
-      // remove the auth listener
-      this.networkClient.packetRegistry().removeListeners(NetworkConstants.INTERNAL_AUTHORIZATION_CHANNEL);
-
-      // add the runtime packet listeners
-      // TODO
-      //this.networkClient.packetRegistry().addListener(
-      //NetworkConstants.CHUNKED_PACKET_COM_CHANNEL,
-      //  new ChunkedPacketListener(EventChunkHandlerFactory.withDefaultEventManager()));
-      this.networkClient.packetRegistry().addListener(
-        NetworkConstants.CHANNEL_MESSAGING_CHANNEL,
-        new PacketServerChannelMessageListener());
-    } finally {
-      lock.unlock();
-    }
+  @Inject
+  @Order(200)
+  private void installShutdownHook(@NonNull ShutdownHandler shutdownHandler) {
+    Runtime.getRuntime().addShutdownHook(new Thread(shutdownHandler));
   }
 
-  /**
-   * Starts the underlying application file in a separate thread based on the command line arguments passed to wrapper.
-   * These must include (in order):
-   * <ol>
-   *   <li>The main class of the application.
-   *   <li>The premain class of the application.
-   *   <li>The path of the application file to start.
-   *   <li>If all files in the jar should get pre-loaded by a non-system class loader (boolean).
-   * </ol>
-   * <p>
-   * The command line arguments will be removed from the known arguments and not passed to the application when starting.
-   *
-   * @return true if the application was started successfully, false otherwise.
-   * @throws Exception if any exception occurs while starting the application.
-   */
-  private boolean startApplication() throws Exception {
+  @Inject
+  @Order(250)
+  private void registerTransformer(@NonNull TransformerRegistry transformerRegistry) {
+    // register our default class transformers
+    transformerRegistry.registerTransformer(
+      "org/bukkit/craftbukkit",
+      "Commodore",
+      new BukkitCommodoreTransformer());
+    transformerRegistry.registerTransformer(
+      "org/bukkit/craftbukkit",
+      "Main",
+      new BukkitJavaVersionCheckTransformer());
+    transformerRegistry.registerTransformer(
+      "org/github/paperspigot",
+      "PaperSpigotConfig",
+      new PaperConfigTransformer());
+    // This prevents shadow from renaming io/netty to eu/cloudnetservice/io/netty
+    transformerRegistry.registerTransformer(
+      String.join("/", "io", "netty", "channel", "epoll"),
+      "Epoll",
+      new OldEpollDisableTransformer());
+  }
+
+  @Inject
+  @Order(300)
+  private void registerDefaultListeners(@NonNull EventManager eventManager) {
+    eventManager.registerListener(TaskChannelMessageListener.class);
+    eventManager.registerListener(GroupChannelMessageListener.class);
+    eventManager.registerListener(ServiceChannelMessageListener.class);
+    eventManager.registerListener(TemplateStorageCallbackListener.class);
+  }
+
+  @Inject
+  @Order(350)
+  private void initPermissionManagement(@NonNull PermissionManagement permissionManagement) {
+    permissionManagement.init();
+  }
+
+  @Inject
+  @Order(Integer.MAX_VALUE)
+  private void startApplication(
+    @NonNull EventManager eventManager,
+    @NonNull @Named("consoleArgs") List<String> consoleArgs
+  ) throws Exception {
     // get all the information provided through the command line
-    var mainClass = this.commandLineArguments.remove(0);
-    var premainClass = this.commandLineArguments.remove(0);
-    var appFile = Path.of(this.commandLineArguments.remove(0));
-    var preLoadAppJar = Boolean.parseBoolean(this.commandLineArguments.remove(0));
+    var mainClass = consoleArgs.remove(0);
+    var premainClass = consoleArgs.remove(0);
+    var appFile = Path.of(consoleArgs.remove(0));
+    var preLoadAppJar = Boolean.parseBoolean(consoleArgs.remove(0));
 
-    var loader = ClassLoader.getSystemClassLoader();
     // preload all jars in the application if requested
+    var loader = ClassLoader.getSystemClassLoader();
     if (preLoadAppJar) {
       // create a custom class loader for loading the application resources
       loader = new URLClassLoader(
@@ -455,8 +290,8 @@ public class Wrapper extends CloudNetDriver {
     var method = main.getMethod("main", String[].class);
 
     // inform the user about the pre-start
-    Collection<String> arguments = new ArrayList<>(this.commandLineArguments);
-    this.eventManager.callEvent(new ApplicationPreStartEvent(this, main, arguments, loader));
+    Collection<String> arguments = new LinkedList<>(consoleArgs);
+    eventManager.callEvent(new ApplicationPreStartEvent(main, arguments, loader));
 
     // start the application
     var applicationThread = new Thread(() -> {
@@ -472,62 +307,6 @@ public class Wrapper extends CloudNetDriver {
     applicationThread.start();
 
     // inform the user about the post-start
-    this.eventManager.callEvent(new ApplicationPostStartEvent(this, main, applicationThread, loader));
-    return true;
-  }
-
-  /**
-   * Get the configuration of the wrapper which is created based on the service information the node has available.
-   *
-   * @return the configuration of the wrapper.
-   */
-  public @NonNull WrapperConfiguration config() {
-    return this.config;
-  }
-
-  /**
-   * Get the directory in which the wrapper is currently running.
-   *
-   * @return the directory in which the wrapper is currently running.
-   */
-  public @NonNull Path workingDirectory() {
-    return WORKING_DIRECTORY;
-  }
-
-  /**
-   * Get the main thread of the wrapper. This is not the main thread of the application started by the wrapper!
-   *
-   * @return the main thread of the wrapper.
-   */
-  public @NonNull Thread mainThread() {
-    return this.mainThread;
-  }
-
-  /**
-   * Gets the last service info snapshot before the current one was created.
-   *
-   * @return the last service info snapshot.
-   */
-  public @NonNull ServiceInfoSnapshot lastServiceInfo() {
-    return this.lastServiceInfoSnapShot;
-  }
-
-  /**
-   * Get the current service info snapshot which is synced to all components in the network.
-   *
-   * @return the current service info snapshot.
-   */
-  public @NonNull ServiceInfoSnapshot currentServiceInfo() {
-    return this.currentServiceInfoSnapshot;
-  }
-
-  /**
-   * Get the transformer registry of the wrapper. This should mostly get used by CloudNet modules, as most (if not all)
-   * classes of an application are already loaded when a plugin, extension, etc. on the application layer gets loaded.
-   *
-   * @return the transformer registry of the wrapper.
-   */
-  public @NonNull TransformerRegistry transformerRegistry() {
-    return Premain.transformerRegistry;
+    eventManager.callEvent(new ApplicationPostStartEvent(main, applicationThread, loader));
   }
 }

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/configuration/DocumentWrapperConfiguration.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/configuration/DocumentWrapperConfiguration.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.wrapper.configuration;
 
+import dev.derklaro.aerogel.auto.Factory;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.network.HostAndPort;
 import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
@@ -34,6 +35,7 @@ public record DocumentWrapperConfiguration(
   private static final Path WRAPPER_CONFIG_PATH = Path.of(
     System.getProperty("cloudnet.wrapper.config.path", ".wrapper/wrapper.json"));
 
+  @Factory
   public static @NonNull WrapperConfiguration load() {
     return JsonDocument.newDocument(WRAPPER_CONFIG_PATH).toInstanceOf(DocumentWrapperConfiguration.class);
   }

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/configuration/WrapperConfiguration.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/configuration/WrapperConfiguration.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.driver.network.HostAndPort;
 import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
+import jakarta.inject.Singleton;
 import lombok.NonNull;
 
 /**
@@ -28,6 +29,7 @@ import lombok.NonNull;
  *
  * @since 4.0
  */
+@Singleton
 public interface WrapperConfiguration {
 
   /**

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/database/WrapperDatabaseProvider.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/database/WrapperDatabaseProvider.java
@@ -22,11 +22,11 @@ import eu.cloudnetservice.driver.network.rpc.RPCSender;
 import eu.cloudnetservice.driver.network.rpc.generation.GenerationContext;
 import lombok.NonNull;
 
-public abstract class DefaultWrapperDatabaseProvider implements DatabaseProvider {
+public abstract class WrapperDatabaseProvider implements DatabaseProvider {
 
   private final RPCSender rpcSender;
 
-  public DefaultWrapperDatabaseProvider(@NonNull RPCSender sender) {
+  public WrapperDatabaseProvider(@NonNull RPCSender sender) {
     this.rpcSender = sender;
   }
 

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPostStartEvent.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPostStartEvent.java
@@ -17,7 +17,6 @@
 package eu.cloudnetservice.wrapper.event;
 
 import eu.cloudnetservice.driver.event.Event;
-import eu.cloudnetservice.wrapper.Wrapper;
 import lombok.NonNull;
 
 /**
@@ -28,7 +27,6 @@ import lombok.NonNull;
  */
 public final class ApplicationPostStartEvent extends Event {
 
-  private final Wrapper cloudNetWrapper;
   private final Class<?> applicationMainClass;
   private final Thread applicationThread;
   private final ClassLoader classLoader;
@@ -36,31 +34,19 @@ public final class ApplicationPostStartEvent extends Event {
   /**
    * Constructs a new ApplicationPostStartEvent instance.
    *
-   * @param cloudNetWrapper      the wrapper instance which will start the application.
    * @param applicationMainClass the main class instance which will be invoked to start the application.
    * @param applicationThread    the thread in which the application was started.
    * @param classLoader          the class loader which loaded the application main class.
-   * @throws NullPointerException if the given wrapper instance, app main, app thread or class loader is null.
+   * @throws NullPointerException if the given app main, app thread or class loader is null.
    */
   public ApplicationPostStartEvent(
-    @NonNull Wrapper cloudNetWrapper,
     @NonNull Class<?> applicationMainClass,
     @NonNull Thread applicationThread,
     @NonNull ClassLoader classLoader
   ) {
-    this.cloudNetWrapper = cloudNetWrapper;
     this.applicationMainClass = applicationMainClass;
     this.applicationThread = applicationThread;
     this.classLoader = classLoader;
-  }
-
-  /**
-   * Get the wrapper instance which started the application.
-   *
-   * @return the wrapper instance.
-   */
-  public @NonNull Wrapper wrapper() {
-    return this.cloudNetWrapper;
   }
 
   /**

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPreStartEvent.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPreStartEvent.java
@@ -17,7 +17,6 @@
 package eu.cloudnetservice.wrapper.event;
 
 import eu.cloudnetservice.driver.event.Event;
-import eu.cloudnetservice.wrapper.Wrapper;
 import java.util.Collection;
 import lombok.NonNull;
 
@@ -29,7 +28,6 @@ import lombok.NonNull;
  */
 public final class ApplicationPreStartEvent extends Event {
 
-  private final Wrapper cloudNetWrapper;
   private final Class<?> applicationMainClass;
   private final Collection<String> arguments;
   private final ClassLoader classLoader;
@@ -37,31 +35,19 @@ public final class ApplicationPreStartEvent extends Event {
   /**
    * Constructs a new ApplicationPreStartEvent instance.
    *
-   * @param cloudNetWrapper      the wrapper instance which will start the application.
    * @param applicationMainClass the main class instance which will be invoked to start the application.
    * @param arguments            the process arguments which will be passed to the application.
    * @param classLoader          the class loader which loaded the application main class.
-   * @throws NullPointerException if the given wrapper instance, application main, arguments or class loader is null.
+   * @throws NullPointerException if the given application main, arguments or class loader is null.
    */
   public ApplicationPreStartEvent(
-    @NonNull Wrapper cloudNetWrapper,
     @NonNull Class<?> applicationMainClass,
     @NonNull Collection<String> arguments,
     @NonNull ClassLoader classLoader
   ) {
-    this.cloudNetWrapper = cloudNetWrapper;
     this.applicationMainClass = applicationMainClass;
     this.arguments = arguments;
     this.classLoader = classLoader;
-  }
-
-  /**
-   * Get the wrapper instance which started the application.
-   *
-   * @return the wrapper instance.
-   */
-  public @NonNull Wrapper wrapper() {
-    return this.cloudNetWrapper;
   }
 
   /**

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/holder/ServiceInfoHolder.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/holder/ServiceInfoHolder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.holder;
+
+import eu.cloudnetservice.common.document.gson.JsonDocument;
+import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
+import lombok.NonNull;
+
+/**
+ * Provides information about the current service info, and methods to update it.
+ *
+ * @since 4.0
+ */
+public interface ServiceInfoHolder {
+
+  /**
+   * Setups the initial service information, this method can only be called once per lifecycle.
+   *
+   * @throws IllegalStateException if called when the provider is already initialized.
+   */
+  void setup();
+
+  /**
+   * Get the current service info snapshot which is synced to all components in the network.
+   *
+   * @return the current service info snapshot.
+   */
+  @NonNull ServiceInfoSnapshot serviceInfo();
+
+  /**
+   * Gets the last service info snapshot before the current one was created.
+   *
+   * @return the last service info snapshot.
+   */
+  @NonNull ServiceInfoSnapshot lastServiceInfo();
+
+  /**
+   * Creates a new service snapshot of this service, copying over the properties of the current service info snapshot.
+   * Only the creation time and process snapshot of the new snapshot differ from the old snapshot.
+   *
+   * @return the newly created service snapshot for this service.
+   */
+  @NonNull ServiceInfoSnapshot createServiceInfoSnapshot();
+
+  /**
+   * Creates a new service snapshot of this service using the provided properties for the new snapshot. Only the
+   * creation time, process snapshot and properties of the new snapshot differ from the old snapshot.
+   * <p>
+   * Changes made to the current service snapshot (like modifying the properties of it) will not reflect into the
+   * snapshot returned by this method.
+   *
+   * @param properties the properties to apply to the new snapshot.
+   * @return the newly created service snapshot for this service.
+   * @throws NullPointerException if the given properties document is null.
+   */
+  @NonNull ServiceInfoSnapshot createServiceInfoSnapshot(@NonNull JsonDocument properties);
+
+  /**
+   * Creates a new service snapshot of this service, copying over the properties of the current service info snapshot,
+   * then configuring it using the registered listeners of the {@code ServiceInfoSnapshotConfigureEvent}.
+   * <p>
+   * Changes made to the current service snapshot (like modifying the properties of it) will not reflect into the
+   * snapshot returned by this method.
+   * <p>
+   * This method will (unlike the {@code createServiceInfoSnapshot} method) change the current and old service snapshot
+   * to the newly created and configured one.
+   *
+   * @return the newly created service snapshot for this service.
+   */
+  @NonNull ServiceInfoSnapshot configureServiceInfoSnapshot();
+
+  /**
+   * Creates a new service snapshot, configures it, updates the current and old one and sends an update to all
+   * components which are currently registered within the CloudNet network.
+   */
+  void publishServiceInfoUpdate();
+
+  /**
+   * Updates the given service snapshot to all components which are currently registered within the CloudNet network.
+   * This method will configure the given snapshot if it belongs to the current wrapper instance.
+   *
+   * @param serviceInfoSnapshot the service snapshot to update.
+   * @throws NullPointerException if the given service snapshot is null.
+   */
+  void publishServiceInfoUpdate(@NonNull ServiceInfoSnapshot serviceInfoSnapshot);
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/holder/WrapperServiceInfoHolder.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/holder/WrapperServiceInfoHolder.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.holder;
+
+import com.google.common.base.Preconditions;
+import dev.derklaro.aerogel.auto.Provides;
+import eu.cloudnetservice.common.document.gson.JsonDocument;
+import eu.cloudnetservice.driver.channel.ChannelMessage;
+import eu.cloudnetservice.driver.event.EventManager;
+import eu.cloudnetservice.driver.network.buffer.DataBuf;
+import eu.cloudnetservice.driver.network.def.NetworkConstants;
+import eu.cloudnetservice.driver.service.ProcessSnapshot;
+import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
+import eu.cloudnetservice.driver.service.ServiceLifeCycle;
+import eu.cloudnetservice.driver.util.VarHandleUtil;
+import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
+import eu.cloudnetservice.wrapper.event.ServiceInfoSnapshotConfigureEvent;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import lombok.NonNull;
+
+/**
+ * The default implementation of a service info holder for the wrapper.
+ *
+ * @since 4.0
+ */
+@Singleton
+@Provides(ServiceInfoHolder.class)
+public final class WrapperServiceInfoHolder implements ServiceInfoHolder {
+
+  private static final VarHandle LAST_INFO_VAR_HANDLE;
+  private static final VarHandle CURRENT_INFO_VARHANDLE;
+
+  static {
+    var lookup = MethodHandles.lookup();
+    // the handle to change the last service snapshot
+    LAST_INFO_VAR_HANDLE = VarHandleUtil.lookup(
+      lookup,
+      WrapperServiceInfoHolder.class,
+      "lastServiceInfoSnapshot",
+      ServiceInfoSnapshot.class);
+    // the handle to change the current service snapshot
+    CURRENT_INFO_VARHANDLE = VarHandleUtil.lookup(
+      lookup,
+      WrapperServiceInfoHolder.class,
+      "currentServiceInfoSnapshot",
+      ServiceInfoSnapshot.class);
+  }
+
+  private final EventManager eventManager;
+  private final WrapperConfiguration configuration;
+
+  // both of these fields are only accessed from the associated var handles
+  @SuppressWarnings({"FieldCanBeLocal", "unused", "FieldMayBeFinal"})
+  private ServiceInfoSnapshot lastServiceInfoSnapshot;
+  @SuppressWarnings({"FieldCanBeLocal", "unused", "FieldMayBeFinal"})
+  private ServiceInfoSnapshot currentServiceInfoSnapshot;
+
+  @Inject
+  private WrapperServiceInfoHolder(@NonNull EventManager eventManager, @NonNull WrapperConfiguration configuration) {
+    this.eventManager = eventManager;
+    this.configuration = configuration;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setup() {
+    Preconditions.checkState(this.currentServiceInfoSnapshot == null, "Cannot setup twice");
+
+    var suppliedServiceSnapshot = this.configuration.serviceInfoSnapshot();
+    // init the last snapshot and the current snapshot
+    this.lastServiceInfoSnapshot = suppliedServiceSnapshot;
+    this.currentServiceInfoSnapshot = new ServiceInfoSnapshot(
+      System.currentTimeMillis(),
+      suppliedServiceSnapshot.address(),
+      ProcessSnapshot.self(),
+      suppliedServiceSnapshot.configuration(),
+      System.currentTimeMillis(),
+      ServiceLifeCycle.RUNNING,
+      suppliedServiceSnapshot.properties());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull ServiceInfoSnapshot serviceInfo() {
+    return (ServiceInfoSnapshot) CURRENT_INFO_VARHANDLE.getAcquire(this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull ServiceInfoSnapshot lastServiceInfo() {
+    return (ServiceInfoSnapshot) LAST_INFO_VAR_HANDLE.getAcquire(this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull ServiceInfoSnapshot createServiceInfoSnapshot() {
+    return this.createServiceInfoSnapshot(this.serviceInfo().properties());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull ServiceInfoSnapshot createServiceInfoSnapshot(@NonNull JsonDocument properties) {
+    var currentServiceInfo = this.serviceInfo();
+    return new ServiceInfoSnapshot(
+      System.currentTimeMillis(),
+      currentServiceInfo.address(),
+      ProcessSnapshot.self(),
+      this.configuration.serviceConfiguration(),
+      currentServiceInfo.connectedTime(),
+      ServiceLifeCycle.RUNNING,
+      properties.clone());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull ServiceInfoSnapshot configureServiceInfoSnapshot() {
+    var serviceInfoSnapshot = this.createServiceInfoSnapshot();
+    this.configureServiceInfoSnapshot(serviceInfoSnapshot);
+    return serviceInfoSnapshot;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void publishServiceInfoUpdate() {
+    this.publishServiceInfoUpdate(this.createServiceInfoSnapshot());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void publishServiceInfoUpdate(@NonNull ServiceInfoSnapshot serviceInfoSnapshot) {
+    // add configuration stuff when updating the current service snapshot
+    if (this.configuration.serviceConfiguration().serviceId().equals(serviceInfoSnapshot.serviceId())) {
+      this.configureServiceInfoSnapshot(serviceInfoSnapshot);
+    }
+
+    // send the update to all nodes and services
+    ChannelMessage.builder()
+      .targetAll()
+      .message("update_service_info")
+      .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
+      .buffer(DataBuf.empty().writeObject(serviceInfoSnapshot))
+      .build()
+      .send();
+  }
+
+  /**
+   * Configures the given service info snapshot and updates the current and old service snapshot.
+   *
+   * @param serviceInfoSnapshot the service snapshot to configure.
+   * @throws NullPointerException if the given snapshot is null.
+   */
+  private void configureServiceInfoSnapshot(@NonNull ServiceInfoSnapshot serviceInfoSnapshot) {
+    this.eventManager.callEvent(new ServiceInfoSnapshotConfigureEvent(serviceInfoSnapshot));
+
+    // update the current & last snapshot
+    var lastSnapshot = (ServiceInfoSnapshot) CURRENT_INFO_VARHANDLE.getAndSetRelease(this, serviceInfoSnapshot);
+    LAST_INFO_VAR_HANDLE.setRelease(this, lastSnapshot);
+  }
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/inject/BootFactories.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/inject/BootFactories.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.inject;
+
+import dev.derklaro.aerogel.auto.Factory;
+import eu.cloudnetservice.driver.ComponentInfo;
+import eu.cloudnetservice.driver.DriverEnvironment;
+import eu.cloudnetservice.driver.event.EventManager;
+import eu.cloudnetservice.driver.network.NetworkClient;
+import eu.cloudnetservice.driver.network.netty.client.NettyNetworkClient;
+import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
+import eu.cloudnetservice.wrapper.network.NetworkClientChannelHandler;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+
+@SuppressWarnings("unused")
+final class BootFactories {
+
+  private BootFactories() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull ComponentInfo provideComponentInfo(@NonNull WrapperConfiguration configuration) {
+    var serviceId = configuration.serviceConfiguration().serviceId();
+    return new ComponentInfo(DriverEnvironment.WRAPPER, serviceId.name(), serviceId.nodeUniqueId());
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull NetworkClient providerNetworkClient(
+    @NonNull EventManager eventManager,
+    @NonNull ComponentInfo componentInfo,
+    @NonNull WrapperConfiguration configuration,
+    @NonNull Provider<NetworkClientChannelHandler> handlerProvider
+  ) {
+    return new NettyNetworkClient(eventManager, componentInfo, handlerProvider::get, configuration.sslConfiguration());
+  }
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/inject/RPCFactories.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/inject/RPCFactories.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019-2022 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.inject;
+
+import dev.derklaro.aerogel.auto.Factory;
+import eu.cloudnetservice.driver.ComponentInfo;
+import eu.cloudnetservice.driver.database.DatabaseProvider;
+import eu.cloudnetservice.driver.event.EventManager;
+import eu.cloudnetservice.driver.network.NetworkClient;
+import eu.cloudnetservice.driver.network.rpc.RPCFactory;
+import eu.cloudnetservice.driver.network.rpc.generation.GenerationContext;
+import eu.cloudnetservice.driver.permission.PermissionManagement;
+import eu.cloudnetservice.driver.provider.CloudServiceFactory;
+import eu.cloudnetservice.driver.provider.CloudServiceProvider;
+import eu.cloudnetservice.driver.provider.ClusterNodeProvider;
+import eu.cloudnetservice.driver.provider.GroupConfigurationProvider;
+import eu.cloudnetservice.driver.provider.ServiceTaskProvider;
+import eu.cloudnetservice.driver.template.TemplateStorageProvider;
+import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
+import eu.cloudnetservice.wrapper.database.WrapperDatabaseProvider;
+import eu.cloudnetservice.wrapper.permission.WrapperPermissionManagement;
+import eu.cloudnetservice.wrapper.provider.WrapperCloudServiceProvider;
+import eu.cloudnetservice.wrapper.provider.WrapperTemplateStorageProvider;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+
+@SuppressWarnings("unused")
+final class RPCFactories {
+
+  private RPCFactories() {
+    throw new UnsupportedOperationException();
+  }
+
+  private static @NonNull <T> T provideBasic(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient,
+    @NonNull Class<T> baseClass
+  ) {
+    var context = GenerationContext.forClass(baseClass).component(networkClient).build();
+    return factory.generateRPCBasedApi(baseClass, context).newInstance();
+  }
+
+  private static @NonNull <T> T provideSpecial(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient,
+    @NonNull Class<T> baseClass,
+    @NonNull Class<? extends T> implementingClass,
+    @NonNull Object... specialConstructorArgs
+  ) {
+    var context = GenerationContext.forClass(implementingClass).component(networkClient).build();
+    return factory.generateRPCBasedApi(baseClass, context).newInstance(specialConstructorArgs);
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull ClusterNodeProvider provideClusterNodeProvider(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient
+  ) {
+    return provideBasic(factory, networkClient, ClusterNodeProvider.class);
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull ServiceTaskProvider provideServiceTaskProvider(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient
+  ) {
+    return provideBasic(factory, networkClient, ServiceTaskProvider.class);
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull GroupConfigurationProvider provideGroupConfigurationProvider(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient
+  ) {
+    return provideBasic(factory, networkClient, GroupConfigurationProvider.class);
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull CloudServiceFactory provideCloudServiceFactory(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient
+  ) {
+    return provideBasic(factory, networkClient, CloudServiceFactory.class);
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull TemplateStorageProvider provideTemplateStorageProvider(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient,
+    @NonNull ComponentInfo componentInfo
+  ) {
+    return provideSpecial(
+      factory,
+      networkClient,
+      TemplateStorageProvider.class,
+      WrapperTemplateStorageProvider.class,
+      componentInfo, networkClient);
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull DatabaseProvider provideDatabaseProvider(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient
+  ) {
+    return provideSpecial(factory, networkClient, DatabaseProvider.class, WrapperDatabaseProvider.class);
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull CloudServiceProvider provideCloudServiceProvider(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient
+  ) {
+    return provideSpecial(factory, networkClient, CloudServiceProvider.class, WrapperCloudServiceProvider.class);
+  }
+
+  @Factory
+  @Singleton
+  public static @NonNull PermissionManagement providePermissionManagement(
+    @NonNull RPCFactory factory,
+    @NonNull NetworkClient networkClient,
+    @NonNull EventManager eventManager,
+    @NonNull WrapperConfiguration configuration
+  ) {
+    return provideSpecial(
+      factory,
+      networkClient,
+      PermissionManagement.class,
+      WrapperPermissionManagement.class,
+      eventManager, configuration.serviceConfiguration());
+  }
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/log/InternalPrintStreamLogHandler.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/log/InternalPrintStreamLogHandler.java
@@ -34,7 +34,7 @@ public final class InternalPrintStreamLogHandler extends AbstractHandler {
   private final PrintStream outputStream;
   private final PrintStream errorStream;
 
-  private InternalPrintStreamLogHandler(PrintStream outputStream, PrintStream errorStream) {
+  private InternalPrintStreamLogHandler(@NonNull PrintStream outputStream, @NonNull PrintStream errorStream) {
     this.outputStream = outputStream;
     this.errorStream = errorStream;
     // set defaults
@@ -45,12 +45,12 @@ public final class InternalPrintStreamLogHandler extends AbstractHandler {
     return InternalPrintStreamLogHandler.newInstance(System.out, System.err);
   }
 
-  public static @NonNull InternalPrintStreamLogHandler newInstance(PrintStream out, PrintStream err) {
+  public static @NonNull InternalPrintStreamLogHandler newInstance(@NonNull PrintStream out, @NonNull PrintStream err) {
     return new InternalPrintStreamLogHandler(out, err);
   }
 
   @Override
-  public void publish(LogRecord record) {
+  public void publish(@NonNull LogRecord record) {
     var stream = record.getLevel().intValue() > Level.INFO.intValue() ? this.errorStream : this.outputStream;
     stream.println(super.getFormatter().format(record));
   }

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/NetworkClientChannelHandler.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/NetworkClientChannelHandler.java
@@ -16,7 +16,7 @@
 
 package eu.cloudnetservice.wrapper.network;
 
-import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.event.events.network.ChannelType;
 import eu.cloudnetservice.driver.event.events.network.NetworkChannelCloseEvent;
 import eu.cloudnetservice.driver.event.events.network.NetworkChannelInitEvent;
@@ -26,37 +26,43 @@ import eu.cloudnetservice.driver.network.NetworkChannelHandler;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.def.PacketClientAuthorization;
 import eu.cloudnetservice.driver.network.protocol.Packet;
-import eu.cloudnetservice.wrapper.Wrapper;
+import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
+import jakarta.inject.Inject;
 import lombok.NonNull;
 
-public class NetworkClientChannelHandler implements NetworkChannelHandler {
+public final class NetworkClientChannelHandler implements NetworkChannelHandler {
+
+  private final EventManager eventManager;
+  private final WrapperConfiguration wrapperConfiguration;
+
+  @Inject
+  public NetworkClientChannelHandler(@NonNull EventManager eventManager, @NonNull WrapperConfiguration configuration) {
+    this.eventManager = eventManager;
+    this.wrapperConfiguration = configuration;
+  }
 
   @Override
   public void handleChannelInitialize(@NonNull NetworkChannel channel) {
-    var networkChannelInitEvent = new NetworkChannelInitEvent(channel, ChannelType.CLIENT_CHANNEL);
-    CloudNetDriver.instance().eventManager().callEvent(networkChannelInitEvent);
-
-    if (networkChannelInitEvent.cancelled()) {
+    var event = this.eventManager.callEvent(new NetworkChannelInitEvent(channel, ChannelType.CLIENT_CHANNEL));
+    if (event.cancelled()) {
       channel.close();
       return;
     }
 
-    networkChannelInitEvent.networkChannel().sendPacket(new PacketClientAuthorization(
+    channel.sendPacket(new PacketClientAuthorization(
       PacketClientAuthorization.PacketAuthorizationType.WRAPPER_TO_NODE,
       DataBuf.empty()
-        .writeString(Wrapper.instance().config().connectionKey())
-        .writeObject(Wrapper.instance().config().serviceConfiguration().serviceId())));
+        .writeString(this.wrapperConfiguration.connectionKey())
+        .writeObject(this.wrapperConfiguration.serviceConfiguration().serviceId())));
   }
 
   @Override
   public boolean handlePacketReceive(@NonNull NetworkChannel channel, @NonNull Packet packet) {
-    return !CloudNetDriver.instance().eventManager().callEvent(
-      new NetworkChannelPacketReceiveEvent(channel, packet)).cancelled();
+    return !this.eventManager.callEvent(new NetworkChannelPacketReceiveEvent(channel, packet)).cancelled();
   }
 
   @Override
   public void handleChannelClose(@NonNull NetworkChannel channel) {
-    CloudNetDriver.instance().eventManager().callEvent(
-      new NetworkChannelCloseEvent(channel, ChannelType.CLIENT_CHANNEL));
+    this.eventManager.callEvent(new NetworkChannelCloseEvent(channel, ChannelType.CLIENT_CHANNEL));
   }
 }

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketAuthorizationResponseListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketAuthorizationResponseListener.java
@@ -19,36 +19,30 @@ package eu.cloudnetservice.wrapper.network.listener;
 import eu.cloudnetservice.driver.network.NetworkChannel;
 import eu.cloudnetservice.driver.network.protocol.Packet;
 import eu.cloudnetservice.driver.network.protocol.PacketListener;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
 import lombok.NonNull;
 
 public final class PacketAuthorizationResponseListener implements PacketListener {
 
-  private final Lock lock;
-  private final Condition condition;
+  private final Thread blockedThread;
+  private final AtomicBoolean result;
 
-  private volatile boolean result;
-
-  public PacketAuthorizationResponseListener(@NonNull Lock lock, @NonNull Condition condition) {
-    this.lock = lock;
-    this.condition = condition;
+  public PacketAuthorizationResponseListener(@NonNull Thread blockedThread) {
+    this.blockedThread = blockedThread;
+    this.result = new AtomicBoolean(false);
   }
 
   @Override
   public void handle(@NonNull NetworkChannel channel, @NonNull Packet packet) {
     // read the auth result
-    this.result = packet.content().readBoolean();
+    this.result.setRelease(packet.content().readBoolean());
+
     // signal all listeners waiting for the auth
-    try {
-      this.lock.lock();
-      this.condition.signalAll();
-    } finally {
-      this.lock.unlock();
-    }
+    LockSupport.unpark(this.blockedThread);
   }
 
   public boolean wasAuthSuccessful() {
-    return this.result;
+    return this.result.getAcquire();
   }
 }

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketServerChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketServerChannelMessageListener.java
@@ -16,17 +16,25 @@
 
 package eu.cloudnetservice.wrapper.network.listener;
 
-import eu.cloudnetservice.driver.CloudNetDriver;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
+import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.event.events.channel.ChannelMessageReceiveEvent;
 import eu.cloudnetservice.driver.network.NetworkChannel;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.protocol.Packet;
 import eu.cloudnetservice.driver.network.protocol.PacketListener;
+import jakarta.inject.Inject;
 import java.util.Set;
 import lombok.NonNull;
 
 public final class PacketServerChannelMessageListener implements PacketListener {
+
+  private final EventManager eventManager;
+
+  @Inject
+  public PacketServerChannelMessageListener(@NonNull EventManager eventManager) {
+    this.eventManager = eventManager;
+  }
 
   @Override
   public void handle(@NonNull NetworkChannel channel, @NonNull Packet packet) {
@@ -35,7 +43,7 @@ public final class PacketServerChannelMessageListener implements PacketListener 
     // read the channel message from the buffer
     var message = packet.content().readObject(ChannelMessage.class);
     // get the query response if available
-    var response = CloudNetDriver.instance().eventManager()
+    var response = this.eventManager
       .callEvent(new ChannelMessageReceiveEvent(message, channel, packet.uniqueId() != null))
       .queryResponse();
     // check if we need to respond to the channel message

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/GroupChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/GroupChannelMessageListener.java
@@ -27,26 +27,20 @@ import lombok.NonNull;
 
 public final class GroupChannelMessageListener {
 
-  private final EventManager eventManager;
-
-  public GroupChannelMessageListener(@NonNull EventManager eventManager) {
-    this.eventManager = eventManager;
-  }
-
   @EventListener
-  public void handle(@NonNull ChannelMessageReceiveEvent event) {
+  public void handle(@NonNull ChannelMessageReceiveEvent event, @NonNull EventManager eventManager) {
     if (event.channel().equals(NetworkConstants.INTERNAL_MSG_CHANNEL)) {
       switch (event.message()) {
         // add group
         case "add_group_configuration" -> {
           var configuration = event.content().readObject(GroupConfiguration.class);
-          this.eventManager.callEvent(new GroupConfigurationAddEvent(configuration));
+          eventManager.callEvent(new GroupConfigurationAddEvent(configuration));
         }
 
         // remove group
         case "remove_group_configuration" -> {
           var configuration = event.content().readObject(GroupConfiguration.class);
-          this.eventManager.callEvent(new GroupConfigurationRemoveEvent(configuration));
+          eventManager.callEvent(new GroupConfigurationRemoveEvent(configuration));
         }
 
         // none of our business

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/PermissionChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/PermissionChannelMessageListener.java
@@ -35,64 +35,56 @@ import lombok.NonNull;
 
 public final class PermissionChannelMessageListener {
 
-  private final EventManager eventManager;
-  private final PermissionManagement permissionManagement;
-
-  public PermissionChannelMessageListener(
-    @NonNull EventManager eventManager,
-    @NonNull PermissionManagement management
-  ) {
-    this.eventManager = eventManager;
-    this.permissionManagement = management;
-  }
-
   @EventListener
-  public void handleChannelMessage(@NonNull ChannelMessageReceiveEvent event) {
-    if (event.channel().equals(NetworkConstants.INTERNAL_MSG_CHANNEL) && event.message()
-      .startsWith("permissions_")) {
+  public void handleChannelMessage(
+    @NonNull ChannelMessageReceiveEvent event,
+    @NonNull EventManager eventManager,
+    @NonNull PermissionManagement permissionManagement
+  ) {
+    if (event.channel().equals(NetworkConstants.INTERNAL_MSG_CHANNEL) && event.message().startsWith("permissions_")) {
       // permission message - handler
       switch (event.message().replaceFirst("permissions_", "")) {
         // user add
-        case "add_user" -> this.eventManager.callEvent(new PermissionAddUserEvent(
-          this.permissionManagement,
+        case "add_user" -> eventManager.callEvent(new PermissionAddUserEvent(
+          permissionManagement,
           event.content().readObject(PermissionUser.class)));
 
         // user update
-        case "update_user" -> this.eventManager.callEvent(new PermissionUpdateUserEvent(
-          this.permissionManagement,
+        case "update_user" -> eventManager.callEvent(new PermissionUpdateUserEvent(
+          permissionManagement,
           event.content().readObject(PermissionUser.class)));
 
         // user remove
-        case "delete_user" -> this.eventManager.callEvent(new PermissionDeleteUserEvent(
-          this.permissionManagement,
+        case "delete_user" -> eventManager.callEvent(new PermissionDeleteUserEvent(
+          permissionManagement,
           event.content().readObject(PermissionUser.class)));
 
         // group add
         case "add_group" -> {
           // read the group
           var group = event.content().readObject(PermissionGroup.class);
-          this.eventManager.callEvent(new PermissionAddGroupEvent(this.permissionManagement, group));
+          eventManager.callEvent(new PermissionAddGroupEvent(permissionManagement, group));
         }
 
         // group update
         case "update_group" -> {
           // read the group
           var group = event.content().readObject(PermissionGroup.class);
-          this.eventManager.callEvent(new PermissionUpdateGroupEvent(this.permissionManagement, group));
+          eventManager.callEvent(new PermissionUpdateGroupEvent(permissionManagement, group));
         }
 
         // group delete
         case "delete_group" -> {
           // read the group
           var group = event.content().readObject(PermissionGroup.class);
-          this.eventManager.callEvent(new PermissionDeleteGroupEvent(this.permissionManagement, group));
+          eventManager.callEvent(new PermissionDeleteGroupEvent(permissionManagement, group));
         }
 
         // group set
         case "set_groups" -> {
           // read the group
           Collection<PermissionGroup> groups = event.content().readObject(PermissionGroup.COL_GROUPS);
-          this.eventManager.callEvent(new PermissionSetGroupsEvent(this.permissionManagement, groups));
+          eventManager.callEvent(new PermissionSetGroupsEvent(permissionManagement, groups));
         }
         default -> throw new IllegalArgumentException("Unhandled permission message " + event.message());
       }

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/ServiceChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/ServiceChannelMessageListener.java
@@ -29,26 +29,24 @@ import eu.cloudnetservice.driver.network.def.NetworkConstants;
 import eu.cloudnetservice.driver.service.ServiceCreateResult;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceLifeCycle;
-import eu.cloudnetservice.wrapper.Wrapper;
+import eu.cloudnetservice.wrapper.holder.ServiceInfoHolder;
 import lombok.NonNull;
 
 public final class ServiceChannelMessageListener {
 
-  private final EventManager eventManager;
-
-  public ServiceChannelMessageListener(@NonNull EventManager eventManager) {
-    this.eventManager = eventManager;
-  }
-
   @EventListener
-  public void handleChannelMessage(@NonNull ChannelMessageReceiveEvent event) {
+  public void handleChannelMessage(
+    @NonNull ChannelMessageReceiveEvent event,
+    @NonNull EventManager eventManager,
+    @NonNull ServiceInfoHolder serviceInfoHolder
+  ) {
     if (event.channel().equals(NetworkConstants.INTERNAL_MSG_CHANNEL)) {
       switch (event.message()) {
         // update of a service in the network
         case "update_service_info" -> {
           var snapshot = event.content().readObject(ServiceInfoSnapshot.class);
           // update locally and call the event
-          this.eventManager.callEvent(new CloudServiceUpdateEvent(snapshot));
+          eventManager.callEvent(new CloudServiceUpdateEvent(snapshot));
         }
 
         // update of a service lifecycle in the network
@@ -56,20 +54,20 @@ public final class ServiceChannelMessageListener {
           var lifeCycle = event.content().readObject(ServiceLifeCycle.class);
           var snapshot = event.content().readObject(ServiceInfoSnapshot.class);
           // update locally and call the event
-          this.eventManager.callEvent(new CloudServiceLifecycleChangeEvent(lifeCycle, snapshot));
+          eventManager.callEvent(new CloudServiceLifecycleChangeEvent(lifeCycle, snapshot));
         }
 
         // force update request of the service info
         case "request_update_service_information" -> event.binaryResponse(DataBuf.empty()
-          .writeObject(Wrapper.instance().configureServiceInfoSnapshot()));
+          .writeObject(serviceInfoHolder.configureServiceInfoSnapshot()));
 
         // force update request of the service information with new properties
         case "request_update_service_information_with_new_properties" -> {
           var properties = event.content().readObject(JsonDocument.class);
-          var snapshot = Wrapper.instance().createServiceInfoSnapshot(properties);
+          var snapshot = serviceInfoHolder.createServiceInfoSnapshot(properties);
 
           // publish the new service info
-          Wrapper.instance().publishServiceInfoUpdate(snapshot);
+          serviceInfoHolder.publishServiceInfoUpdate(snapshot);
         }
 
         // call the event for a new line in the log of the service
@@ -81,7 +79,7 @@ public final class ServiceChannelMessageListener {
             ? CloudServiceLogEntryEvent.StreamType.STDERR
             : CloudServiceLogEntryEvent.StreamType.STDOUT;
 
-          this.eventManager.callEvent(eventChannel, new CloudServiceLogEntryEvent(snapshot, line, type));
+          eventManager.callEvent(eventChannel, new CloudServiceLogEntryEvent(snapshot, line, type));
         }
 
         // a deferred service start result is available, call the event
@@ -89,7 +87,7 @@ public final class ServiceChannelMessageListener {
           var creationId = event.content().readUniqueId();
           var createResult = event.content().readObject(ServiceCreateResult.class);
 
-          this.eventManager.callEvent(new CloudServiceDeferredStateEvent(creationId, createResult));
+          eventManager.callEvent(new CloudServiceDeferredStateEvent(creationId, createResult));
         }
 
         // none of our business

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/TaskChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/TaskChannelMessageListener.java
@@ -27,26 +27,20 @@ import lombok.NonNull;
 
 public final class TaskChannelMessageListener {
 
-  private final EventManager eventManager;
-
-  public TaskChannelMessageListener(@NonNull EventManager eventManager) {
-    this.eventManager = eventManager;
-  }
-
   @EventListener
-  public void handleChannelMessage(@NonNull ChannelMessageReceiveEvent event) {
+  public void handleChannelMessage(@NonNull ChannelMessageReceiveEvent event, @NonNull EventManager eventManager) {
     if (event.channel().equals(NetworkConstants.INTERNAL_MSG_CHANNEL)) {
       switch (event.message()) {
         // add task
         case "add_service_task" -> {
           var task = event.content().readObject(ServiceTask.class);
-          this.eventManager.callEvent(new ServiceTaskAddEvent(task));
+          eventManager.callEvent(new ServiceTaskAddEvent(task));
         }
 
         // remove task
         case "remove_service_task" -> {
           var task = event.content().readObject(ServiceTask.class);
-          this.eventManager.callEvent(new ServiceTaskRemoveEvent(task));
+          eventManager.callEvent(new ServiceTaskRemoveEvent(task));
         }
 
         // none of our business

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/permission/PermissionCacheListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/permission/PermissionCacheListener.java
@@ -27,7 +27,7 @@ import lombok.NonNull;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
-public final class PermissionCacheListener {
+final class PermissionCacheListener {
 
   private final WrapperPermissionManagement permissionManagement;
 

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/permission/WrapperPermissionManagement.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/permission/WrapperPermissionManagement.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.wrapper.permission;
 
-import eu.cloudnetservice.driver.CloudNetDriver;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.network.rpc.RPCSender;
 import eu.cloudnetservice.driver.permission.DefaultCachedPermissionManagement;
@@ -26,7 +25,7 @@ import eu.cloudnetservice.driver.permission.PermissionCheckResult;
 import eu.cloudnetservice.driver.permission.PermissionGroup;
 import eu.cloudnetservice.driver.permission.PermissionManagement;
 import eu.cloudnetservice.driver.permission.PermissionUser;
-import eu.cloudnetservice.wrapper.Wrapper;
+import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.wrapper.network.listener.message.PermissionChannelMessageListener;
 import java.util.Collection;
 import java.util.UUID;
@@ -37,16 +36,22 @@ public abstract class WrapperPermissionManagement extends DefaultCachedPermissio
 
   private final RPCSender rpcSender;
   private final EventManager eventManager;
+  private final ServiceConfiguration serviceConfiguration;
 
   private final PermissionCacheListener cacheListener;
   private final PermissionChannelMessageListener channelMessageListener;
 
-  public WrapperPermissionManagement(@NonNull RPCSender sender) {
+  public WrapperPermissionManagement(
+    @NonNull RPCSender sender,
+    @NonNull EventManager eventManager,
+    @NonNull ServiceConfiguration serviceConfiguration
+  ) {
     this.rpcSender = sender;
-    this.eventManager = CloudNetDriver.instance().eventManager();
+    this.eventManager = eventManager;
+    this.serviceConfiguration = serviceConfiguration;
 
+    this.channelMessageListener = new PermissionChannelMessageListener();
     this.cacheListener = new PermissionCacheListener(this);
-    this.channelMessageListener = new PermissionChannelMessageListener(this.eventManager, this);
   }
 
   @Override
@@ -119,7 +124,7 @@ public abstract class WrapperPermissionManagement extends DefaultCachedPermissio
   ) {
     return this.groupsPermissionResult(
       permissible,
-      Wrapper.instance().currentServiceInfo().configuration().groups().toArray(new String[0]),
+      this.serviceConfiguration.groups().toArray(new String[0]),
       permission);
   }
 

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperMessenger.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperMessenger.java
@@ -17,38 +17,43 @@
 package eu.cloudnetservice.wrapper.provider;
 
 import com.google.gson.reflect.TypeToken;
+import dev.derklaro.aerogel.auto.Provides;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
-import eu.cloudnetservice.driver.network.NetworkComponent;
+import eu.cloudnetservice.driver.network.NetworkClient;
 import eu.cloudnetservice.driver.network.def.PacketServerChannelMessage;
 import eu.cloudnetservice.driver.provider.CloudMessenger;
 import eu.cloudnetservice.driver.provider.defaults.DefaultMessenger;
-import eu.cloudnetservice.wrapper.Wrapper;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import lombok.NonNull;
 
+@Singleton
+@Provides(CloudMessenger.class)
 public class WrapperMessenger extends DefaultMessenger implements CloudMessenger {
 
   private static final Type MESSAGES = TypeToken.getParameterized(Collection.class, ChannelMessage.class).getType();
 
-  private final NetworkComponent component;
+  private final NetworkClient networkClient;
 
-  public WrapperMessenger(@NonNull Wrapper wrapper) {
-    this.component = wrapper.networkClient();
+  @Inject
+  public WrapperMessenger(@NonNull NetworkClient networkClient) {
+    this.networkClient = networkClient;
   }
 
   @Override
   public void sendChannelMessage(@NonNull ChannelMessage channelMessage) {
     if (channelMessage.sendSync()) {
-      this.component.sendPacketSync(new PacketServerChannelMessage(channelMessage, true));
+      this.networkClient.sendPacketSync(new PacketServerChannelMessage(channelMessage, true));
     } else {
-      this.component.sendPacket(new PacketServerChannelMessage(channelMessage, true));
+      this.networkClient.sendPacket(new PacketServerChannelMessage(channelMessage, true));
     }
   }
 
   @Override
   public @NonNull Collection<ChannelMessage> sendChannelMessageQuery(@NonNull ChannelMessage channelMessage) {
-    return this.component.firstChannel()
+    return this.networkClient.firstChannel()
       .queryPacketManager()
       .sendQueryPacket(new PacketServerChannelMessage(channelMessage, true))
       .join()

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperTemplateStorageProvider.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperTemplateStorageProvider.java
@@ -16,6 +16,8 @@
 
 package eu.cloudnetservice.wrapper.provider;
 
+import eu.cloudnetservice.driver.ComponentInfo;
+import eu.cloudnetservice.driver.network.NetworkClient;
 import eu.cloudnetservice.driver.network.rpc.RPCSender;
 import eu.cloudnetservice.driver.network.rpc.generation.GenerationContext;
 import eu.cloudnetservice.driver.service.ServiceTemplate;
@@ -28,9 +30,17 @@ import org.jetbrains.annotations.Nullable;
 public abstract class WrapperTemplateStorageProvider implements TemplateStorageProvider {
 
   private final RPCSender rpcSender;
+  private final ComponentInfo componentInfo;
+  private final NetworkClient networkClient;
 
-  public WrapperTemplateStorageProvider(@NonNull RPCSender sender) {
+  public WrapperTemplateStorageProvider(
+    @NonNull RPCSender sender,
+    @NonNull ComponentInfo componentInfo,
+    @NonNull NetworkClient networkClient
+  ) {
     this.rpcSender = sender;
+    this.componentInfo = componentInfo;
+    this.networkClient = networkClient;
   }
 
   @Override
@@ -49,6 +59,6 @@ public abstract class WrapperTemplateStorageProvider implements TemplateStorageP
       this.rpcSender,
       TemplateStorage.class,
       GenerationContext.forClass(RemoteTemplateStorage.class).build()
-    ).newInstance(storage); // TODO: fix: this needs the component info and network client as well
+    ).newInstance(new Object[]{storage, this.componentInfo, this.networkClient}, new Object[]{storage});
   }
 }


### PR DESCRIPTION
### Motivation
The wrapper needs migration to use dependency injection as well.

### Modification
Remove all usages of CloudNetDriver.instance and Wrapper.instance from wrapper.

### Result
Dependency injection is fully applied to wrapper.
