### PR TITLE
fix: properly escape escaping chars in the mysql database

### DIFF
--- a/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
+++ b/modules/database-mongodb/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,16 +83,19 @@ class MongoDBDatabaseTest {
 
     Assertions.assertTrue(database.insert("1234", JsonDocument.newDocument("hello", "world")));
     Assertions.assertTrue(database.insert("12234", JsonDocument.newDocument("hello", "world2")));
+    Assertions.assertTrue(database.insert("122234", JsonDocument.newDocument("hello", "world_123")));
 
     Assertions.assertTrue(database.contains("1234"));
     Assertions.assertTrue(database.contains("12234"));
+    Assertions.assertTrue(database.contains("122234"));
 
-    Assertions.assertEquals(2, database.documentCount());
+    Assertions.assertEquals(3, database.documentCount());
 
     var keys = database.keys();
-    Assertions.assertEquals(2, keys.size());
+    Assertions.assertEquals(3, keys.size());
     Assertions.assertTrue(keys.contains("1234"));
     Assertions.assertTrue(keys.contains("12234"));
+    Assertions.assertTrue(keys.contains("122234"));
 
     var entry = database.get("1234");
     Assertions.assertNotNull(entry);
@@ -113,16 +116,20 @@ class MongoDBDatabaseTest {
     Assertions.assertEquals(1, entry5.size());
     Assertions.assertEquals("world2", entry5.iterator().next().getString("hello"));
 
+    var entry6 = database.find("hello", "world_123");
+    Assertions.assertEquals(1, entry6.size());
+    Assertions.assertEquals("world_123", entry6.iterator().next().getString("hello"));
+
     var entries = database.entries();
-    Assertions.assertEquals(2, entries.size());
+    Assertions.assertEquals(3, entries.size());
     Assertions.assertEquals("world", entries.get("1234").getString("hello"));
     Assertions.assertEquals("world2", entries.get("12234").getString("hello"));
 
     var documents = database.documents();
-    Assertions.assertEquals(2, documents.size());
+    Assertions.assertEquals(3, documents.size());
 
     Assertions.assertTrue(database.delete("12234"));
-    Assertions.assertEquals(1, database.documentCount());
+    Assertions.assertEquals(2, database.documentCount());
 
     database.clear();
     Assertions.assertEquals(0, database.documentCount());

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ public final class MySQLDatabase extends SQLDatabase {
         TABLE_COLUMN_VAL,
         this.name,
         TABLE_COLUMN_VAL,
-        Objects.toString(fieldValue).replaceAll("([_%])", "\\$1"),
+        Objects.toString(fieldValue).replaceAll("([_%])", "\\\\$1"),
         fieldName),
       resultSet -> {
         List<JsonDocument> results = new ArrayList<>();
@@ -128,7 +128,7 @@ public final class MySQLDatabase extends SQLDatabase {
           .append("JSON_SEARCH(")
           .append(TABLE_COLUMN_VAL)
           .append(", 'one', '")
-          .append(entry.getValue().replaceAll("([_%])", "\\$1"))
+          .append(entry.getValue().replaceAll("([_%])", "\\\\$1"))
           .append("', NULL, '$.")
           .append(entry.getKey())
           .append("') IS NOT NULL")

--- a/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
+++ b/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,16 +90,19 @@ class MySQLDatabaseTest {
 
     Assertions.assertTrue(database.insert("1234", JsonDocument.newDocument("hello", "world")));
     Assertions.assertTrue(database.insert("12234", JsonDocument.newDocument("hello", "world2")));
+    Assertions.assertTrue(database.insert("122234", JsonDocument.newDocument("hello", "world_123")));
 
     Assertions.assertTrue(database.contains("1234"));
     Assertions.assertTrue(database.contains("12234"));
+    Assertions.assertTrue(database.contains("122234"));
 
-    Assertions.assertEquals(2, database.documentCount());
+    Assertions.assertEquals(3, database.documentCount());
 
     var keys = database.keys();
-    Assertions.assertEquals(2, keys.size());
+    Assertions.assertEquals(3, keys.size());
     Assertions.assertTrue(keys.contains("1234"));
     Assertions.assertTrue(keys.contains("12234"));
+    Assertions.assertTrue(keys.contains("122234"));
 
     var entry = database.get("1234");
     Assertions.assertNotNull(entry);
@@ -120,16 +123,20 @@ class MySQLDatabaseTest {
     Assertions.assertEquals(1, entry5.size());
     Assertions.assertEquals("world2", entry5.iterator().next().getString("hello"));
 
+    var entry6 = database.find("hello", "world_123");
+    Assertions.assertEquals(1, entry6.size());
+    Assertions.assertEquals("world_123", entry6.iterator().next().getString("hello"));
+
     var entries = database.entries();
-    Assertions.assertEquals(2, entries.size());
+    Assertions.assertEquals(3, entries.size());
     Assertions.assertEquals("world", entries.get("1234").getString("hello"));
     Assertions.assertEquals("world2", entries.get("12234").getString("hello"));
 
     var documents = database.documents();
-    Assertions.assertEquals(2, documents.size());
+    Assertions.assertEquals(3, documents.size());
 
     Assertions.assertTrue(database.delete("12234"));
-    Assertions.assertEquals(1, database.documentCount());
+    Assertions.assertEquals(2, database.documentCount());
 
     database.clear();
     Assertions.assertEquals(0, database.documentCount());

--- a/node/src/test/java/eu/cloudnetservice/node/database/xodus/XodusDatabaseTest.java
+++ b/node/src/test/java/eu/cloudnetservice/node/database/xodus/XodusDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,16 +77,19 @@ class XodusDatabaseTest {
 
     Assertions.assertTrue(database.insert("1234", JsonDocument.newDocument("hello", "world")));
     Assertions.assertTrue(database.insert("12234", JsonDocument.newDocument("hello", "world2")));
+    Assertions.assertTrue(database.insert("122234", JsonDocument.newDocument("hello", "world_123")));
 
     Assertions.assertTrue(database.contains("1234"));
     Assertions.assertTrue(database.contains("12234"));
+    Assertions.assertTrue(database.contains("122234"));
 
-    Assertions.assertEquals(2, database.documentCount());
+    Assertions.assertEquals(3, database.documentCount());
 
     var keys = database.keys();
-    Assertions.assertEquals(2, keys.size());
+    Assertions.assertEquals(3, keys.size());
     Assertions.assertTrue(keys.contains("1234"));
     Assertions.assertTrue(keys.contains("12234"));
+    Assertions.assertTrue(keys.contains("122234"));
 
     var entry = database.get("1234");
     Assertions.assertNotNull(entry);
@@ -107,16 +110,20 @@ class XodusDatabaseTest {
     Assertions.assertEquals(1, entry5.size());
     Assertions.assertEquals("world2", entry5.iterator().next().getString("hello"));
 
+    var entry6 = database.find("hello", "world_123");
+    Assertions.assertEquals(1, entry6.size());
+    Assertions.assertEquals("world_123", entry6.iterator().next().getString("hello"));
+
     var entries = database.entries();
-    Assertions.assertEquals(2, entries.size());
+    Assertions.assertEquals(3, entries.size());
     Assertions.assertEquals("world", entries.get("1234").getString("hello"));
     Assertions.assertEquals("world2", entries.get("12234").getString("hello"));
 
     var documents = database.documents();
-    Assertions.assertEquals(2, documents.size());
+    Assertions.assertEquals(3, documents.size());
 
     Assertions.assertTrue(database.delete("12234"));
-    Assertions.assertEquals(1, database.documentCount());
+    Assertions.assertEquals(2, database.documentCount());
 
     database.clear();
     Assertions.assertEquals(0, database.documentCount());


### PR DESCRIPTION
### Motivation
An user reported an issue with the mysql database if the searched value (like an username) contained underscores.

### Modification
Changed our replacement from `\\$1` to `\\\\$1` to make sure that the char (e.g. underscore) is escaped to `\_` in the final query.

### Result
We can search with values that contain escaping chars.

##### Other context
Fixes #1063 
