### PR TITLE
chore: migrate papi expansion to use injection

### DIFF
--- a/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
+++ b/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
@@ -16,14 +16,23 @@
 
 package eu.cloudnetservice.plugins.papi;
 
+import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
-import eu.cloudnetservice.wrapper.Wrapper;
+import eu.cloudnetservice.wrapper.holder.ServiceInfoHolder;
 import lombok.NonNull;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.Nullable;
 
 public class CloudNetPapiExpansion extends PlaceholderExpansion {
+
+  private final ServiceInfoHolder serviceInfoHolder;
+
+  public CloudNetPapiExpansion() {
+    // not an ideal solution but should be enough in order to let this expansion
+    // work without the need to wrap it in a plugin
+    this.serviceInfoHolder = InjectionLayer.ext().instance(ServiceInfoHolder.class);
+  }
 
   @Override
   public @NonNull String getIdentifier() {
@@ -56,7 +65,7 @@ public class CloudNetPapiExpansion extends PlaceholderExpansion {
     // The bridge will just replace all placeholders in the string with the correct association.
     // We can just return null if the resulting string matches the input string
     var input = '%' + params + '%';
-    var out = BridgeServiceHelper.fillCommonPlaceholders(input, null, Wrapper.instance().currentServiceInfo());
+    var out = BridgeServiceHelper.fillCommonPlaceholders(input, null, this.serviceInfoHolder.serviceInfo());
 
     return out.equals(input) ? null : out;
   }


### PR DESCRIPTION
### Motivation
Migrates the papi expansion to use dependency injection (somewhat).

### Modification
Instead of using Wrapper.instance we now get the service info holder instance from the ext injection layer. This is not the ideal use for that case, but, it prevents us from needing to wrap the expansion into a plugin to create an injection layer just for that purpose.

### Result
The papi expansion now uses injection.
