### PR TITLE
chore: rename the event in the ModuleTask annotation to lifecycle

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleWrapper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleWrapper.java
@@ -302,7 +302,7 @@ public class DefaultModuleWrapper implements ModuleWrapper {
       var moduleTask = method.getAnnotation(ModuleTask.class);
       if (moduleTask != null && !Modifier.isStatic(method.getModifiers())) {
         try {
-          var entries = result.computeIfAbsent(moduleTask.event(), $ -> new ArrayList<>());
+          var entries = result.computeIfAbsent(moduleTask.lifecycle(), $ -> new ArrayList<>());
           entries.add(new DefaultModuleTaskEntry(this, moduleTask, method));
           // re-sort the list now as we don't want to re-iterate later
           entries.sort(TASK_COMPARATOR);

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleTask.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleTask.java
@@ -57,5 +57,5 @@ public @interface ModuleTask {
    *
    * @return the module lifecycle in which this task should be fired.
    */
-  ModuleLifeCycle event() default ModuleLifeCycle.STARTED;
+  ModuleLifeCycle lifecycle() default ModuleLifeCycle.STARTED;
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/CloudNetBridgeModule.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/CloudNetBridgeModule.java
@@ -63,14 +63,14 @@ public final class CloudNetBridgeModule extends DriverModule {
     layer.installAutoConfigureBindings(CloudNetBridgeModule.class.getClassLoader(), "bridge");
   }
 
-  @ModuleTask(order = 50, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 50, lifecycle = ModuleLifeCycle.LOADED)
   public void initNetworkHelpers() {
     DefaultObjectMapper.DEFAULT_MAPPER
       .registerBinding(Title.class, new TitleObjectSerializer(), false)
       .registerBinding(Component.class, new ComponentObjectSerializer(), false);
   }
 
-  @ModuleTask(event = ModuleLifeCycle.STARTED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.STARTED)
   public void convertOldDatabaseEntries(
     @NonNull ServiceVersionProvider versionProvider,
     @NonNull NodeDatabaseProvider databaseProvider
@@ -136,7 +136,7 @@ public final class CloudNetBridgeModule extends DriverModule {
     }
   }
 
-  @ModuleTask(order = 40, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 40, lifecycle = ModuleLifeCycle.LOADED)
   public void convertOldConfiguration() {
     // read the file
     var config = JsonDocument.newDocument(this.configPath()).getDocument("config");
@@ -169,7 +169,7 @@ public final class CloudNetBridgeModule extends DriverModule {
     }
   }
 
-  @ModuleTask(order = 127, event = ModuleLifeCycle.STARTED)
+  @ModuleTask(order = 127, lifecycle = ModuleLifeCycle.STARTED)
   public void initModule(
     @NonNull HttpServer httpServer,
     @NonNull ServiceRegistry serviceRegistry,
@@ -198,13 +198,13 @@ public final class CloudNetBridgeModule extends DriverModule {
     httpServer.annotationParser().parseAndRegister(V2HttpHandlerBridge.class);
   }
 
-  @ModuleTask(event = ModuleLifeCycle.STARTED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.STARTED)
   public void registerCommand(@NonNull CommandProvider commandProvider) {
     // register the bridge command
     commandProvider.register(BridgeCommand.class);
   }
 
-  @ModuleTask(event = ModuleLifeCycle.RELOADING)
+  @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
   public void handleReload(@Nullable BridgeManagement management) {
     if (management != null) {
       management.configuration(this.loadConfiguration());

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/CloudNetCloudflareModule.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/CloudNetCloudflareModule.java
@@ -58,7 +58,7 @@ public final class CloudNetCloudflareModule extends DriverModule {
 
   private CloudflareConfiguration cloudflareConfiguration;
 
-  @ModuleTask(event = ModuleLifeCycle.LOADED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.LOADED)
   public void convertConfiguration() {
     var config = this.readConfig().get("config");
     if (config != null) {
@@ -66,7 +66,7 @@ public final class CloudNetCloudflareModule extends DriverModule {
     }
   }
 
-  @ModuleTask(order = 127, event = ModuleLifeCycle.STARTED)
+  @ModuleTask(order = 127, lifecycle = ModuleLifeCycle.STARTED)
   public void loadConfiguration() {
     var config = this.readConfig(
       CloudflareConfiguration.class,
@@ -83,7 +83,7 @@ public final class CloudNetCloudflareModule extends DriverModule {
     this.updateConfiguration(config);
   }
 
-  @ModuleTask(order = 126, event = ModuleLifeCycle.STARTED)
+  @ModuleTask(order = 126, lifecycle = ModuleLifeCycle.STARTED)
   public void createNodeRecordsWhenNeeded(@NonNull CloudFlareRecordManager recordManager) {
     for (var entry : this.cloudflareConfiguration.entries()) {
       if (entry.enabled()) {
@@ -123,12 +123,12 @@ public final class CloudNetCloudflareModule extends DriverModule {
     }
   }
 
-  @ModuleTask(order = 125, event = ModuleLifeCycle.STARTED)
+  @ModuleTask(order = 125, lifecycle = ModuleLifeCycle.STARTED)
   public void finishStartup(@NonNull EventManager eventManager) {
     eventManager.registerListener(CloudflareServiceStateListener.class);
   }
 
-  @ModuleTask(event = ModuleLifeCycle.RELOADING)
+  @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
   public void handleReload(@NonNull CloudFlareRecordManager recordManager, @NonNull Configuration nodeConfig) {
     // store the old entries for later comparison
     var oldEntries = this.cloudflareConfiguration.entries();
@@ -210,7 +210,7 @@ public final class CloudNetCloudflareModule extends DriverModule {
     this.createRecordsForEntries(nodeConfig, recordManager, addedEntries);
   }
 
-  @ModuleTask(order = 64, event = ModuleLifeCycle.STOPPED)
+  @ModuleTask(order = 64, lifecycle = ModuleLifeCycle.STOPPED)
   public void removeAllServiceRecords(@NonNull CloudFlareRecordManager recordManager) {
     var deletionFutures = recordManager.trackedRecords().entries().stream()
       .filter(trackedRecordEntry -> {

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/node/CloudNetCloudPermissionsModule.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/node/CloudNetCloudPermissionsModule.java
@@ -36,7 +36,7 @@ public final class CloudNetCloudPermissionsModule extends DriverModule {
 
   private volatile CloudPermissionConfig permissionsConfig;
 
-  @ModuleTask(order = 127, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 127, lifecycle = ModuleLifeCycle.LOADED)
   public void registerDataSyncHandler(@NonNull DataSyncRegistry dataSyncRegistry) {
     dataSyncRegistry.registerHandler(DataSyncHandler.<CloudPermissionConfig>builder()
       .key("cloudperms-config")
@@ -48,19 +48,19 @@ public final class CloudNetCloudPermissionsModule extends DriverModule {
       .build());
   }
 
-  @ModuleTask(order = 126, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 126, lifecycle = ModuleLifeCycle.LOADED)
   public void initConfig() {
     this.permissionsConfig = this.readConfig(
       CloudPermissionConfig.class,
       () -> new CloudPermissionConfig(true, List.of()));
   }
 
-  @ModuleTask(event = ModuleLifeCycle.RELOADING)
+  @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
   public void reload() {
     this.initConfig();
   }
 
-  @ModuleTask(order = 124, event = ModuleLifeCycle.STARTED)
+  @ModuleTask(order = 124, lifecycle = ModuleLifeCycle.STARTED)
   public void registerListeners(@NonNull EventManager eventManager, @NonNull ModuleHelper moduleHelper) {
     eventManager.registerListener(new PluginIncludeListener(
       "cloudnet-cloudperms",

--- a/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/CloudNetMongoDatabaseModule.java
+++ b/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/CloudNetMongoDatabaseModule.java
@@ -30,12 +30,12 @@ public class CloudNetMongoDatabaseModule extends DriverModule {
 
   private MongoDBConnectionConfig config;
 
-  @ModuleTask(order = 126, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 126, lifecycle = ModuleLifeCycle.LOADED)
   public void loadConfig() {
     this.config = this.readConfig(MongoDBConnectionConfig.class, MongoDBConnectionConfig::new);
   }
 
-  @ModuleTask(order = 125, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 125, lifecycle = ModuleLifeCycle.LOADED)
   public void registerDatabaseProvider(@NonNull ServiceRegistry serviceRegistry) {
     serviceRegistry.registerProvider(
       NodeDatabaseProvider.class,
@@ -43,7 +43,7 @@ public class CloudNetMongoDatabaseModule extends DriverModule {
       new MongoDBDatabaseProvider(this.config));
   }
 
-  @ModuleTask(order = 127, event = ModuleLifeCycle.STOPPED)
+  @ModuleTask(order = 127, lifecycle = ModuleLifeCycle.STOPPED)
   public void unregisterDatabaseProvider(@NonNull ServiceRegistry serviceRegistry) {
     serviceRegistry.unregisterProvider(NodeDatabaseProvider.class, this.config.databaseServiceName());
   }

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/CloudNetMySQLDatabaseModule.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/CloudNetMySQLDatabaseModule.java
@@ -35,7 +35,7 @@ public final class CloudNetMySQLDatabaseModule extends DriverModule {
 
   private volatile MySQLConfiguration configuration;
 
-  @ModuleTask(order = 127, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 127, lifecycle = ModuleLifeCycle.LOADED)
   public void convertConfig() {
     var config = this.readConfig();
     if (config.contains("addresses")) {
@@ -49,7 +49,7 @@ public final class CloudNetMySQLDatabaseModule extends DriverModule {
     }
   }
 
-  @ModuleTask(order = 125, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 125, lifecycle = ModuleLifeCycle.LOADED)
   public void registerDatabaseProvider(@NonNull ServiceRegistry serviceRegistry) {
     this.configuration = this.readConfig(MySQLConfiguration.class, () -> new MySQLConfiguration(
       "root",
@@ -64,7 +64,7 @@ public final class CloudNetMySQLDatabaseModule extends DriverModule {
       new MySQLDatabaseProvider(this.configuration, null));
   }
 
-  @ModuleTask(order = 127, event = ModuleLifeCycle.STOPPED)
+  @ModuleTask(order = 127, lifecycle = ModuleLifeCycle.STOPPED)
   public void unregisterDatabaseProvider(@NonNull ServiceRegistry serviceRegistry) {
     serviceRegistry.unregisterProvider(NodeDatabaseProvider.class, this.configuration.databaseServiceName());
   }

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServicesModule.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServicesModule.java
@@ -89,12 +89,12 @@ public class DockerizedServicesModule extends DriverModule {
     serviceManager.addCloudServiceFactory(this.configuration.factoryName(), factory);
   }
 
-  @ModuleTask(event = ModuleLifeCycle.STARTED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.STARTED)
   public void registerComponents(@NonNull CommandProvider commandProvider) {
     commandProvider.register(DockerCommand.class);
   }
 
-  @ModuleTask(event = ModuleLifeCycle.STOPPED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.STOPPED)
   public void unregisterServiceFactory(@NonNull CloudServiceManager cloudServiceManager) {
     cloudServiceManager.removeCloudServiceFactory(this.configuration.factoryName());
   }

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/CloudNetLabyModModule.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/CloudNetLabyModModule.java
@@ -44,7 +44,7 @@ import lombok.NonNull;
 @Singleton
 public class CloudNetLabyModModule extends DriverModule {
 
-  @ModuleTask(order = 127, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 127, lifecycle = ModuleLifeCycle.LOADED)
   public void convertConfig() {
     if (Files.exists(this.configPath())) {
       var config = this.readConfig().getDocument("config");
@@ -76,7 +76,7 @@ public class CloudNetLabyModModule extends DriverModule {
     }
   }
 
-  @ModuleTask(event = ModuleLifeCycle.LOADED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.LOADED)
   public void initManagement(
     @NonNull DataSyncRegistry dataSyncRegistry,
     @NonNull @Named("module") InjectionLayer<?> layer
@@ -100,12 +100,12 @@ public class CloudNetLabyModModule extends DriverModule {
         .build());
   }
 
-  @ModuleTask(event = ModuleLifeCycle.RELOADING)
+  @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
   public void handleReload(@NonNull NodeLabyModManagement management) {
     management.configuration(this.loadConfiguration());
   }
 
-  @ModuleTask(order = 16, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 16, lifecycle = ModuleLifeCycle.LOADED)
   public void initListeners(
     @NonNull ModuleHelper moduleHelper,
     @NonNull EventManager eventManager,

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
@@ -200,7 +200,7 @@ public class CloudNetNPCModule extends DriverModule {
     commandProvider.register(NPCCommand.class);
   }
 
-  @ModuleTask(event = ModuleLifeCycle.RELOADING)
+  @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
   public void handleReload(@NonNull ServiceRegistry serviceRegistry) {
     var management = serviceRegistry.firstProvider(NPCManagement.class);
     if (management != null) {

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/CloudNetReportModule.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/CloudNetReportModule.java
@@ -96,7 +96,7 @@ public final class CloudNetReportModule extends DriverModule {
     commandProvider.register(ReportCommand.class);
   }
 
-  @ModuleTask(event = ModuleLifeCycle.RELOADING)
+  @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
   public void handleReload() {
     this.configuration = this.readConfig(
       ReportConfiguration.class,

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/CloudNetSignsModule.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/CloudNetSignsModule.java
@@ -103,12 +103,12 @@ public class CloudNetSignsModule extends DriverModule {
     this.convertDatabaseIfNecessary(databaseProvider);
   }
 
-  @ModuleTask(order = 40, event = ModuleLifeCycle.STOPPED)
+  @ModuleTask(order = 40, lifecycle = ModuleLifeCycle.STOPPED)
   public void handleStopping() throws Exception {
     this.database.close();
   }
 
-  @ModuleTask(event = ModuleLifeCycle.RELOADING)
+  @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
   public void handleReload() {
     var management = ServiceRegistry.first(SignManagement.class);
     if (management != null) {

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/CloudNetSmartModule.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/CloudNetSmartModule.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 @Singleton
 public class CloudNetSmartModule extends DriverModule {
 
-  @ModuleTask(event = ModuleLifeCycle.STARTED, order = Byte.MAX_VALUE)
+  @ModuleTask(lifecycle = ModuleLifeCycle.STARTED, order = Byte.MAX_VALUE)
   public void rewriteOldSmartTaskEntries(@NonNull ServiceTaskProvider taskProvider) {
     for (var task : taskProvider.serviceTasks()) {
       // check if the task had a smart config entry previously
@@ -68,7 +68,7 @@ public class CloudNetSmartModule extends DriverModule {
     }
   }
 
-  @ModuleTask(event = ModuleLifeCycle.STARTED, order = 64)
+  @ModuleTask(lifecycle = ModuleLifeCycle.STARTED, order = 64)
   public void addMissingSmartConfigurationEntries(@NonNull ServiceTaskProvider taskProvider) {
     for (var task : taskProvider.serviceTasks()) {
       // check if the service task needs a smart entry
@@ -80,7 +80,7 @@ public class CloudNetSmartModule extends DriverModule {
     }
   }
 
-  @ModuleTask(event = ModuleLifeCycle.STARTED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.STARTED)
   public void start(@NonNull EventManager eventManager, @NonNull CommandProvider commandProvider) {
     eventManager
       .registerListener(CloudNetTickListener.class)

--- a/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorageModule.java
+++ b/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorageModule.java
@@ -34,7 +34,7 @@ public final class S3TemplateStorageModule extends DriverModule {
   private S3TemplateStorage storage;
   private volatile S3TemplateStorageConfig config;
 
-  @ModuleTask(event = ModuleLifeCycle.LOADED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.LOADED)
   public void handleInit(@NonNull ServiceRegistry serviceRegistry, @NonNull DataSyncRegistry dataSyncRegistry) {
     this.config = this.readConfig(
       S3TemplateStorageConfig.class,
@@ -64,7 +64,7 @@ public final class S3TemplateStorageModule extends DriverModule {
       .build());
   }
 
-  @ModuleTask(event = ModuleLifeCycle.STOPPED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.STOPPED)
   public void handleStop(@NonNull ServiceRegistry serviceRegistry) {
     this.storage.close();
     serviceRegistry.unregisterProvider(TemplateStorage.class, this.storage.name());

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageModule.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageModule.java
@@ -39,7 +39,7 @@ public final class SFTPTemplateStorageModule extends DriverModule {
   private SFTPTemplateStorage storage;
   private volatile SFTPTemplateStorageConfig config;
 
-  @ModuleTask(order = Byte.MAX_VALUE, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = Byte.MAX_VALUE, lifecycle = ModuleLifeCycle.LOADED)
   public void convertConfig() {
     // the old config was located in a directory called '-ftp' rather than '-sftp'
     var oldConfigPath = this.moduleWrapper().moduleProvider().moduleDirectoryPath()
@@ -63,7 +63,7 @@ public final class SFTPTemplateStorageModule extends DriverModule {
     }
   }
 
-  @ModuleTask(event = ModuleLifeCycle.LOADED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.LOADED)
   public void handleInit(@NonNull ServiceRegistry serviceRegistry, @NonNull DataSyncRegistry dataSyncRegistry) {
     this.config = this.readConfig(SFTPTemplateStorageConfig.class, SFTPTemplateStorageConfig::new);
     // init the storage
@@ -80,7 +80,7 @@ public final class SFTPTemplateStorageModule extends DriverModule {
       .build());
   }
 
-  @ModuleTask(event = ModuleLifeCycle.STOPPED)
+  @ModuleTask(lifecycle = ModuleLifeCycle.STOPPED)
   public void handleStop(@NonNull ServiceRegistry serviceRegistry) throws IOException {
     this.storage.close();
     serviceRegistry.unregisterProvider(TemplateStorage.class, this.storage.name());

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/CloudNetSyncProxyModule.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/CloudNetSyncProxyModule.java
@@ -46,7 +46,7 @@ public final class CloudNetSyncProxyModule extends DriverModule {
     layer.installAutoConfigureBindings(this.getClass().getClassLoader(), "syncproxy");
   }
 
-  @ModuleTask(order = 127, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 127, lifecycle = ModuleLifeCycle.LOADED)
   public void convertConfig() {
     if (Files.exists(this.configPath())) {
       // the old config is located in a document with the key "config", extract the actual config
@@ -59,7 +59,7 @@ public final class CloudNetSyncProxyModule extends DriverModule {
     }
   }
 
-  @ModuleTask(order = 126, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 126, lifecycle = ModuleLifeCycle.LOADED)
   public void initManagement(
     @NonNull ServiceRegistry serviceRegistry,
     @NonNull DataSyncRegistry dataSyncRegistry,
@@ -85,7 +85,7 @@ public final class CloudNetSyncProxyModule extends DriverModule {
         .build());
   }
 
-  @ModuleTask(order = 64, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 64, lifecycle = ModuleLifeCycle.LOADED)
   public void initListeners(
     @NonNull EventManager eventManager,
     @NonNull ModuleHelper moduleHelper,
@@ -105,13 +105,13 @@ public final class CloudNetSyncProxyModule extends DriverModule {
     ));
   }
 
-  @ModuleTask(order = 60, event = ModuleLifeCycle.LOADED)
+  @ModuleTask(order = 60, lifecycle = ModuleLifeCycle.LOADED)
   public void registerCommands(@NonNull CommandProvider commandProvider) {
     // register the syncproxy command to provide config management
     commandProvider.register(SyncProxyCommand.class);
   }
 
-  @ModuleTask(event = ModuleLifeCycle.RELOADING)
+  @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
   public void handleReload(@NonNull ServiceRegistry serviceRegistry) {
     var management = serviceRegistry.firstProvider(SyncProxyManagement.class);
     if (management != null) {


### PR DESCRIPTION
### Motivation
Calling the module lifecycle in the ModuleTask annotation `event` is missleading and not really consistant as we are referring to it as lifecycle all the time.

### Modification
Renamed the property to lifecycle.

### Result
The naming is consistant and not missleading anymore.
