### PR TITLE
fix: correct some netty channel options

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
@@ -135,6 +135,8 @@ public class NettyNetworkClient implements DefaultNetworkComponent, NetworkClien
       .option(ChannelOption.IP_TOS, 0x18)
       .option(ChannelOption.AUTO_READ, true)
       .option(ChannelOption.TCP_NODELAY, true)
+      .option(ChannelOption.SO_REUSEADDR, true)
+      .option(ChannelOption.TCP_FASTOPEN_CONNECT, true)
       .option(ChannelOption.WRITE_BUFFER_WATER_MARK, WATER_MARK)
       .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECTION_TIMEOUT_MILLIS)
 

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServer.java
@@ -113,10 +113,11 @@ public class NettyHttpServer extends NettySslServer implements HttpServer {
       .channelFactory(NettyUtil.serverChannelFactory())
       .childHandler(new NettyHttpServerInitializer(this, hostAndPort))
 
-      .childOption(ChannelOption.IP_TOS, 24)
       .childOption(ChannelOption.AUTO_READ, true)
       .childOption(ChannelOption.TCP_NODELAY, true)
       .childOption(ChannelOption.SO_REUSEADDR, true)
+
+      .option(ChannelOption.SO_REUSEADDR, true)
 
       .bind(hostAndPort.host(), hostAndPort.port())
       .addListener(future -> {

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
@@ -141,7 +141,11 @@ public class NettyNetworkServer extends NettySslServer implements DefaultNetwork
       .childOption(ChannelOption.AUTO_READ, true)
       .childOption(ChannelOption.TCP_NODELAY, true)
       .childOption(ChannelOption.SO_REUSEADDR, true)
+      .childOption(ChannelOption.SO_KEEPALIVE, true)
       .childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, WATER_MARK)
+
+      .option(ChannelOption.TCP_FASTOPEN, 3)
+      .option(ChannelOption.SO_REUSEADDR, true)
 
       .bind(hostAndPort.host(), hostAndPort.port())
       .addListener(future -> {


### PR DESCRIPTION
### Motivation
Some of the currently set netty channel options are not correctly applied to the boss channel which will (on the server side) listen for incoming connections and accept them. Due to this, there were some people reporting issues with re-starting a node instance as the node port would be blocked by the idle state and not be re-used.

### Modification
The channel options that need to get applied to the boss channel are now applied correctly, as well enabling tcp keepalive packets for connections and enabling tcp fast connect.

### Result
There should no longer be issues with blocked ports, and all channel options should now be applied correctly.
