### PR TITLE
chore: update for 1.19.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ bungeecord = "1.19-R0.1-SNAPSHOT"
 vault = "1.7.1"
 adventure = "4.11.0"
 modlauncher = "8.1.3"
-npcLib = "3.0.0-beta1"
+npcLib = "3.0.0-beta2"
 placeholderApi = "2.11.2"
 
 # fabric platform special dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ npcLib = "3.0.0-beta1"
 placeholderApi = "2.11.2"
 
 # fabric platform special dependencies
-minecraft = "1.19.2"
+minecraft = "1.19.3"
 fabricLoader = "0.14.10"
 
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
@@ -30,11 +30,12 @@ import lombok.NonNull;
   name = "CloudNet-Bridge",
   version = "{project.build.version}",
   dependencies = {
-    @Dependency(name = "fabricloader", version = ">=0.14.8"),
-    @Dependency(name = "minecraft", version = "~1.19.1"),
+    @Dependency(name = "fabricloader", version = ">=0.14.11"),
+    @Dependency(name = "minecraft", version = "~1.19.3"),
     @Dependency(name = "java", version = ">=17")
   },
-  authors = "CloudNetService")
+  authors = "CloudNetService"
+)
 public final class FabricBridgeInitializer implements PlatformEntrypoint {
 
   private final ModuleHelper moduleHelper;

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
@@ -94,7 +94,7 @@ public class NPCBukkitPlatformSelector extends BukkitPlatformSelectorEntity {
         this.npc.profileProperties().stream()
           .map(prop -> ProfileProperty.property(prop.name(), prop.value(), prop.signature()))
           .collect(Collectors.toSet())))
-      .position(BukkitPlatformUtil.positionFromBukkit(this.npcLocation))
+      .position(BukkitPlatformUtil.positionFromBukkitLegacy(this.npcLocation))
       .buildAndTrack();
   }
 

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -91,11 +91,11 @@
               "-Dpaperclip.patchonly=true"
             ],
             "fetchOverPaperApi": true,
-            "versionGroup": "1.19.2"
+            "versionGroup": "1.19.3"
           }
         },
         {
-          "name": "1.19.2",
+          "name": "1.19.3",
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -106,7 +106,7 @@
               "-Dpaperclip.patchonly=true"
             ],
             "fetchOverPaperApi": true,
-            "versionGroup": "1.19.2"
+            "versionGroup": "1.19.3"
           }
         },
         {
@@ -262,7 +262,7 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://api.purpurmc.org/v2/purpur/1.19.2/latest/download",
+          "url": "https://api.purpurmc.org/v2/purpur/1.19.3/latest/download",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -276,8 +276,8 @@
           }
         },
         {
-          "name": "1.19.2",
-          "url": "https://api.purpurmc.org/v2/purpur/1.19.2/latest/download",
+          "name": "1.19.3",
+          "url": "https://api.purpurmc.org/v2/purpur/1.19.3/latest/download",
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -329,12 +329,12 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://download.getbukkit.org/spigot/spigot-1.19.2.jar",
+          "url": "https://download.getbukkit.org/spigot/spigot-1.19.3.jar",
           "cacheFiles": false
         },
         {
-          "name": "1.19.2",
-          "url": "https://download.getbukkit.org/spigot/spigot-1.19.2.jar"
+          "name": "1.19.3",
+          "url": "https://download.getbukkit.org/spigot/spigot-1.19.3.jar"
         },
         {
           "name": "1.18.2",
@@ -405,7 +405,7 @@
       "website": "https://fabricmc.net",
       "versions": [
         {
-          "name": "1.19.2",
+          "name": "1.19.3",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -446,11 +446,11 @@
             },
             "fetchOverSpongeApi": true,
             "artifact": "spongevanilla",
-            "mcVersion": "1.19.2"
+            "mcVersion": "1.19.3"
           }
         },
         {
-          "name": "1.19.2",
+          "name": "1.19.3",
           "properties": {
             "copy": {
               "libraries/.*": "/",
@@ -459,7 +459,7 @@
             },
             "fetchOverSpongeApi": true,
             "artifact": "spongevanilla",
-            "mcVersion": "1.19.2"
+            "mcVersion": "1.19.3"
           }
         },
         {


### PR DESCRIPTION
### Motivation
1.19.3 was released and the version installer is not yet supporting it.

### Modification
Add 1.19.3 to the version installer, bump fabric & npc-lib dependencies to support 1.19.3.

### Result
CloudNet can install and run 1.19.3.
