### PR TITLE
[ci skip] chore: update copyright for 2023

### DIFF
--- a/.template/start.command
+++ b/.template/start.command
@@ -1,19 +1,4 @@
 #!/bin/bash
-#
-# Copyright 2019-2023 CloudNetService team & contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 cd "$(dirname "$0")" || exit 1
 

--- a/.template/start.command
+++ b/.template/start.command
@@ -1,4 +1,20 @@
 #!/bin/bash
+#
+# Copyright 2019-2023 CloudNetService team & contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 cd "$(dirname "$0")" || exit 1
 
 # check if java is installed

--- a/.template/start.sh
+++ b/.template/start.sh
@@ -1,19 +1,4 @@
 #!/bin/sh
-#
-# Copyright 2019-2023 CloudNetService team & contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 cd "$(dirname "$(readlink -fn "$0")")" || exit 1
 

--- a/.template/start.sh
+++ b/.template/start.sh
@@ -1,4 +1,20 @@
 #!/bin/sh
+#
+# Copyright 2019-2023 CloudNetService team & contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 cd "$(dirname "$(readlink -fn "$0")")" || exit 1
 
 # check if java is installed

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/build.gradle.kts
+++ b/build-extensions/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 plugins {
   `kotlin-dsl`
 }

--- a/build-extensions/src/main/kotlin/Files.kt
+++ b/build-extensions/src/main/kotlin/Files.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/Versions.kt
+++ b/build-extensions/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/cloudnet.parent-build-logic.gradle.kts
+++ b/build-extensions/src/main/kotlin/cloudnet.parent-build-logic.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/extensions.kt
+++ b/build-extensions/src/main/kotlin/extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/publishing-extensions.kt
+++ b/build-extensions/src/main/kotlin/publishing-extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/updater-extensions.kt
+++ b/build-extensions/src/main/kotlin/updater-extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2019-2022 CloudNetService team & contributors
+  ~ Copyright 2019-2023 CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
+++ b/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/Nameable.java
+++ b/common/src/main/java/eu/cloudnetservice/common/Nameable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/StringUtil.java
+++ b/common/src/main/java/eu/cloudnetservice/common/StringUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/WildcardUtil.java
+++ b/common/src/main/java/eu/cloudnetservice/common/WildcardUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/collection/Pair.java
+++ b/common/src/main/java/eu/cloudnetservice/common/collection/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/column/ColumnEntry.java
+++ b/common/src/main/java/eu/cloudnetservice/common/column/ColumnEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/column/ColumnFormatter.java
+++ b/common/src/main/java/eu/cloudnetservice/common/column/ColumnFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/column/RowBasedFormatter.java
+++ b/common/src/main/java/eu/cloudnetservice/common/column/RowBasedFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/concurrent/CountingTask.java
+++ b/common/src/main/java/eu/cloudnetservice/common/concurrent/CountingTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/concurrent/ListenableTask.java
+++ b/common/src/main/java/eu/cloudnetservice/common/concurrent/ListenableTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/concurrent/Task.java
+++ b/common/src/main/java/eu/cloudnetservice/common/concurrent/Task.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/Document.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/Document.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/Persistable.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/Persistable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/Readable.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/Readable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/gson/JsonDocument.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/gson/JsonDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/gson/JsonDocumentTypeAdapter.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/gson/JsonDocumentTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/gson/PathTypeAdapter.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/gson/PathTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/gson/PatternTypeAdapter.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/gson/PatternTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/property/DocProperty.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/property/DocProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/property/DocPropertyHolder.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/property/DocPropertyHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/property/FunctionalDocProperty.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/property/FunctionalDocProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/document/property/JsonDocPropertyHolder.java
+++ b/common/src/main/java/eu/cloudnetservice/common/document/property/JsonDocPropertyHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/function/ThrowableBiFunction.java
+++ b/common/src/main/java/eu/cloudnetservice/common/function/ThrowableBiFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/function/ThrowableConsumer.java
+++ b/common/src/main/java/eu/cloudnetservice/common/function/ThrowableConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/function/ThrowableFunction.java
+++ b/common/src/main/java/eu/cloudnetservice/common/function/ThrowableFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/function/ThrowableSupplier.java
+++ b/common/src/main/java/eu/cloudnetservice/common/function/ThrowableSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/hash/HashUtil.java
+++ b/common/src/main/java/eu/cloudnetservice/common/hash/HashUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/io/FileUtil.java
+++ b/common/src/main/java/eu/cloudnetservice/common/io/FileUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/io/ZipUtil.java
+++ b/common/src/main/java/eu/cloudnetservice/common/io/ZipUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/language/I18n.java
+++ b/common/src/main/java/eu/cloudnetservice/common/language/I18n.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/AbstractHandler.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/AbstractHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/FallbackLoggerFactory.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/FallbackLoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/FallbackPassthroughLogger.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/FallbackPassthroughLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/LogManager.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/LogManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/LogRecordDispatcher.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/LogRecordDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/Logger.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/LoggerFactory.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/LoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/LoggingUtil.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/LoggingUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/defaults/AcceptingLogHandler.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/defaults/AcceptingLogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/defaults/DefaultFileHandler.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/defaults/DefaultFileHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/defaults/DefaultLogFormatter.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/defaults/DefaultLogFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/defaults/ThreadedLogRecordDispatcher.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/defaults/ThreadedLogRecordDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/log/io/LogOutputStream.java
+++ b/common/src/main/java/eu/cloudnetservice/common/log/io/LogOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/stream/ListeningOutputStream.java
+++ b/common/src/main/java/eu/cloudnetservice/common/stream/ListeningOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/unsafe/CPUUsageResolver.java
+++ b/common/src/main/java/eu/cloudnetservice/common/unsafe/CPUUsageResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/eu/cloudnetservice/common/unsafe/ResourceResolver.java
+++ b/common/src/main/java/eu/cloudnetservice/common/unsafe/ResourceResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/JavaVersionTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/JavaVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/StringUtilTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/StringUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/WildcardUtilTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/WildcardUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/column/ColumnTextFormatterTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/column/ColumnTextFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/column/RowBasedFormatterTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/column/RowBasedFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/concurrent/CompletedTaskTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/concurrent/CompletedTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/concurrent/CountingTaskTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/concurrent/CountingTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/concurrent/ListenableTaskTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/concurrent/ListenableTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/concurrent/TaskTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/concurrent/TaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/document/gson/JsonDocumentTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/document/gson/JsonDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/io/ZipUtilTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/io/ZipUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/language/I18nTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/language/I18nTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/eu/cloudnetservice/common/unsafe/ResourceResolverTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/unsafe/ResourceResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/build.gradle.kts
+++ b/driver/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/ap/java/eu/cloudnetservice/driver/ap/RPCValidationProcessor.java
+++ b/driver/src/ap/java/eu/cloudnetservice/driver/ap/RPCValidationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/ap/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/driver/src/ap/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/CloudNetVersion.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/CloudNetVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/ComponentInfo.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/ComponentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/DriverEnvironment.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/DriverEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessage.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessageSender.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessageSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessageTarget.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessageTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/command/CommandInfo.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/command/CommandInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/database/Database.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/database/Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/database/DatabaseProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/database/DatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/Cancelable.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/Cancelable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/DefaultEventManager.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/DefaultEventManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/DefaultRegisteredEventListener.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/DefaultRegisteredEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/Event.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/EventListener.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/EventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/EventListenerException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/EventListenerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/EventManager.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/EventManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/InvocationOrder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/InvocationOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/RegisteredEventListener.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/RegisteredEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/channel/ChannelMessageReceiveEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/channel/ChannelMessageReceiveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/chunk/ChunkedPacketSessionOpenEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/chunk/ChunkedPacketSessionOpenEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationAddEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationAddEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationRemoveEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationRemoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModuleEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModuleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostInstallDependencyEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostInstallDependencyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostLoadEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostLoadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostReloadEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostReloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostStartEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostStopEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostStopEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostUnloadEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostUnloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreInstallDependencyEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreInstallDependencyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreLoadEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreLoadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreReloadEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreReloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreStartEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreStopEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreStopEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreUnloadEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreUnloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/UnloadedModuleEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/module/UnloadedModuleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/ChannelType.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/ChannelType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelCloseEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelCloseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelInitEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelInitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelPacketReceiveEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelPacketReceiveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelPacketSendEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelPacketSendEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionAddGroupEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionAddGroupEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionAddUserEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionAddUserEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionDeleteGroupEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionDeleteGroupEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionDeleteUserEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionDeleteUserEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionGroupEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionGroupEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionSetGroupsEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionSetGroupsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionUpdateGroupEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionUpdateGroupEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionUpdateUserEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionUpdateUserEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionUserEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/permission/PermissionUserEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceDeferredStateEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceDeferredStateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceLifecycleChangeEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceLifecycleChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceLogEntryEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceLogEntryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceUpdateEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskAddEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskAddEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskRemoveEvent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskRemoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/inject/DefaultInjectionLayer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/inject/DefaultInjectionLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerHolder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/inject/UncloseableInjectionLayer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/inject/UncloseableInjectionLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModule.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleDependencyLoader.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleDependencyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleProviderHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleProviderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleTaskEntry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleTaskEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleWrapper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/Module.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfigurationNotFoundException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfigurationNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependency.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyLoader.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyNotFoundException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyOutdatedException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyOutdatedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleLifeCycle.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleProviderHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleProviderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleRepository.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleTask.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleTaskEntry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleTaskEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleURLClassLoader.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleURLClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleWrapper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/driver/DriverModule.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/driver/DriverModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/driver/ModuleConfigurationInvalidException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/driver/ModuleConfigurationInvalidException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/util/ModuleDependencyUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/util/ModuleDependencyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/DefaultNetworkChannel.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/DefaultNetworkChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/DefaultNetworkComponent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/DefaultNetworkComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/HostAndPort.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/HostAndPort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkChannel.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkChannelHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkClient.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkComponent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/NetworkServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBufFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBufFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBufable.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBufable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketSender.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/TransferStatus.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/TransferStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/data/ChunkSessionInformation.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/data/ChunkSessionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultChunkedPacketProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultChunkedPacketProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkPacketSender.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkPacketSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkedPacketHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkedPacketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/FileChunkedPacketSenderBuilder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/FileChunkedPacketSenderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/factory/EventChunkHandlerFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/factory/EventChunkHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/splitter/NetworkChannelsPacketSplitter.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/splitter/NetworkChannelsPacketSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/network/ChunkedPacket.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/network/ChunkedPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/network/ChunkedPacketListener.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/network/ChunkedPacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NetworkCluster.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NetworkCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NetworkClusterNode.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NetworkClusterNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NodeInfoSnapshot.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NodeInfoSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/def/NetworkConstants.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/def/NetworkConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/def/PacketClientAuthorization.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/def/PacketClientAuthorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/def/PacketServerChannelMessage.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/def/PacketServerChannelMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpChannel.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpComponent.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpContext.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpContextPreprocessor.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpContextPreprocessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpCookie.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpHandleException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpHandleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpMessage.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpRequest.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpResponse.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpResponseCode.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpResponseCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpVersion.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/HttpVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/FirstRequestQueryParam.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/FirstRequestQueryParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/HttpRequestHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/HttpRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/Optional.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/Optional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestBody.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestHeader.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestPath.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestPathParam.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestPathParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestQueryParam.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/RequestQueryParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/AnnotationHttpHandleException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/AnnotationHttpHandleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/DefaultHttpAnnotationParser.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/DefaultHttpAnnotationParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/HttpAnnotationParser.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/HttpAnnotationParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/HttpAnnotationProcessor.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/HttpAnnotationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/HttpAnnotationProcessorUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/HttpAnnotationProcessorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/MethodHttpHandlerInvoker.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/MethodHttpHandlerInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/ParameterInvocationHint.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/annotation/parser/ParameterInvocationHint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/websocket/WebSocketChannel.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/websocket/WebSocketChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/websocket/WebSocketFrameType.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/websocket/WebSocketFrameType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/http/websocket/WebSocketListener.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/http/websocket/WebSocketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyNetworkChannel.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyNetworkChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyNetworkHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyNetworkHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettySslServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettySslServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyTransport.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyDataBufFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyDataBufFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyImmutableDataBuf.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyImmutableDataBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyMutableDataBuf.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyMutableDataBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClientHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClientHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClientInitializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClientInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/NettyPacketDecoder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/NettyPacketDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/NettyPacketEncoder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/NettyPacketEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/VarInt32FrameDecoder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/VarInt32FrameDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/VarInt32FramePrepender.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/codec/VarInt32FramePrepender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpChannel.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpMessage.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerContext.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerInitializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerRequest.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerResponse.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyIdleStateHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyIdleStateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyWebSocketServerChannel.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyWebSocketServerChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyWebSocketServerChannelHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyWebSocketServerChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServerHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServerInitializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/BasePacket.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/BasePacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/EmptyPacket.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/EmptyPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/Packet.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/Packet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListener.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListenerRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListenerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketSender.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/QueryPacketManager.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/QueryPacketManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/defaults/DefaultPacketListenerRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/defaults/DefaultPacketListenerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/defaults/DefaultQueryPacketManager.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/defaults/DefaultQueryPacketManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/ChainableRPC.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/ChainableRPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPC.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCChain.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCExecutable.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCExecutable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCHandlerRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCHandlerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCInvocationContext.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCInvocationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCSender.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCFieldGetter.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCFieldGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCIgnore.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCIgnore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCNoResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCNoResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCValidation.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/DefaultRPCFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/DefaultRPCFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/DefaultRPCProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/DefaultRPCProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/MethodInformation.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/MethodInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ApiImplementationGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ApiImplementationGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ChainedApiImplementationGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ChainedApiImplementationGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/DefaultHandlingResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/DefaultHandlingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/DefaultRPCHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/DefaultRPCHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/DefaultRPCHandlerRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/DefaultRPCHandlerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/context/DefaultRPCInvocationContext.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/context/DefaultRPCInvocationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/context/DefaultRPCInvocationContextBuilder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/context/DefaultRPCInvocationContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/invoker/MethodInvoker.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/invoker/MethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/invoker/MethodInvokerGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/invoker/MethodInvokerGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/util/ExceptionalResultUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/util/ExceptionalResultUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/DefaultObjectMapper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/DefaultObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassInformation.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassInvokerGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassInvokerGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/CollectionObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/CollectionObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/DataBufObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/DataBufObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/DataBufableObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/DataBufableObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/EnumObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/EnumObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/FunctionalObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/FunctionalObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/JsonDocumentObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/JsonDocumentObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/MapObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/MapObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/OptionalObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/OptionalObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/PathObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/PathObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/PatternObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/PatternObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/UUIDObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/serializers/UUIDObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/DefaultRPC.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/DefaultRPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/DefaultRPCChain.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/DefaultRPCChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/RPCResultMapper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/rpc/RPCResultMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/sender/DefaultRPCSender.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/sender/DefaultRPCSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/CannotDecideException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/CannotDecideException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/ClassCreationException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/ClassCreationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/MissingAllArgsConstructorException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/MissingAllArgsConstructorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/MissingNoArgsConstructorException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/MissingNoArgsConstructorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/MissingObjectSerializerException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/MissingObjectSerializerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/RPCException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/RPCException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/RPCExecutionException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/RPCExecutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/generation/ChainInstanceFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/generation/ChainInstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/generation/GenerationContext.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/generation/GenerationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/generation/InstanceFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/generation/InstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/listener/RPCPacketListener.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/listener/RPCPacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/object/ObjectMapper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/object/ObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/object/ObjectSerializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/object/ObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/packet/RPCRequestPacket.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/packet/RPCRequestPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/ssl/SSLConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/ssl/SSLConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/AbstractPermissible.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/AbstractPermissible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/CachedPermissionManagement.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/CachedPermissionManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/DefaultCachedPermissionManagement.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/DefaultCachedPermissionManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/DefaultPermissionManagement.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/DefaultPermissionManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/Permissible.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/Permissible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/Permission.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/Permission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionCheckResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionCheckResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionGroup.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionManagement.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionUser.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionUserGroupInfo.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionUserGroupInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/CloudMessenger.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/CloudMessenger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceFactory.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/ClusterNodeProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/ClusterNodeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/GroupConfigurationProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/GroupConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/ServiceTaskProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/ServiceTaskProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/provider/defaults/DefaultMessenger.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/provider/defaults/DefaultMessenger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/registry/DefaultServiceRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/registry/DefaultServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/GroupConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/GroupConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessSnapshot.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfigurationBase.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceConfigurationBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateRetryConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateRetryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceDeployment.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceDeployment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironment.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceId.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceInfoSnapshot.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceInfoSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceLifeCycle.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceRemoteInclusion.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceRemoteInclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTemplate.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ThreadSnapshot.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ThreadSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/property/FunctionalServiceProperty.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/property/FunctionalServiceProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/property/JsonServiceProperty.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/property/JsonServiceProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/property/ServiceProperty.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/property/ServiceProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/property/TransformingServiceProperty.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/property/TransformingServiceProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/template/FileInfo.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/template/FileInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/template/TemplateStorage.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/template/TemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/template/TemplateStorageProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/template/TemplateStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/template/defaults/RemoteTemplateStorage.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/template/defaults/RemoteTemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/ExecutorServiceUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/ExecutorServiceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/ModuleHelper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/ModuleHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/VarHandleUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/VarHandleUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/asm/AsmHelper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/asm/AsmHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/define/ClassDefiner.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/define/ClassDefiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/define/ClassDefiners.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/define/ClassDefiners.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/define/FallbackClassDefiner.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/define/FallbackClassDefiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/main/java/eu/cloudnetservice/driver/util/define/LookupClassDefiner.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/define/LookupClassDefiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/event/DefaultEventManagerTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/event/DefaultEventManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/module/ModuleDependencyUtilTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/module/ModuleDependencyUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/HostAndPortTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/HostAndPortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/NetworkTestCase.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/NetworkTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketSenderTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/http/NettyHttpAnnotatedHandlerTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/http/NettyHttpAnnotatedHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/http/NettyHttpServerTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/http/NettyHttpServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/http/WebSocketClientEndpoint.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/http/WebSocketClientEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/netty/NettyUtilTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/netty/NettyUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/netty/codec/NettyPacketCodecTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/netty/codec/NettyPacketCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/netty/codec/VarIntCodecTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/netty/codec/VarIntCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/netty/communication/NettyNetworkServerClientTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/netty/communication/NettyNetworkServerClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/protocol/DefaultPacketListenerRegistryTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/protocol/DefaultPacketListenerRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/protocol/DefaultQueryPacketManagerTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/protocol/DefaultQueryPacketManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/BasePermissionManagement.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/BasePermissionManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/RPCImplementationGeneratorTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/RPCImplementationGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/SenderNeedingManagement.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/SenderNeedingManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/chain/RPCChainImplementationGeneratorTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/chain/RPCChainImplementationGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/handler/DefaultRPCHandlerTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/handler/DefaultRPCHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/object/AllPrimitiveTypesDataClass.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/object/AllPrimitiveTypesDataClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/object/DefaultObjectMapperTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/object/DefaultObjectMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/registry/DefaultRPCHandlerRegistryTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/registry/DefaultRPCHandlerRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/build.gradle.kts
+++ b/ext/adventure-helper/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/adventure/AdventureSerializerUtil.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/adventure/AdventureSerializerUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/adventure/AdventureTextFormatLookup.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/adventure/AdventureTextFormatLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/AdventureComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/AdventureComponentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/BungeeComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/BungeeComponentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentConverter.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormats.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/JavaEditionComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/JavaEditionComponentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/MappingConverter.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/MappingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/adventure/AdventureSerializerUtilTest.java
+++ b/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/adventure/AdventureSerializerUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/adventure/AdventureTextFormatLookupTest.java
+++ b/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/adventure/AdventureTextFormatLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/component/ComponentFormatsTest.java
+++ b/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/component/ComponentFormatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/build.gradle.kts
+++ b/ext/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/bukkit-command/build.gradle.kts
+++ b/ext/bukkit-command/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/bukkit-command/src/main/java/eu/cloudnetservice/ext/bukkitcommands/BaseTabExecutor.java
+++ b/ext/bukkit-command/src/main/java/eu/cloudnetservice/ext/bukkitcommands/BaseTabExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/modlauncher/build.gradle.kts
+++ b/ext/modlauncher/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/modlauncher/src/main/java/eu/cloudnetservice/ext/modlauncher/CloudNetLaunchPluginService.java
+++ b/ext/modlauncher/src/main/java/eu/cloudnetservice/ext/modlauncher/CloudNetLaunchPluginService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/modlauncher/src/main/resources/META-INF/services/cpw.mods.modlauncher.serviceapi.ILaunchPluginService
+++ b/ext/modlauncher/src/main/resources/META-INF/services/cpw.mods.modlauncher.serviceapi.ILaunchPluginService
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/build.gradle.kts
+++ b/ext/platform-inject-support/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformEntrypoint.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformEntrypoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformPluginInfo.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformPluginInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformPluginManager.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/data/ParsedPluginData.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/data/ParsedPluginData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/data/PluginDataParser.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/data/PluginDataParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/defaults/BasePlatformPluginManager.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/defaults/BasePlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/defaults/DefaultPlatformPluginInfo.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/defaults/DefaultPlatformPluginInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/generator/PlatformMainClassGenerator.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/generator/PlatformMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/generator/PluginInfoGenerator.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/generator/PluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/inject/BindingsInstaller.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/inject/BindingsInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/mapping/Container.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/mapping/Container.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/mapping/PlatformedContainer.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/mapping/PlatformedContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/registry/PlatformManagerRegistryHolder.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/registry/PlatformManagerRegistryHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformDataGeneratorProvider.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformDataGeneratorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformPluginManagerProvider.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformPluginManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformPluginManagerRegistry.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformPluginManagerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Command.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ConstructionListener.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ConstructionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Dependency.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Dependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ExternalDependency.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ExternalDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/PlatformPlugin.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/PlatformPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ProvidesFor.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ProvidesFor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Repository.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/util/FunctionalUtil.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/util/FunctionalUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/util/PluginUtil.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/util/PluginUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectSupportLoader.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectSupportLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/build.gradle.kts
+++ b/ext/platform-inject-support/build.gradle.kts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/ext/platform-inject-support/loader/build.gradle.kts
+++ b/ext/platform-inject-support/loader/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/JarInJarClassLoader.java
+++ b/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/JarInJarClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectLoaderLazy.java
+++ b/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectLoaderLazy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectSupportLoader.java
+++ b/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectSupportLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/build.gradle.kts
+++ b/ext/platform-inject-support/processor/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/BindingClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/BindingClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/PlatformPluginProcessor.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/PlatformPluginProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/BaseMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/BaseMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/JavapoetMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/JavapoetMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/MethodBasedMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/MethodBasedMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/infogen/NightConfigInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/infogen/NightConfigInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongeMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongeMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongePlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongePlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongePluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongePluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/ConfigUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/ConfigUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/GeantyrefUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/GeantyrefUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/PatternUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/PatternUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/ResourceUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/ResourceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/TypeUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/TypeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformDataGeneratorProvider
+++ b/ext/platform-inject-support/processor/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformDataGeneratorProvider
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/ext/platform-inject-support/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/build.gradle.kts
+++ b/ext/platform-inject-support/runtime/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/DefaultPlatformPluginManagerRegistry.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/DefaultPlatformPluginManagerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bukkit/BukkitPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bukkit/BukkitPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bukkit/BukkitPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bukkit/BukkitPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/fabric/FabricPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/fabric/FabricPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/fabric/FabricPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/fabric/FabricPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/minestom/MinestomPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/minestom/MinestomPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/minestom/MinestomPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/minestom/MinestomPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/nukkit/NukkitPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/nukkit/NukkitPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/nukkit/NukkitPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/nukkit/NukkitPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/sponge/SpongePlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/sponge/SpongePlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/sponge/SpongePlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/sponge/SpongePlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/velocity/VelocityPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/velocity/VelocityPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/velocity/VelocityPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/velocity/VelocityPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/waterdog/WaterDogPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/waterdog/WaterDogPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/waterdog/WaterDogPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/waterdog/WaterDogPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/util/BindingUtil.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/util/BindingUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/util/LazyClassInstantiationUtil.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/util/LazyClassInstantiationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformPluginManagerProvider
+++ b/ext/platform-inject-support/runtime/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformPluginManagerProvider
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformPluginManagerRegistry
+++ b/ext/platform-inject-support/runtime/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformPluginManagerRegistry
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/updater/build.gradle.kts
+++ b/ext/updater/build.gradle.kts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/Updater.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/Updater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/UpdaterRegistry.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/UpdaterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/defaults/DefaultUpdaterRegistry.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/defaults/DefaultUpdaterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/util/ChecksumUtil.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/util/ChecksumUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/util/GitHubUtil.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/util/GitHubUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradlew
+++ b/gradlew
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 #
-# Copyright © 2015-2021 the original authors.
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/build.gradle.kts
+++ b/launcher/java17/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/ApplicationBootstrap.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/ApplicationBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/ApplicationLock.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/ApplicationLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/CloudNetLauncher.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/CloudNetLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/cnl/CnlCommand.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/cnl/CnlCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/cnl/CnlInterpreter.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/cnl/CnlInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/cnl/defaults/VarCnlCommand.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/cnl/defaults/VarCnlCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/dependency/Dependency.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/dependency/Dependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/dependency/DependencyHelper.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/dependency/DependencyHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/dependency/Repository.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/dependency/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/LauncherUpdaterContext.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/LauncherUpdaterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/LauncherUpdaterRegistry.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/LauncherUpdaterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherChecksumsFileUpdater.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherChecksumsFileUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherCloudNetUpdater.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherCloudNetUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherModuleJsonUpdater.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherModuleJsonUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherPatcherUpdater.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherPatcherUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherUpdater.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/updaters/LauncherUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/util/FileDownloadUpdateHelper.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/updater/util/FileDownloadUpdateHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/BootstrapUtil.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/BootstrapUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/CommandLineHelper.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/CommandLineHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/Environment.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/Environment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/HttpUtil.java
+++ b/launcher/java17/src/main/java/eu/cloudnetservice/launcher/java17/util/HttpUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java8/build.gradle.kts
+++ b/launcher/java8/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java8/src/main/java/eu/cloudnetservice/launcher/java8/Launcher.java
+++ b/launcher/java8/src/main/java/eu/cloudnetservice/launcher/java8/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/patcher/build.gradle.kts
+++ b/launcher/patcher/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/patcher/src/main/java/eu/cloudnetservice/launcher/patcher/CloudNetLauncherPatcher.java
+++ b/launcher/patcher/src/main/java/eu/cloudnetservice/launcher/patcher/CloudNetLauncherPatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/build.gradle.kts
+++ b/modules/bridge/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceHelper.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceProperties.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/WorldPosition.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/WorldPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/ProxyFallback.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/ProxyFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/ProxyFallbackConfiguration.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/ProxyFallbackConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeConfigurationUpdateEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeConfigurationUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeDeleteCloudOfflinePlayerEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeDeleteCloudOfflinePlayerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerDisconnectEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerDisconnectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerLoginEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerLoginEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerServerSwitchEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerServerSwitchEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeServerPlayerDisconnectEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeServerPlayerDisconnectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeServerPlayerLoginEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeServerPlayerLoginEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeUpdateCloudOfflinePlayerEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeUpdateCloudOfflinePlayerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeUpdateCloudPlayerEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeUpdateCloudPlayerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/CloudNetBridgeModule.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/CloudNetBridgeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/NodeBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/NodeBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/BridgeCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/BridgeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/event/LocalPlayerPreLoginEvent.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/event/LocalPlayerPreLoginEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/http/V2HttpHandlerBridge.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/http/V2HttpHandlerBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/BridgeLocalProxyPlayerDisconnectListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/BridgeLocalProxyPlayerDisconnectListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/NodeSetupListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/NodeSetupListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/network/NodeBridgeChannelMessageListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/network/NodeBridgeChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/network/NodePlayerChannelMessageListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/network/NodePlayerChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/player/NodePlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/player/NodePlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/player/NodePlayerManager.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/player/NodePlayerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/player/NodePlayerProvider.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/player/NodePlayerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerExecutorAdapter.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerExecutorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerManager.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitUtil.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordHelper.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/PendingConnectionProxiedPlayer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/PendingConnectionProxiedPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordCloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordCloudCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordFakeReloadCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordFakeReloadCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordHubCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordHubCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ClientIntentionPacketMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ClientIntentionPacketMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/CompressionThresholdMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/CompressionThresholdMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ConnectionMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ConnectionMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerHandshakePacketListenerMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerHandshakePacketListenerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerLoginPacketListenerMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerLoginPacketListenerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/handling/MinecraftServerMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/handling/MinecraftServerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/handling/PlayerListMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/handling/PlayerListMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/util/BridgedClientConnection.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/util/BridgedClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/util/BridgedServer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/util/BridgedServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/util/FabricInjectionHolder.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/util/FabricInjectionHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fallback/FallbackProfile.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fallback/FallbackProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/helper/ProxyPlatformHelper.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/helper/ProxyPlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/helper/ServerPlatformHelper.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/helper/ServerPlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/listener/PlatformChannelMessageListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/listener/PlatformChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/listener/PlatformInformationListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/listener/PlatformInformationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomBridgeExtension.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomBridgeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongePlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongePlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityHubCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityHubCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEHandlers.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEPlayerManagementListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPECloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPECloudCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPEHubCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPEHubCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudOfflinePlayer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudOfflinePlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudPlayer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkPlayerProxyInfo.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkPlayerProxyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkPlayerServerInfo.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkPlayerServerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkServiceInfo.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkServiceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerProvider.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/ServicePlayer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/ServicePlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/PlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/PlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/ServerSelectorType.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/ServerSelectorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/rpc/ComponentObjectSerializer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/rpc/ComponentObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/rpc/TitleObjectSerializer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/rpc/TitleObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/util/BridgeHostAndPortUtil.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/util/BridgeHostAndPortUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/build.gradle.kts
+++ b/modules/cloudflare/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/CloudNetCloudflareModule.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/CloudNetCloudflareModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/CloudFlareRecordManager.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/CloudFlareRecordManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/DnsRecordDetail.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/DnsRecordDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareConfiguration.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareConfigurationEntry.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareGroupConfiguration.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareGroupConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/dns/DnsRecord.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/dns/DnsRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/dns/DnsType.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/dns/DnsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/dns/SrvRecord.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/dns/SrvRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/listener/CloudflareServiceStateListener.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/listener/CloudflareServiceStateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/build.gradle.kts
+++ b/modules/cloudperms/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/CloudPermissionsHelper.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/CloudPermissionsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/PermissionsUpdateListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/PermissionsUpdateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPermissible.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPermissible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitPermissionHelper.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitPermissionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/listener/BukkitCloudPermissionsPlayerListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/listener/BukkitCloudPermissionsPlayerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/vault/VaultChatImplementation.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/vault/VaultChatImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/vault/VaultPermissionImplementation.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/vault/VaultPermissionImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/vault/VaultSupport.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/vault/VaultSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlayerListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlayerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/MinestomCloudPermissionsExtension.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/MinestomCloudPermissionsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/MinestomCloudPermissionsPlayer.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/MinestomCloudPermissionsPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/listener/MinestomCloudPermissionsPlayerListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/listener/MinestomCloudPermissionsPlayerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/node/CloudNetCloudPermissionsModule.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/node/CloudNetCloudPermissionsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/node/config/CloudPermissionConfig.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/node/config/CloudPermissionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPermissible.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPermissible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitPermissionInjectionHelper.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitPermissionInjectionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/listener/NukkitCloudPermissionsPlayerListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/listener/NukkitCloudPermissionsPlayerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongeCloudPermissionsListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongeCloudPermissionsListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongeCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongeCloudPermissionsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongePermissionsServiceListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongePermissionsServiceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/CloudPermissionDescription.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/CloudPermissionDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/CloudPermsPermissionService.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/CloudPermsPermissionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/CloudSubjectReference.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/CloudSubjectReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubject.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubjectCollection.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubjectCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubjectData.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/memory/InMemorySubjectData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/AbstractSubject.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/AbstractSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/AbstractSubjectCollection.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/AbstractSubjectCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/PermissibleSubjectData.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/PermissibleSubjectData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/group/CloudGroupCollection.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/group/CloudGroupCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/group/PermissionGroupData.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/group/PermissionGroupData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/group/PermissionGroupSubject.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/group/PermissionGroupSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/user/CloudUserCollection.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/user/CloudUserCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/user/PermissionUserData.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/user/PermissionUserData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/user/PermissionUserSubject.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/user/PermissionUserSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/user/UUIDUtil.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/permissible/user/UUIDUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/system/SystemSubject.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/system/SystemSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/system/SystemSubjectCollection.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/service/system/SystemSubjectCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudPermissionFunction.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudPermissionFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudPermissionProvider.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudPermissionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/listener/VelocityCloudPermissionsPlayerListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/listener/VelocityCloudPermissionsPlayerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/waterdogpe/WaterdogPECloudPermissionsPlayerListener.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/waterdogpe/WaterdogPECloudPermissionsPlayerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/waterdogpe/WaterdogPECloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/waterdogpe/WaterdogPECloudPermissionsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/build.gradle.kts
+++ b/modules/database-mongodb/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/CloudNetMongoDatabaseModule.java
+++ b/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/CloudNetMongoDatabaseModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabase.java
+++ b/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseProvider.java
+++ b/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/config/MongoDBConnectionConfig.java
+++ b/modules/database-mongodb/src/main/java/eu/cloudnetservice/modules/mongodb/config/MongoDBConnectionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
+++ b/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/build.gradle.kts
+++ b/modules/database-mysql/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/CloudNetMySQLDatabaseModule.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/CloudNetMySQLDatabaseModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseProvider.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConfiguration.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConnectionEndpoint.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConnectionEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
+++ b/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/build.gradle.kts
+++ b/modules/dockerized-services/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerCommand.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedLocalCloudServiceFactory.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedLocalCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedService.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServiceLogCache.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServiceLogCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServicesModule.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServicesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/config/DockerConfiguration.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/config/DockerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/config/DockerImage.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/config/DockerImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/config/TaskDockerConfig.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/config/TaskDockerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/build.gradle.kts
+++ b/modules/influx/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/InfluxConfiguration.java
+++ b/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/InfluxConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/InfluxModule.java
+++ b/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/InfluxModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/Publisher.java
+++ b/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/Publisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/PublisherRegistry.java
+++ b/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/PublisherRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/defaults/DefaultPublisherRegistry.java
+++ b/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/defaults/DefaultPublisherRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/publishers/ConnectedNodeInfoPublisher.java
+++ b/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/publishers/ConnectedNodeInfoPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/publishers/RunningServiceProcessSnapshotPublisher.java
+++ b/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/publish/publishers/RunningServiceProcessSnapshotPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/util/PointUtil.java
+++ b/modules/influx/src/main/java/eu/cloudnetservice/modules/influx/util/PointUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/build.gradle.kts
+++ b/modules/labymod/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/LabyModManagement.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/LabyModManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModBanner.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModBanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModConfiguration.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModDiscordRPC.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModDiscordRPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModPermissions.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModPlayerOptions.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModPlayerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModServiceDisplay.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModServiceDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/CloudNetLabyModModule.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/CloudNetLabyModModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/NodeLabyModListener.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/NodeLabyModListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/NodeLabyModManagement.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/NodeLabyModManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/PlatformLabyModListener.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/PlatformLabyModListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/PlatformLabyModManagement.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/PlatformLabyModManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/bungeecord/BungeeCordLabyModListener.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/bungeecord/BungeeCordLabyModListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/bungeecord/BungeeCordLabyModPlugin.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/bungeecord/BungeeCordLabyModPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModListener.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModPlugin.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/build.gradle.kts
+++ b/modules/npcs/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/AbstractNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/AbstractNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/NPC.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/NPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/NPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/NPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/SharedChannelMessageListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/SharedChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/CloudNPC.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/CloudNPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/NPCAction.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/NPCAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/NPCConstants.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/NPCConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/configuration/NPCConfiguration.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/configuration/NPCConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/configuration/NPCConfigurationEntry.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/configuration/NPCConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/package-info.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/InventoryConfiguration.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/InventoryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/ItemLayout.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/ItemLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/LabyModEmoteConfiguration.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/LabyModEmoteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCConfiguration.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCConfigurationEntry.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCPoolOptions.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCPoolOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NPCCommand.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NPCCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/listeners/NodeChannelMessageListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/listeners/NodeChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/listeners/NodeSetupListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/listeners/NodeSetupListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/CloudNetServiceListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/CloudNetServiceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformSelectorEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/EntityBukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/EntityBukkitPlatformSelectorEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitEntityProtectionListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitEntityProtectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitWorldListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitWorldListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/util/ReflectionUtil.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/util/ReflectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/build.gradle.kts
+++ b/modules/report/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/CloudNetReportModule.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/CloudNetReportModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/command/ReportCommand.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/command/ReportCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/config/PasteServer.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/config/PasteServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/config/ReportConfiguration.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/config/ReportConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/EmitterRegistry.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/EmitterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/ReportDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/ReportDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/ReportDataWriter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/ReportDataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/SpecificReportDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/SpecificReportDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/GroupConfigDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/GroupConfigDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/HeapDumpDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/HeapDumpDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/LocalModuleDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/LocalModuleDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/LocalNodeConfigDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/LocalNodeConfigDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/NodeServerDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/NodeServerDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/ServiceInfoDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/ServiceInfoDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/ServiceTasksDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/ServiceTasksDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/SystemInfoDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/SystemInfoDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/ThreadInfoDataEmitter.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/emitter/defaults/ThreadInfoDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/util/ReportConstants.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/util/ReportConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/build.gradle.kts
+++ b/modules/rest/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/CloudNetRestModule.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/CloudNetRestModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerAuthorization.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerAuthorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerCluster.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerDatabase.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerDocumentation.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerGroup.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerModule.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerNode.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerPermission.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerService.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerServiceVersionProvider.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerServiceVersionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerSession.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTask.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTemplate.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTemplateStorage.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/rest/src/main/resources/documentation/index.html
+++ b/modules/rest/src/main/resources/documentation/index.html
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2019-2023 CloudNetService team & contributors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <!doctype html>
 <html lang="en">
 <head>

