### PR TITLE
fix: register module updater before executing the module updates

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -58,6 +58,7 @@ import eu.cloudnetservice.node.event.CloudNetNodePostInitializationEvent;
 import eu.cloudnetservice.node.log.QueuedConsoleLogHandler;
 import eu.cloudnetservice.node.module.ModulesHolder;
 import eu.cloudnetservice.node.module.NodeModuleProviderHandler;
+import eu.cloudnetservice.node.module.updater.ModuleUpdater;
 import eu.cloudnetservice.node.module.updater.ModuleUpdaterRegistry;
 import eu.cloudnetservice.node.network.chunk.FileDeployCallbackListener;
 import eu.cloudnetservice.node.permission.NodePermissionManagement;
@@ -216,11 +217,13 @@ public final class Node {
   private void updateAndLoadModules(
     @NonNull ModulesHolder modulesHolder,
     @NonNull ModuleProvider moduleProvider,
+    @NonNull ModuleUpdater moduleUpdater,
     @NonNull ModuleUpdaterRegistry updaterRegistry
   ) throws Exception {
     // apply all module updates if we're not running in dev mode
     if (!DEV_MODE) {
       LOGGER.info(I18n.trans("start-module-updater"));
+      updaterRegistry.registerUpdater(moduleUpdater);
       updaterRegistry.runUpdater(modulesHolder, !AUTO_UPDATE);
     }
 


### PR DESCRIPTION
### Motivation
With commit 9f99fed5bd622933d81a1cd55012730236926708 the actual updater was no longer registered to the module updater registry, causing modules to not get any updates.

### Modification
Register the module updater to the updater registry before executing updates.

### Result
Modules are getting updated again.
