### PR TITLE
fix: use correct database name for sign management

### DIFF
--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/NodeSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/NodeSignManagement.java
@@ -57,7 +57,7 @@ public class NodeSignManagement extends AbstractSignManagement implements SignMa
     super(configuration);
 
     this.configPath = dataDirectory.resolve("config.json");
-    this.database = databaseProvider.database("");
+    this.database = databaseProvider.database(CloudNetSignsModule.DATABASE_NAME);
 
     this.database.documentsAsync().thenAccept(jsonDocuments -> {
       for (var document : jsonDocuments) {


### PR DESCRIPTION
### Motivation
The signs module is currently using an empty string as the database name instead of the correct signs db name.

### Modification
Use the signs database name instead of an empty string.

### Result
The signs module uses the correct database again.
