### PR TITLE
fix: only stop a service if there are more than the minServiceCount

### DIFF
--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/util/SmartUtil.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/util/SmartUtil.java
@@ -36,7 +36,7 @@ public final class SmartUtil {
     // get the min service count
     var minServiceCount = Math.max(task.minServiceCount(), config.smartMinServiceCount());
     // check if stopping the service would instantly cause a new service to start - beware
-    return (runningServices - 1) > minServiceCount;
+    return (runningServices - 1) >= minServiceCount;
   }
 
   public static double playerPercentage(@NonNull ServiceInfoSnapshot snapshot) {


### PR DESCRIPTION
### Motivation
The smart module is stopping services even if that instantly results in the creation of a new service.

### Modification
Changed the check to only allow stopping if there are more services then requested.

### Result
No services are stopped that get started instantly after stopping.
