### PR TITLE
chore: bind injection layers to more generic types

### DIFF
--- a/driver/build.gradle.kts
+++ b/driver/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
   "implementation"(libs.asm)
   "implementation"(libs.gson)
   "implementation"(libs.guava)
+  "implementation"(libs.geantyref)
 
   // netty
   "implementation"(libs.bundles.netty)

--- a/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayer.java
@@ -46,10 +46,6 @@ public sealed interface InjectionLayer<I extends Injector>
    * {@code installAutoConfigureBindings} and gets formatted with the given component name to the method.
    */
   String AUTO_CONFIGURE_FILE_NAME_FORMAT = "autoconfigure/%s.aero";
-  /**
-   * The element which represents the boot injection layer.
-   */
-  Element LAYER_ELEMENT = Element.forType(InjectionLayer.class);
 
   /**
    * Returns the singleton boot injection layer. That layer contains all bindings which were used during the current

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ slf4j = "1.7.36"
 caffeine = "3.1.1"
 awsSdk = "2.18.16"
 reflexion = "1.7.0"
+geantyref = "1.3.13"
 dockerJava = "3.2.13"
 unirest = "4.0.0-RC2"
 nightConfig = "3.6.6"
@@ -139,6 +140,7 @@ slf4jNop = { group = "org.slf4j", name = "slf4j-nop", version.ref = "slf4j" }
 awsSdk = { group = "software.amazon.awssdk", name = "s3", version.ref = "awsSdk" }
 oshi = { group = "com.github.oshi", name = "oshi-core-java11", version.ref = "oshi" }
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
+geantyref = { group = "io.leangen.geantyref", name = "geantyref", version.ref = "geantyref" }
 reflexion = { group = "dev.derklaro.reflexion", name = "reflexion", version.ref = "reflexion" }
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }
 influxClient = { group = "com.influxdb", name = "influxdb-client-java", version.ref = "influxClient" }


### PR DESCRIPTION
### Motivation
Currently we only bind created injection layers to the raw type of them. In most use cases however, we (or other developers) want to inject parameterised layers into method or constructors, to prevent compiler and ide warnings. 

### Modification
Bind all new injection layers to:
* `InjectionLayer`
* `InjectionLayer<?>`
* `InjectionLayer<Injector>` or `InjectionLayer<SpecifiedInjector>` (depending on the injector type)

### Result
Easier to inject an injection layer into a method or constructor without having compiler/ide warnings.
