### PR TITLE
chore: allow a plugin info generator to create multiple files

### DIFF
--- a/ext/platform-inject-support/src/main/java/eu/cloudnetservice/ext/platforminject/platform/bukkit/BukkitPluginInfoGenerator.java
+++ b/ext/platform-inject-support/src/main/java/eu/cloudnetservice/ext/platforminject/platform/bukkit/BukkitPluginInfoGenerator.java
@@ -30,7 +30,7 @@ import lombok.NonNull;
 final class BukkitPluginInfoGenerator extends NightConfigInfoGenerator {
 
   public BukkitPluginInfoGenerator() {
-    super(YamlFormat.defaultInstance(), "plugin.minecraft_server.yml");
+    super(YamlFormat.defaultInstance(), "plugin.minecraft_server.yml", "plugin.glowstone.yml");
   }
 
   @Override


### PR DESCRIPTION
### Motivation
A platform info generator might want to create multiple files when the same main class info can be re-used for multiple platforms.

### Modification
Allow an info generator to specifiy multiple main classes, and use that new feature to generate a glowstone plugin definition alongside the bukkit plugin definition.

### Result
A info generator can define multiple output files and the bukkit generator is generating the plugin info for glowstone as well.
