### PR TITLE
fix: make sure that we connect the player only to one service

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
@@ -73,7 +73,8 @@ final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
       .filter(pair -> pair.second().isPresent())
       .map(p -> new Pair<>(p.first(), ProxyServer.getInstance().getServerInfo(p.second().get().name())))
       .filter(pair -> pair.second() != null)
-      .forEach(pair -> pair.first().connect(pair.second(), Reason.PLUGIN));
+      .findFirst()
+      .ifPresent(pair -> pair.first().connect(pair.second(), Reason.PLUGIN));
   }
 
   @Override
@@ -83,7 +84,8 @@ final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
       .sorted(selectorType.comparator())
       .map(service -> ProxyServer.getInstance().getServerInfo(service.name()))
       .filter(Objects::nonNull)
-      .forEach(server -> this.forEach(player -> player.connect(server, Reason.PLUGIN)));
+      .findFirst()
+      .ifPresent(server -> this.forEach(player -> player.connect(server, Reason.PLUGIN)));
   }
 
   @Override
@@ -93,7 +95,8 @@ final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
       .sorted(selectorType.comparator())
       .map(service -> ProxyServer.getInstance().getServerInfo(service.name()))
       .filter(Objects::nonNull)
-      .forEach(server -> this.forEach(player -> player.connect(server, Reason.PLUGIN)));
+      .findFirst()
+      .ifPresent(server -> this.forEach(player -> player.connect(server, Reason.PLUGIN)));
   }
 
   @Override

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityDirectPlayerExecutor.java
@@ -75,7 +75,8 @@ final class VelocityDirectPlayerExecutor extends PlatformPlayerExecutorAdapter<P
       .filter(pair -> pair.second().isPresent())
       .map(pair -> new Pair<>(pair.first(), this.proxyServer.getServer(pair.second().get().name())))
       .filter(pair -> pair.second().isPresent())
-      .forEach(pair -> pair.first().createConnectionRequest(pair.second().get()).fireAndForget());
+      .findFirst()
+      .ifPresent(pair -> pair.first().createConnectionRequest(pair.second().get()).fireAndForget());
   }
 
   @Override
@@ -86,7 +87,8 @@ final class VelocityDirectPlayerExecutor extends PlatformPlayerExecutorAdapter<P
       .map(service -> this.proxyServer.getServer(service.name()))
       .filter(Optional::isPresent)
       .map(Optional::get)
-      .forEach(server -> this.forEach(player -> player.createConnectionRequest(server).fireAndForget()));
+      .findFirst()
+      .ifPresent(server -> this.forEach(player -> player.createConnectionRequest(server).fireAndForget()));
   }
 
   @Override
@@ -97,7 +99,8 @@ final class VelocityDirectPlayerExecutor extends PlatformPlayerExecutorAdapter<P
       .map(service -> this.proxyServer.getServer(service.name()))
       .filter(Optional::isPresent)
       .map(Optional::get)
-      .forEach(server -> this.forEach(player -> player.createConnectionRequest(server).fireAndForget()));
+      .findFirst()
+      .ifPresent(server -> this.forEach(player -> player.createConnectionRequest(server).fireAndForget()));
   }
 
   @Override

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEDirectPlayerExecutor.java
@@ -72,7 +72,8 @@ final class WaterDogPEDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
       .filter(pair -> pair.second().isPresent())
       .map(p -> new Pair<>(p.first(), ProxyServer.getInstance().getServerInfo(p.second().get().name())))
       .filter(pair -> pair.second() != null)
-      .forEach(pair -> pair.first().connect(pair.second()));
+      .findFirst()
+      .ifPresent(pair -> pair.first().connect(pair.second()));
   }
 
   @Override
@@ -82,7 +83,8 @@ final class WaterDogPEDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
       .sorted(selectorType.comparator())
       .map(service -> ProxyServer.getInstance().getServerInfo(service.name()))
       .filter(Objects::nonNull)
-      .forEach(server -> this.forEach(player -> player.connect(server)));
+      .findFirst()
+      .ifPresent(server -> this.forEach(player -> player.connect(server)));
   }
 
   @Override
@@ -92,7 +94,8 @@ final class WaterDogPEDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
       .sorted(selectorType.comparator())
       .map(service -> ProxyServer.getInstance().getServerInfo(service.name()))
       .filter(Objects::nonNull)
-      .forEach(server -> this.forEach(player -> player.connect(server)));
+      .findFirst()
+      .ifPresent(server -> this.forEach(player -> player.connect(server)));
   }
 
   @Override


### PR DESCRIPTION
### Motivation
During some tests on a big network we discovered that the connectToTask / connectToGroup method always tries to connect the player to all services.

### Modification
Made sure that we use the first result of the stream and connect the player to that service.

### Result
The player is only connected to one service.

##### Other context
Fixes #1025 