--- a/modules/rest/src/main/resources/documentation/logo.svg
+++ b/modules/rest/src/main/resources/documentation/logo.svg
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  - Copyright 2019-2023 CloudNetService team & contributors
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="3000px" height="3000px" viewBox="0 0 3000 3000" enable-background="new 0 0 3000 3000" xml:space="preserve">  <image id="image0" width="3000" height="3000" x="0" y="0"
     href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAC7gAAAu4CAYAAABxFfV5AAAABGdBTUEAALGPC/xhBQAAACBjSFJN

--- a/modules/signs/build.gradle.kts
+++ b/modules/signs/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 import eu.cloudnetservice.gradle.juppiter.ModuleConfiguration

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/AbstractSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/AbstractSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/SharedChannelMessageListener.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/SharedChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/Sign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/Sign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/SignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/SignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/Sign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/Sign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/SignConstants.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/SignConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/SignLayout.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/SignLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/SignConfiguration.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/SignConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/SignConfigurationReaderAndWriter.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/SignConfigurationReaderAndWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/entry/SignConfigurationEntry.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/entry/SignConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/entry/SignConfigurationEntryType.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/entry/SignConfigurationEntryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/entry/SignConfigurationTaskEntry.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/entry/SignConfigurationTaskEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/entry/SignLayoutConfiguration.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/configuration/entry/SignLayoutConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/package-info.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/_deprecated/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignConfigurationEntry.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignGroupConfiguration.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignGroupConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayout.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignsConfiguration.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/CloudNetSignsModule.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/CloudNetSignsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/NodeSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/NodeSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/NodeSignsListener.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/NodeSignsListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/SignCommand.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/SignCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/configuration/NodeSignsConfigurationHelper.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/configuration/NodeSignsConfigurationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/configuration/SignConfigurationType.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/configuration/SignConfigurationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/util/SignEntryTaskSetup.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/util/SignEntryTaskSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/SignsPlatformListener.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/SignsPlatformListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitCompatibility.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitPlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitPlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignsPlugin.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/event/BukkitCloudSignInteractEvent.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/event/BukkitCloudSignInteractEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/functionality/SignInteractListener.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/functionality/SignInteractListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/functionality/SignsCommand.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/functionality/SignsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomPlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomPlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignBlockHandler.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignBlockHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignsExtension.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/event/MinestomCloudSignInteractEvent.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/event/MinestomCloudSignInteractEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/functionality/SignInteractListener.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/functionality/SignInteractListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/functionality/SignsCommand.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/functionality/SignsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitPlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitPlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignsPlugin.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/event/NukkitCloudSignInteractEvent.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/event/NukkitCloudSignInteractEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/functionality/SignInteractListener.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/functionality/SignInteractListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/functionality/SignsCommand.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/functionality/SignsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/CommandRegistrationListener.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/CommandRegistrationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongePlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongePlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignsPlugin.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/event/SpongeCloudSignInteractEvent.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/event/SpongeCloudSignInteractEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/functionality/SignInteractListener.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/functionality/SignInteractListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/functionality/SignsCommand.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/functionality/SignsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/util/LayoutUtil.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/util/LayoutUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/util/PriorityUtil.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/util/PriorityUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/build.gradle.kts
+++ b/modules/smart/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/CloudNetSmartModule.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/CloudNetSmartModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/SmartCommand.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/SmartCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/SmartServiceTaskConfig.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/SmartServiceTaskConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetLocalServiceListener.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetLocalServiceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetLocalServiceTaskListener.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetLocalServiceTaskListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetTickListener.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetTickListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/util/SmartUtil.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/util/SmartUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/build.gradle.kts
+++ b/modules/storage-s3/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorage.java
+++ b/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorageModule.java
+++ b/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorageModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/config/S3TemplateStorageConfig.java
+++ b/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/config/S3TemplateStorageConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
+++ b/modules/storage-s3/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/build.gradle.kts
+++ b/modules/storage-sftp/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/NopLoggerFactory.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/NopLoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPClientPool.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPClientPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageModule.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/config/SFTPTemplateStorageConfig.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/config/SFTPTemplateStorageConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/sshj/ActiveHeartbeatKeepAliveProvider.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/sshj/ActiveHeartbeatKeepAliveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/sshj/FilteringLocalFileSource.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/sshj/FilteringLocalFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
+++ b/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/build.gradle.kts
+++ b/modules/syncproxy/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyConfigurationUpdateEvent.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyConfigurationUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyConstants.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyConfiguration.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyLoginConfiguration.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyLoginConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyMotd.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyMotd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabList.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabListConfiguration.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabListConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/CloudNetSyncProxyModule.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/CloudNetSyncProxyModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/NodeSyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/NodeSyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/command/SyncProxyCommand.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/command/SyncProxyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/listener/NodeSyncProxyChannelMessageListener.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/listener/NodeSyncProxyChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/PlatformSyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/PlatformSyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyListener.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyPlugin.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/listener/SyncProxyCloudListener.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/listener/SyncProxyCloudListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyListener.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyPlugin.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyListener.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyPlugin.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/build.gradle.kts
+++ b/node/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/ShutdownHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/ShutdownHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/TickLoop.java
+++ b/node/src/main/java/eu/cloudnetservice/node/TickLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/boot/BootFactories.java
+++ b/node/src/main/java/eu/cloudnetservice/node/boot/BootFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/boot/Bootstrap.java
+++ b/node/src/main/java/eu/cloudnetservice/node/boot/Bootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/LocalNodeServer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/LocalNodeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/NodeServer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/NodeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/NodeServerProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/NodeServerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/NodeServerState.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/NodeServerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultLocalNodeServer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultLocalNodeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultNodeServerProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultNodeServerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/RemoteNodeServer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/RemoteNodeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DataSyncHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DataSyncHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DataSyncRegistry.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DataSyncRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DefaultDataSyncRegistry.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DefaultDataSyncRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/sync/prettyprint/GulfArrayDiffPrinter.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/sync/prettyprint/GulfArrayDiffPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/sync/prettyprint/GulfHelper.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/sync/prettyprint/GulfHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/sync/prettyprint/GulfMapDiffPrinter.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/sync/prettyprint/GulfMapDiffPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/sync/prettyprint/GulfPrettyPrint.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/sync/prettyprint/GulfPrettyPrint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/task/LocalNodeUpdateTask.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/task/LocalNodeUpdateTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/task/NodeDisconnectTrackerTask.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/task/NodeDisconnectTrackerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/util/NodeDisconnectHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/util/NodeDisconnectHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/util/QueuedNetworkChannel.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/util/QueuedNetworkChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/CommandProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/CommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/annotation/CommandAlias.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/annotation/CommandAlias.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/annotation/Description.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/annotation/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/annotation/Documentation.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/annotation/Documentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/AerogelInjectionService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/AerogelInjectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCaptionVariableReplacementHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCaptionVariableReplacementHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandPostProcessor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandPreProcessor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandPreProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultSuggestionProcessor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultSuggestionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/exception/ArgumentNotAvailableException.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/exception/ArgumentNotAvailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/exception/CommandExceptionHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/exception/CommandExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/source/CommandSource.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/source/CommandSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/source/ConsoleCommandSource.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/source/ConsoleCommandSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/source/DriverCommandSource.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/source/DriverCommandSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClearCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClearCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/CreateCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/CreateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/DebugCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/DebugCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ExitCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ExitCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/GroupsCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/GroupsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/HelpCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/HelpCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/MeCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/MeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/MigrateCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/MigrateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ModulesCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ModulesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/PermissionsCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/PermissionsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ServiceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TemplateCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TemplateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/VersionCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/VersionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/config/Configuration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/config/ConfigurationUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/ConfigurationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/config/RestConfiguration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/RestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/Console.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/ConsoleColor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/ConsoleColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/ConsoleReadThread.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/ConsoleReadThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/JLine3Completer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/JLine3Completer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/JLine3Console.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/JLine3Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/AbstractConsoleAnimation.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/AbstractConsoleAnimation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/ConsoleProgressAnimation.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/ConsoleProgressAnimation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/ConsoleProgressWrappers.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/ConsoleProgressWrappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/wrapper/WrappedInputStream.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/wrapper/WrappedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/wrapper/WrappedIterator.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/wrapper/WrappedIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/ConsoleAnswerTabCompleteHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/ConsoleAnswerTabCompleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/ConsoleSetupAnimation.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/ConsoleSetupAnimation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/QuestionAnswerType.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/QuestionAnswerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/QuestionListEntry.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/QuestionListEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/handler/ConsoleInputHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/handler/ConsoleInputHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/handler/ConsoleTabCompleteHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/handler/ConsoleTabCompleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/handler/Toggleable.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/handler/Toggleable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/log/ColoredLogFormatter.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/log/ColoredLogFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/console/util/HeaderReader.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/util/HeaderReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/AbstractDatabase.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/AbstractDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/LocalDatabase.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/LocalDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/NodeDatabaseProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/NodeDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/h2/H2Database.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/h2/H2Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/h2/H2DatabaseProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/h2/H2DatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/sql/SQLDatabase.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/sql/SQLDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/sql/SQLDatabaseProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/sql/SQLDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/util/LocalDatabaseUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/util/LocalDatabaseUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/xodus/XodusDatabase.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/xodus/XodusDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/database/xodus/XodusDatabaseProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/database/xodus/XodusDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/CloudNetNodePostInitializationEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/CloudNetNodePostInitializationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/cluster/LocalNodeSnapshotConfigureEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/cluster/LocalNodeSnapshotConfigureEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/cluster/NetworkClusterNodeInfoUpdateEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/cluster/NetworkClusterNodeInfoUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/command/CommandInvalidSyntaxEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/command/CommandInvalidSyntaxEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/command/CommandNotFoundEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/command/CommandNotFoundEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/command/CommandPostProcessEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/command/CommandPostProcessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/command/CommandPreProcessEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/command/CommandPreProcessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/command/CommandProcessEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/command/CommandProcessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/group/LocalGroupConfigurationAddEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/group/LocalGroupConfigurationAddEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/group/LocalGroupConfigurationRemoveEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/group/LocalGroupConfigurationRemoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/instance/CloudNetTickEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/instance/CloudNetTickEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/instance/CloudNetTickServiceStartEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/instance/CloudNetTickServiceStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/log/LoggingEntryEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/log/LoggingEntryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/network/NetworkClusterNodeAuthSuccessEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/network/NetworkClusterNodeAuthSuccessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/network/NetworkClusterNodeReconnectEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/network/NetworkClusterNodeReconnectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/network/NetworkServiceAuthSuccessEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/network/NetworkServiceAuthSuccessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceCreateEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceCreateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceDeploymentEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceDeploymentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostLifecycleEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostLifecycleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostPrepareEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostPrepareEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostProcessStartEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostProcessStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreForceStopEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreForceStopEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLifecycleEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLifecycleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLoadInclusionEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLoadInclusionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePrePrepareEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePrePrepareEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreProcessStartEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreProcessStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceTemplateLoadEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceTemplateLoadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupCancelledEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupCancelledEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupCompleteEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupCompleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupInitiateEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupInitiateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupResponseEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/setup/SetupResponseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/task/LocalServiceTaskAddEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/task/LocalServiceTaskAddEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/task/LocalServiceTaskRemoveEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/task/LocalServiceTaskRemoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/event/template/ServiceTemplateInstallEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/template/ServiceTemplateInstallEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/http/DefaultHttpSession.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/DefaultHttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/http/HttpSession.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/HttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/http/V2HttpAuthentication.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/V2HttpAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/http/V2HttpHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/V2HttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/http/annotation/BasicAuth.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/annotation/BasicAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/http/annotation/BearerAuth.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/annotation/BearerAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/http/annotation/HandlerPermission.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/annotation/HandlerPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/http/annotation/SecurityAnnotationExtension.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/annotation/SecurityAnnotationExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/log/QueuedConsoleLogHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/log/QueuedConsoleLogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/module/ModuleEntry.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/ModuleEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/module/ModulesHolder.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/ModulesHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/module/NodeModuleProviderHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/NodeModuleProviderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/module/listener/PluginIncludeListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/listener/PluginIncludeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/module/updater/ModuleUpdater.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/updater/ModuleUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/module/updater/ModuleUpdaterContext.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/updater/ModuleUpdaterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/module/updater/ModuleUpdaterRegistry.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/updater/ModuleUpdaterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/module/util/ModuleUpdateUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/util/ModuleUpdateUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/DefaultNetworkClientChannelHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/DefaultNetworkClientChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/DefaultNetworkServerChannelHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/DefaultNetworkServerChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/NodeNetworkUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/NodeNetworkUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/chunk/FileDeployCallbackListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/chunk/FileDeployCallbackListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/chunk/StaticServiceDeployCallback.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/chunk/StaticServiceDeployCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/chunk/TemplateDeployCallback.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/chunk/TemplateDeployCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/chunk/TemplateFileDeployCallback.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/chunk/TemplateFileDeployCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketClientAuthorizationListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketClientAuthorizationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketClientServiceSyncAckListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketClientServiceSyncAckListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerAuthorizationResponseListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerAuthorizationResponseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/message/GroupChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/message/GroupChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/message/NodeChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/message/NodeChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/message/PermissionChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/message/PermissionChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/message/ServiceChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/message/ServiceChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/message/TaskChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/message/TaskChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/packet/PacketServerAuthorizationResponse.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/packet/PacketServerAuthorizationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/network/packet/PacketServerServiceSyncAckPacket.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/packet/PacketServerServiceSyncAckPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/permission/DefaultDatabasePermissionManagement.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/DefaultDatabasePermissionManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/permission/DefaultPermissionManagementHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/DefaultPermissionManagementHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/permission/NodePermissionManagement.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/NodePermissionManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/permission/command/PermissionUserCommandSource.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/command/PermissionUserCommandSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/permission/handler/PermissionManagementHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/handler/PermissionManagementHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/permission/handler/PermissionManagementHandlerAdapter.java
+++ b/node/src/main/java/eu/cloudnetservice/node/permission/handler/PermissionManagementHandlerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeClusterNodeProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeClusterNodeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeGroupConfigurationProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeGroupConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeMessenger.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeMessenger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeServiceTaskProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeServiceTaskProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/CloudService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/CloudService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/LocalCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/LocalCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/ServiceConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/ServiceConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/ServiceConsoleLineHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/ServiceConsoleLineHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/ServiceConsoleLogCache.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/ServiceConsoleLogCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/ServiceCreateRetryTracker.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/ServiceCreateRetryTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/AbstractServiceConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/AbstractServiceConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/BungeeConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/GlowstoneConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/GlowstoneConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/NukkitConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/NukkitConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VanillaServiceConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VanillaServiceConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VelocityConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/VelocityConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/WaterdogPEConfigurationPreparer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/config/WaterdogPEConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/BaseLocalCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/BaseLocalCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/JVMLocalCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/JVMLocalCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/log/AbstractServiceLogCache.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/log/AbstractServiceLogCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/log/ProcessServiceLogCache.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/log/ProcessServiceLogCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/EmptySpecificCloudServiceProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/EmptySpecificCloudServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/RemoteNodeCloudServiceProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/provider/RemoteNodeCloudServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultClusterSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultClusterSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultInstallation.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultInstallation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultTaskSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultTaskSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/setup/PermissionGroupSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/PermissionGroupSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/setup/SpecificTaskSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/SpecificTaskSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/template/LocalTemplateStorage.java
+++ b/node/src/main/java/eu/cloudnetservice/node/template/LocalTemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/template/NodeTemplateStorageProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/template/NodeTemplateStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/template/TemplateStorageUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/template/TemplateStorageUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/template/listener/TemplatePrepareListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/template/listener/TemplatePrepareListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/util/JavaVersionResolver.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/JavaVersionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersion.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionType.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/InstallStep.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/InstallStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/InstallStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/InstallStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/BuildStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/BuildStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/CopyFilterStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/CopyFilterStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/DeployStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/DeployStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/DownloadStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/DownloadStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/FabricApiVersionFetch.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/FabricApiVersionFetch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/PaperApiVersionFetchStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/PaperApiVersionFetchStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/SpongeApiVersionFetchStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/SpongeApiVersionFetchStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/UnzipStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/UnzipStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/information/FileSystemVersionInstaller.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/information/FileSystemVersionInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/information/TemplateVersionInstaller.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/information/TemplateVersionInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/java/eu/cloudnetservice/node/version/information/VersionInstaller.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/information/VersionInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/main/resources/files/nms/server.properties
+++ b/node/src/main/resources/files/nms/server.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2019-2023 CloudNetService team & contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #Minecraft server properties
 #Sat Jul 16 21:34:52 CEST 2022
 enable-jmx-monitoring=false

