### PR TITLE
fix: make service creation timeouts in a cluster more robust

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/message/ServiceChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/message/ServiceChannelMessageListener.java
@@ -72,6 +72,14 @@ public final class ServiceChannelMessageListener {
               .build()));
         }
 
+        // feedback from a node that a service which should have been moved to accepted
+        // is no longer registered as unaccepted and not yet moved to registered, which
+        // means that the cache ttl on the target node exceeded
+        case "node_to_head_node_unaccepted_service_ttl_exceeded" -> {
+          var serviceUniqueId = event.content().readUniqueId();
+          this.serviceManager.forceRemoveRegisteredService(serviceUniqueId);
+        }
+
         // request to start a service on the local node
         case "head_node_to_node_start_service" -> {
           var configuration = event.content().readObject(ServiceConfiguration.class);
@@ -85,9 +93,23 @@ public final class ServiceChannelMessageListener {
           var serviceUniqueId = event.content().readUniqueId();
           var service = this.serviceManager.takeUnacceptedService(serviceUniqueId);
 
-          // should not happen, ignore silently
           if (service != null) {
+            // service is still locally present, finish the registration of it
             service.handleServiceRegister();
+          } else {
+            // service is no longer locally present as unaccepted
+            // re-check if the service was already moved to registered
+            var registeredService = this.serviceManager.localCloudService(serviceUniqueId);
+            if (registeredService == null) {
+              // send this as feedback to the head node in order to remove the registered service from there as well
+              ChannelMessage.builder()
+                .target(event.sender().toTarget())
+                .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
+                .message("node_to_head_node_unaccepted_service_ttl_exceeded")
+                .buffer(DataBuf.empty().writeUniqueId(serviceUniqueId))
+                .build()
+                .send();
+            }
           }
         }
 

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/message/ServiceChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/message/ServiceChannelMessageListener.java
@@ -83,25 +83,11 @@ public final class ServiceChannelMessageListener {
         // publish the service info of a created service to the cluster
         case "head_node_to_node_finish_service_registration" -> {
           var serviceUniqueId = event.content().readUniqueId();
-          var service = this.serviceManager.localCloudService(serviceUniqueId);
+          var service = this.serviceManager.takeUnacceptedService(serviceUniqueId);
 
           // should not happen, ignore silently
           if (service != null) {
             service.handleServiceRegister();
-          }
-        }
-
-        // force remove the service associated with the supplied service id
-        case "head_node_to_node_force_remove_service" -> {
-          var serviceUniqueId = event.content().readUniqueId();
-          var service = this.serviceManager.localCloudService(serviceUniqueId);
-
-          // at this point the service just gets removed - there is nothing we need to worry about as this
-          // message is only send internally. In case someone is abusing this message to create invalid
-          // results, that is no longer on our risk to do (for example to send this message when the service
-          // is running, there is no way after this call to stop the service anymore)
-          if (service != null) {
-            this.serviceManager.unregisterLocalService(service);
           }
         }
 

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/message/ServiceChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/message/ServiceChannelMessageListener.java
@@ -80,6 +80,31 @@ public final class ServiceChannelMessageListener {
           event.binaryResponse(DataBuf.empty().writeObject(ServiceCreateResult.created(service.serviceInfo())));
         }
 
+        // publish the service info of a created service to the cluster
+        case "head_node_to_node_finish_service_registration" -> {
+          var serviceUniqueId = event.content().readUniqueId();
+          var service = this.serviceManager.localCloudService(serviceUniqueId);
+
+          // should not happen, ignore silently
+          if (service != null) {
+            service.handleServiceRegister();
+          }
+        }
+
+        // force remove the service associated with the supplied service id
+        case "head_node_to_node_force_remove_service" -> {
+          var serviceUniqueId = event.content().readUniqueId();
+          var service = this.serviceManager.localCloudService(serviceUniqueId);
+
+          // at this point the service just gets removed - there is nothing we need to worry about as this
+          // message is only send internally. In case someone is abusing this message to create invalid
+          // results, that is no longer on our risk to do (for example to send this message when the service
+          // is running, there is no way after this call to stop the service anymore)
+          if (service != null) {
+            this.serviceManager.unregisterLocalService(service);
+          }
+        }
+
         // update of a service in the network
         case "update_service_info" -> {
           var snapshot = event.content().readObject(ServiceInfoSnapshot.class);

--- a/node/src/main/java/eu/cloudnetservice/node/service/CloudService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/CloudService.java
@@ -72,5 +72,8 @@ public interface CloudService extends SpecificCloudServiceProvider {
   void publishServiceInfoSnapshot();
 
   @ApiStatus.Internal
+  void handleServiceRegister();
+
+  @ApiStatus.Internal
   void updateServiceInfoSnapshot(@NonNull ServiceInfoSnapshot serviceInfoSnapshot);
 }

--- a/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
@@ -100,6 +100,9 @@ public interface CloudServiceManager extends CloudServiceProvider {
   @Nullable CloudService takeUnacceptedService(@NonNull UUID serviceUniqueId);
 
   @ApiStatus.Internal
+  void forceRemoveRegisteredService(@NonNull UUID uniqueId);
+
+  @ApiStatus.Internal
   @Nullable SpecificCloudServiceProvider registerService(
     @NonNull ServiceInfoSnapshot snapshot,
     @NonNull NetworkChannel source);

--- a/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
@@ -31,7 +31,6 @@ import java.util.UUID;
 import lombok.NonNull;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jetbrains.annotations.UnmodifiableView;
 
@@ -95,7 +94,12 @@ public interface CloudServiceManager extends CloudServiceProvider {
   void unregisterLocalService(@NonNull CloudService service);
 
   @ApiStatus.Internal
-  void handleServiceUpdate(@NonNull ServiceInfoSnapshot snapshot, @UnknownNullability NetworkChannel source);
+  @Nullable SpecificCloudServiceProvider registerService(
+    @NonNull ServiceInfoSnapshot snapshot,
+    @NonNull NetworkChannel source);
+
+  @ApiStatus.Internal
+  void handleServiceUpdate(@NonNull ServiceInfoSnapshot snapshot, @Nullable NetworkChannel source);
 
   @ApiStatus.Internal
   @NonNull CloudService createLocalCloudService(@NonNull ServiceConfiguration serviceConfiguration);

--- a/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
@@ -94,6 +94,12 @@ public interface CloudServiceManager extends CloudServiceProvider {
   void unregisterLocalService(@NonNull CloudService service);
 
   @ApiStatus.Internal
+  void registerUnacceptedService(@NonNull CloudService service);
+
+  @ApiStatus.Internal
+  @Nullable CloudService takeUnacceptedService(@NonNull UUID serviceUniqueId);
+
+  @ApiStatus.Internal
   @Nullable SpecificCloudServiceProvider registerService(
     @NonNull ServiceInfoSnapshot snapshot,
     @NonNull NetworkChannel source);

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
@@ -156,7 +156,7 @@ public abstract class AbstractService implements CloudService {
     this.pushServiceInfoSnapshotUpdate(ServiceLifeCycle.PREPARED, false);
 
     // register the service locally for now
-    manager.registerLocalService(this);
+    manager.registerUnacceptedService(this);
   }
 
   protected static @NonNull Path resolveServicePath(
@@ -533,6 +533,10 @@ public abstract class AbstractService implements CloudService {
 
   @Override
   public void handleServiceRegister() {
+    // just ensure that this service is removed from the cache & moved to a "real" registered local service
+    this.cloudServiceManager.registerLocalService(this);
+    this.cloudServiceManager.takeUnacceptedService(this.serviceId().uniqueId());
+
     // publish the initial service info to the cluster
     this.pushServiceInfoSnapshotUpdate(ServiceLifeCycle.PREPARED);
 

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
@@ -153,10 +153,10 @@ public abstract class AbstractService implements CloudService {
       -1,
       ServiceLifeCycle.PREPARED,
       configuration.properties().clone());
-    this.pushServiceInfoSnapshotUpdate(ServiceLifeCycle.PREPARED);
+    this.pushServiceInfoSnapshotUpdate(ServiceLifeCycle.PREPARED, false);
 
+    // register the service locally for now
     manager.registerLocalService(this);
-    eventManager.callEvent(new CloudServiceCreateEvent(this));
   }
 
   protected static @NonNull Path resolveServicePath(
@@ -529,6 +529,15 @@ public abstract class AbstractService implements CloudService {
       .buffer(DataBuf.empty().writeObject(this.currentServiceInfo))
       .build()
       .send();
+  }
+
+  @Override
+  public void handleServiceRegister() {
+    // publish the initial service info to the cluster
+    this.pushServiceInfoSnapshotUpdate(ServiceLifeCycle.PREPARED);
+
+    // notify the local listeners that this service was created
+    this.eventManager.callEvent(new CloudServiceCreateEvent(this));
   }
 
   @Override

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/DefaultCloudServiceManager.java
@@ -459,6 +459,11 @@ public class DefaultCloudServiceManager implements CloudServiceManager {
   }
 
   @Override
+  public void forceRemoveRegisteredService(@NonNull UUID uniqueId) {
+    this.knownServices.remove(uniqueId);
+  }
+
+  @Override
   public @Nullable SpecificCloudServiceProvider registerService(
     @NonNull ServiceInfoSnapshot snapshot,
     @NonNull NetworkChannel source

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
@@ -18,6 +18,8 @@ package eu.cloudnetservice.node.service.defaults;
 
 import dev.derklaro.aerogel.PostConstruct;
 import dev.derklaro.aerogel.auto.Provides;
+import eu.cloudnetservice.common.log.LogManager;
+import eu.cloudnetservice.common.log.Logger;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.channel.ChannelMessageTarget;
 import eu.cloudnetservice.driver.event.EventManager;
@@ -31,6 +33,7 @@ import eu.cloudnetservice.driver.service.GroupConfiguration;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.driver.service.ServiceCreateResult;
 import eu.cloudnetservice.driver.service.ServiceCreateRetryConfiguration;
+import eu.cloudnetservice.node.cluster.NodeServer;
 import eu.cloudnetservice.node.cluster.NodeServerProvider;
 import eu.cloudnetservice.node.event.service.CloudServiceNodeSelectEvent;
 import eu.cloudnetservice.node.network.listener.message.ServiceChannelMessageListener;
@@ -50,6 +53,8 @@ import lombok.NonNull;
 @Singleton
 @Provides(CloudServiceFactory.class)
 public class NodeCloudServiceFactory implements CloudServiceFactory {
+
+  private static final Logger LOGGER = LogManager.logger(NodeCloudServiceFactory.class);
 
   private final EventManager eventManager;
   private final CloudServiceManager serviceManager;
@@ -128,10 +133,10 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
             "head_node_to_node_start_service",
             nodeServer.info().uniqueId(),
             serviceConfiguration);
+
+          // process the service creation result and return it if the creation was successful
+          createResult = this.processServiceStartResponse(createResult, nodeServer);
           if (createResult.state() == ServiceCreateResult.State.CREATED) {
-            // register the service locally in case the registration packet was not sent before a response to this
-            // packet was received
-            this.serviceManager.handleServiceUpdate(createResult.serviceInfo(), nodeServer.channel());
             return createResult;
           }
 
@@ -140,9 +145,12 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
             maybeServiceConfiguration.retryConfiguration(),
             serviceConfiguration);
         } else {
-          // start on the current node
-          var serviceInfo = this.serviceManager.createLocalCloudService(serviceConfiguration).serviceInfo();
-          return ServiceCreateResult.created(serviceInfo);
+          // start on the current node & publish the service snapshot to all components
+          var createdService = this.serviceManager.createLocalCloudService(serviceConfiguration);
+          createdService.handleServiceRegister();
+
+          // construct the create result
+          return ServiceCreateResult.created(createdService.serviceInfo());
         }
       } finally {
         this.serviceCreationLock.unlock();
@@ -153,6 +161,45 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
         "node_to_head_start_service",
         this.nodeServerProvider.headNode().info().uniqueId(),
         maybeServiceConfiguration);
+    }
+  }
+
+  protected @NonNull ServiceCreateResult processServiceStartResponse(
+    @NonNull ServiceCreateResult result,
+    @NonNull NodeServer associatedNode
+  ) {
+    // if the service creation failed we don't need to check anything
+    if (result.state() != ServiceCreateResult.State.CREATED) {
+      return result;
+    }
+
+    // check if the node is still connected
+    var nodeChannel = associatedNode.channel();
+    if (nodeChannel == null || !associatedNode.available()) {
+      LOGGER.fine(
+        "Unable to register service on node %s as the node is no longer connected",
+        null,
+        associatedNode.info().uniqueId());
+      return ServiceCreateResult.FAILED;
+    }
+
+    // try to register the created service locally
+    var serviceUniqueId = result.serviceInfo().serviceId().uniqueId();
+    var serviceProvider = this.serviceManager.registerService(result.serviceInfo(), nodeChannel);
+    if (serviceProvider != null) {
+      // service registered successfully, publish the associated service info
+      this.sendServiceRegisterResult(
+        "head_node_to_node_finish_service_registration",
+        associatedNode.info().uniqueId(),
+        serviceUniqueId);
+      return result;
+    } else {
+      // force the service unregister on the node
+      this.sendServiceRegisterResult(
+        "head_node_to_node_force_remove_service",
+        associatedNode.info().uniqueId(),
+        serviceUniqueId);
+      return ServiceCreateResult.FAILED;
     }
   }
 
@@ -169,12 +216,22 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
       .buffer(DataBuf.empty().writeObject(configuration))
       .build()
       .sendSingleQueryAsync()
-      .get(5, TimeUnit.SECONDS, null);
+      .get(20, TimeUnit.SECONDS, null);
 
     // read the result service info from the buffer, if the there was no response then we need to fail (only the head
     // node should queue start requests)
     var createResult = result == null ? null : result.content().readObject(ServiceCreateResult.class);
     return Objects.requireNonNullElse(createResult, ServiceCreateResult.FAILED);
+  }
+
+  protected void sendServiceRegisterResult(@NonNull String message, @NonNull String node, @NonNull UUID serviceId) {
+    ChannelMessage.builder()
+      .target(ChannelMessageTarget.Type.NODE, node)
+      .message(message)
+      .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
+      .buffer(DataBuf.empty().writeUniqueId(serviceId))
+      .build()
+      .send();
   }
 
   protected @NonNull ServiceCreateResult scheduleCreateRetryIfEnabled(


### PR DESCRIPTION
### Motivation
The current handling of service starts has a small issue in the way services are started:
```mermaid
flowchart TB
  A["Head Node"] -->|Start Request| B["Node to start on"]
  B -- Create Result --> A
  B -->|Publish| C["All other components"]
```

The head node waits for the node to start the service for 5 seconds, and if nothing happended will try to re-create the service or continue with the normal ticking (which might trigger a new service start try). However, the remote node is unaware that the service creation timed out and will still register the service locally and publish its info the cluster, which might lead to duplicate service creations.

### Modification
The new system is more aware of delays and handles the creation mistakes much better:
```mermaid
flowchart TB
  A1["Head Node"] -->Z1["Start request with timeout (20 seconds)"]
  Z1-->|To target node| A2
  C1["Head Node Register Try"]
  C1 -->|"Success (Send by Head Node to Target Node)"| D2
  C1 -->|Failure| G2
  Z1 -->|Timeout| G2
  C2-.->|"TTL exceeded"| G2

  A2["Request received"]-->B2["Service created"]-->C2["Register to waiting services (TTL: 1 Minute)"]-->|Responds with Create Result| C1
  D2["Removal from unaccepted services"]
  D2-->|Success| E2["Register as local Service"]
  D2-->|TTL exceeded| H2["Unregister from Head Node"]
  G2["Auto remove"]

  E2-->|Publish of Service Info| F2["All other components"]
```

With that way the head node takes full control over service creations and no longer allows a node to do things independent from the head node. That allows us to ensure that service registrations in the cluster happen once, and only once without any side effects for later service starts which are requested by the head node.

### Result
Services should no longer get registered as "ghosts" but only fully controlled by the head node, and removed properly in case a service creation timeout occurs.

##### Other context
Fixes #994
