### PR TITLE
chore: migrate storage modules to use dependency injection

### DIFF
--- a/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorageModule.java
+++ b/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorageModule.java
@@ -20,19 +20,22 @@ import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.module.ModuleLifeCycle;
 import eu.cloudnetservice.driver.module.ModuleTask;
 import eu.cloudnetservice.driver.module.driver.DriverModule;
+import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.driver.template.TemplateStorage;
 import eu.cloudnetservice.modules.s3.config.S3TemplateStorageConfig;
-import eu.cloudnetservice.node.Node;
 import eu.cloudnetservice.node.cluster.sync.DataSyncHandler;
+import eu.cloudnetservice.node.cluster.sync.DataSyncRegistry;
+import jakarta.inject.Singleton;
 import lombok.NonNull;
 
+@Singleton
 public final class S3TemplateStorageModule extends DriverModule {
 
   private S3TemplateStorage storage;
   private volatile S3TemplateStorageConfig config;
 
   @ModuleTask(event = ModuleLifeCycle.LOADED)
-  public void handleInit() {
+  public void handleInit(@NonNull ServiceRegistry serviceRegistry, @NonNull DataSyncRegistry dataSyncRegistry) {
     this.config = this.readConfig(
       S3TemplateStorageConfig.class,
       () -> new S3TemplateStorageConfig(
@@ -49,9 +52,9 @@ public final class S3TemplateStorageModule extends DriverModule {
         false));
     // init the storage
     this.storage = new S3TemplateStorage(this);
-    this.serviceRegistry().registerProvider(TemplateStorage.class, this.config.name(), this.storage);
+    serviceRegistry.registerProvider(TemplateStorage.class, this.config.name(), this.storage);
     // register the cluster sync handler
-    Node.instance().dataSyncRegistry().registerHandler(DataSyncHandler.<S3TemplateStorageConfig>builder()
+    dataSyncRegistry.registerHandler(DataSyncHandler.<S3TemplateStorageConfig>builder()
       .key("s3-storage-config")
       .nameExtractor($ -> "S3 Template Storage Config")
       .convertObject(S3TemplateStorageConfig.class)
@@ -62,9 +65,9 @@ public final class S3TemplateStorageModule extends DriverModule {
   }
 
   @ModuleTask(event = ModuleLifeCycle.STOPPED)
-  public void handleStop() {
+  public void handleStop(@NonNull ServiceRegistry serviceRegistry) {
     this.storage.close();
-    this.serviceRegistry().unregisterProvider(TemplateStorage.class, this.storage.name());
+    serviceRegistry.unregisterProvider(TemplateStorage.class, this.storage.name());
   }
 
   public void writeConfig(@NonNull S3TemplateStorageConfig config) {

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageModule.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageModule.java
@@ -22,15 +22,18 @@ import eu.cloudnetservice.driver.module.ModuleLifeCycle;
 import eu.cloudnetservice.driver.module.ModuleTask;
 import eu.cloudnetservice.driver.module.driver.DriverModule;
 import eu.cloudnetservice.driver.network.HostAndPort;
+import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.driver.template.TemplateStorage;
 import eu.cloudnetservice.modules.sftp.config.SFTPTemplateStorageConfig;
-import eu.cloudnetservice.node.Node;
 import eu.cloudnetservice.node.cluster.sync.DataSyncHandler;
+import eu.cloudnetservice.node.cluster.sync.DataSyncRegistry;
+import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import lombok.NonNull;
 
+@Singleton
 public final class SFTPTemplateStorageModule extends DriverModule {
 
   private SFTPTemplateStorage storage;
@@ -61,13 +64,13 @@ public final class SFTPTemplateStorageModule extends DriverModule {
   }
 
   @ModuleTask(event = ModuleLifeCycle.LOADED)
-  public void handleInit() {
+  public void handleInit(@NonNull ServiceRegistry serviceRegistry, @NonNull DataSyncRegistry dataSyncRegistry) {
     this.config = this.readConfig(SFTPTemplateStorageConfig.class, SFTPTemplateStorageConfig::new);
     // init the storage
     this.storage = new SFTPTemplateStorage(this.config);
-    this.serviceRegistry().registerProvider(TemplateStorage.class, this.storage.name(), this.storage);
+    serviceRegistry.registerProvider(TemplateStorage.class, this.storage.name(), this.storage);
     // register the cluster sync handler
-    Node.instance().dataSyncRegistry().registerHandler(DataSyncHandler.<SFTPTemplateStorageConfig>builder()
+    dataSyncRegistry.registerHandler(DataSyncHandler.<SFTPTemplateStorageConfig>builder()
       .key("sftp-storage-config")
       .nameExtractor($ -> "SFTP Template Storage Config")
       .convertObject(SFTPTemplateStorageConfig.class)
@@ -78,9 +81,9 @@ public final class SFTPTemplateStorageModule extends DriverModule {
   }
 
   @ModuleTask(event = ModuleLifeCycle.STOPPED)
-  public void handleStop() throws IOException {
+  public void handleStop(@NonNull ServiceRegistry serviceRegistry) throws IOException {
     this.storage.close();
-    this.serviceRegistry().unregisterProvider(TemplateStorage.class, this.storage.name());
+    serviceRegistry.unregisterProvider(TemplateStorage.class, this.storage.name());
   }
 
   public void updateConfig(@NonNull SFTPTemplateStorageConfig config) {


### PR DESCRIPTION
### Motivation
The two template storage modules still need a migration to dependency injection.

### Modification
Migrate storage s3 and sftp to dependency injection.

### Result
The storage modules are using dependency injection.
