### PR TITLE
fix: use concurrent queue for default installation setups

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultInstallation.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultInstallation.java
@@ -25,13 +25,14 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.LinkedList;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.LockSupport;
 import lombok.NonNull;
 
 @Singleton
 public final class DefaultInstallation {
 
-  private final Queue<Class<? extends DefaultSetup>> setups = new LinkedList<>();
+  private final Queue<Class<? extends DefaultSetup>> setups = new ConcurrentLinkedQueue<>();
 
   private final Console console;
   private final EventManager eventManager;


### PR DESCRIPTION
### Motivation
If the instantiation of a setup causes the creation and registration of another setup we run into concurrency issues as our queue is not thread safe.

### Modification
Replaced the LinkedList with a ConcurrentLinkedQueue.

### Result
All setups are registered and executed even if the setup is created as an 

##### Other context
Fixes #1083
