### PR TITLE
feat: add includes & excludes to the service command

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
@@ -314,9 +314,17 @@ public final class ServiceCommand {
   public void addDeployment(
     @NonNull CommandSource source,
     @NonNull @Argument("name") Collection<ServiceInfoSnapshot> matchedServices,
-    @NonNull @Argument("deployment") ServiceTemplate template
+    @NonNull @Argument("deployment") ServiceTemplate template,
+    @Nullable @Flag("excludes") @Quoted String excludes,
+    @Nullable @Flag("includes") @Quoted String includes,
+    @Flag("case-sensitive") boolean caseSensitive
   ) {
-    var deployment = ServiceDeployment.builder().template(template).build();
+    var deployment = ServiceDeployment.builder()
+      .template(template)
+      .excludes(ServiceCommand.parseDeploymentPatterns(excludes, caseSensitive))
+      .includes(ServiceCommand.parseDeploymentPatterns(includes, caseSensitive))
+      .withDefaultExclusions()
+      .build();
     for (var matchedService : matchedServices) {
       matchedService.provider().addServiceDeployment(deployment);
     }


### PR DESCRIPTION
### Motivation
We have implemented includes and excludes for ServiceDeployments but the service command does not feature these options when adding a deployment on the fly.

### Modification
Added the flags for includes / excludes & case-sens and parsed them into the ServiceDeployment

### Result
The command is capable of setting includes and excludes on the fly
