### PR TITLE
fix: make sure to load cloudperms before Vault

### DIFF
--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
@@ -20,7 +20,6 @@ import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.permission.PermissionManagement;
 import eu.cloudnetservice.driver.util.ModuleHelper;
 import eu.cloudnetservice.ext.platforminject.api.PlatformEntrypoint;
-import eu.cloudnetservice.ext.platforminject.api.stereotype.Dependency;
 import eu.cloudnetservice.ext.platforminject.api.stereotype.PlatformPlugin;
 import eu.cloudnetservice.modules.cloudperms.PermissionsUpdateListener;
 import eu.cloudnetservice.modules.cloudperms.bukkit.listener.BukkitCloudPermissionsPlayerListener;
@@ -39,11 +38,7 @@ import org.bukkit.plugin.java.JavaPlugin;
   name = "CloudNet-CloudPerms",
   authors = "CloudNetService",
   version = "{project.build.version}",
-  description = "Bukkit extension which implement the permission management system from CloudNet into Bukkit",
-  dependencies = {
-    @Dependency(name = "Vault", optional = true),
-    @Dependency(name = "VaultAPI", optional = true)
-  }
+  description = "Bukkit extension which implement the permission management system from CloudNet into Bukkit"
 )
 public final class BukkitCloudPermissionsPlugin implements PlatformEntrypoint {
 

--- a/modules/cloudperms/src/main/resources/plugin.minecraft_server.yml.template
+++ b/modules/cloudperms/src/main/resources/plugin.minecraft_server.yml.template
@@ -1,0 +1,1 @@
+loadbefore: ["Vault"]


### PR DESCRIPTION
### Motivation
Vault expects any permission system that they do not support themselves to be loaded before Vault. This is the only way to access permission groups etc. via Vault.

### Modification
Removed the our depend on Vault and the VaultAPI and instead set a loadbefore on Vault.

### Result
CloudPerms is loaded before Vault is and therefore permission system related calls are working.