--- a/node/src/main/resources/files/nukkit/server.properties
+++ b/node/src/main/resources/files/nukkit/server.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2019-2023 CloudNetService team & contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #Properties Config file
 #2022-07-16 09:50:15
 motd=A Nukkit Powered Server

--- a/node/src/main/resources/lang/de_DE.properties
+++ b/node/src/main/resources/lang/de_DE.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Initial setup
 #
 cloudnet-init-eula-not-accepted=Wenn die EULA nicht akzeptiert wird, können keine Minecraft-Services gestartet werden\!
 cloudnet-init-eula=Stimmst Du den Bestimmungen der Mojang EULA (https\://aka.ms/MinecraftEULA) zu?

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Initial setup
 #
 cloudnet-init-eula-not-accepted=If you don't accept the eula, you cannot run a minecraft server!
 cloudnet-init-eula=Do you agree to the Mojang EULA (https://aka.ms/MinecraftEULA)?

--- a/node/src/test/java/eu/cloudnetservice/node/command/CommandProviderTest.java
+++ b/node/src/test/java/eu/cloudnetservice/node/command/CommandProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/test/java/eu/cloudnetservice/node/database/h2/H2DatabaseTest.java
+++ b/node/src/test/java/eu/cloudnetservice/node/database/h2/H2DatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/test/java/eu/cloudnetservice/node/database/xodus/XodusDatabaseTest.java
+++ b/node/src/test/java/eu/cloudnetservice/node/database/xodus/XodusDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/src/test/java/eu/cloudnetservice/node/template/LocalTemplateStorageTest.java
+++ b/node/src/test/java/eu/cloudnetservice/node/template/LocalTemplateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/chat/build.gradle.kts
+++ b/plugins/chat/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/BukkitChatPlugin.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/BukkitChatPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/ChatFormatter.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/ChatFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/MinestomChatExtension.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/MinestomChatExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/NukkitChatPlugin.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/NukkitChatPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/SpongeChatPlugin.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/SpongeChatPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/chat/src/main/resources/config.properties
+++ b/plugins/chat/src/main/resources/config.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2019-2023 CloudNetService team & contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Available placeholders:
 # %group%    - the name of the highest permission group of the player
 # %display%  - the display of the highest permission group of the player

--- a/plugins/papi-expansion/build.gradle.kts
+++ b/plugins/papi-expansion/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
+++ b/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/build.gradle.kts
+++ b/plugins/simplenametags/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/CloudSimpleNameTagsListener.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/CloudSimpleNameTagsListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/SimpleNameTagsManager.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/SimpleNameTagsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/bukkit/BukkitCompatibility.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/bukkit/BukkitCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/bukkit/BukkitSimpleNameTagsManager.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/bukkit/BukkitSimpleNameTagsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/bukkit/BukkitSimpleNameTagsPlugin.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/bukkit/BukkitSimpleNameTagsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/event/PrePlayerPrefixSetEvent.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/event/PrePlayerPrefixSetEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/minestom/MinestomSimpleNameTagsExtension.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/minestom/MinestomSimpleNameTagsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/minestom/MinestomSimpleNameTagsManager.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/minestom/MinestomSimpleNameTagsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/sponge/SpongeSimpleNameTagsManager.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/sponge/SpongeSimpleNameTagsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/sponge/SpongeSimpleNameTagsPlugin.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/sponge/SpongeSimpleNameTagsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/build.gradle.kts
+++ b/wrapper-jvm/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Main.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Premain.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Premain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/ShutdownHandler.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/ShutdownHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/configuration/DocumentWrapperConfiguration.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/configuration/DocumentWrapperConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/configuration/WrapperConfiguration.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/configuration/WrapperConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/database/WrapperDatabase.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/database/WrapperDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/database/WrapperDatabaseProvider.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/database/WrapperDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPostStartEvent.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPostStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPreStartEvent.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPreStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ServiceInfoSnapshotConfigureEvent.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/event/ServiceInfoSnapshotConfigureEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/holder/ServiceInfoHolder.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/holder/ServiceInfoHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/holder/WrapperServiceInfoHolder.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/holder/WrapperServiceInfoHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/inject/BootFactories.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/inject/BootFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/inject/RPCFactories.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/inject/RPCFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/log/InternalPrintStreamLogHandler.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/log/InternalPrintStreamLogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/NetworkClientChannelHandler.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/NetworkClientChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/chunk/TemplateStorageCallbackListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/chunk/TemplateStorageCallbackListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketAuthorizationResponseListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketAuthorizationResponseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketServerChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketServerChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/GroupChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/GroupChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/PermissionChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/PermissionChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/ServiceChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/ServiceChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/TaskChannelMessageListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/message/TaskChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/permission/PermissionCacheListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/permission/PermissionCacheListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/permission/WrapperPermissionManagement.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/permission/WrapperPermissionManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperCloudServiceProvider.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperCloudServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperMessenger.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperMessenger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperTemplateStorageProvider.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperTemplateStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/DefaultTransformerRegistry.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/DefaultTransformerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/Transformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/Transformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/TransformerRegistry.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/TransformerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/BukkitCommodoreTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/BukkitCommodoreTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/BukkitJavaVersionCheckTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/BukkitJavaVersionCheckTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/PaperConfigTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/PaperConfigTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/netty/OldEpollDisableTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/netty/OldEpollDisableTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/src/main/resources/META-INF/services/org.jboss.shrinkwrap.resolver.spi.format.FormatProcessor
+++ b/wrapper-jvm/src/main/resources/META-INF/services/org.jboss.shrinkwrap.resolver.spi.format.FormatProcessor
@@ -1,1 +1,17 @@
+#
+# Copyright 2019-2023 CloudNetService team & contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 org.jboss.shrinkwrap.resolver.impl.maven.format.MavenResolvedArtifactProcessor

--- a/wrapper-jvm/src/main/resources/lang/english.properties
+++ b/wrapper-jvm/src/main/resources/lang/english.properties
@@ -1,22 +1,5 @@
 #
-# Copyright 2019-2022 CloudNetService team & contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# CloudNet language file
-# Language: english
-#
-# Copyright 2019-2022 CloudNetService team & contributors
+# Copyright 2019-2023 CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Motivation
Since the year 2023 has now begun, the year 2022, which is currently specified in the copyright header, is no longer current.

### Modification
Updates the copyright year in all copyright headers in all files to 2023 (included LICENSE_HEADER).

### Result
The copyright year in the license header is up to date again.