### PR TITLE
fix: npc command editing profile resulting in an exception

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
@@ -499,7 +499,7 @@ public final class NPCCommand extends BaseTabExecutor {
                 .collect(Collectors.toSet()))
               .build())
             .exceptionally(throwable -> {
-              sender.sendMessage(String.format("§cUnable to complete profile of §6%s§c!", args[3]));
+              sender.sendMessage(String.format("§cUnable to complete profile of §6%s§c!", args[2]));
               return null;
             }).join();
 


### PR DESCRIPTION
### Motivation
An user reported issues with the npc edit command. When editing the profile of a npc and the resolving fails an exception occurs

### Modification
Changed the accessing index from 3 to 2

### Result
The correct message is printed instead of an exception.

##### Other context
Fixes #1013 
