### PR TITLE
chore: bump checkstyle to 10.6.0

### DIFF
--- a/build-extensions/src/main/kotlin/Versions.kt
+++ b/build-extensions/src/main/kotlin/Versions.kt
@@ -21,5 +21,5 @@ object Versions {
   const val cloudNetCodeName = "Blizzard"
 
   // external tools
-  const val checkstyleTools = "10.3.4"
+  const val checkstyleTools = "10.6.0"
 }


### PR DESCRIPTION
### Motivation
Checkstyle is not automatically updated by renovate and wasn't updated for a few minor releases and we should do that.

### Modification
Update checkstyle to 10.6.0.

### Result
Checkstyle is up-to-date.