### PR TITLE
chore: improve and fixup connection handling between nodes

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -409,6 +409,21 @@ public final class Node {
 
   @Inject
   @Order(650)
+  private void registerDefaultCommands(@NonNull CommandProvider commandProvider, @NonNull Console console) {
+    // register the default commands
+    LOGGER.info(I18n.trans("start-commands"));
+    commandProvider.registerDefaultCommands();
+    commandProvider.registerConsoleHandler(console);
+  }
+
+  @Inject
+  @Order(700)
+  private void startModules(@NonNull ModuleProvider moduleProvider) {
+    moduleProvider.startAll();
+  }
+
+  @Inject
+  @Order(750)
   private void requestClusterDataIfNeeded(@NonNull NodeServerProvider nodeServerProvider) {
     // we are now connected to all nodes - request the full cluster data set if the head node is not the current one
     if (!nodeServerProvider.localNode().head()) {
@@ -420,21 +435,6 @@ public final class Node {
         .build()
         .send();
     }
-  }
-
-  @Inject
-  @Order(700)
-  private void registerDefaultCommands(@NonNull CommandProvider commandProvider, @NonNull Console console) {
-    // register the default commands
-    LOGGER.info(I18n.trans("start-commands"));
-    commandProvider.registerDefaultCommands();
-    commandProvider.registerConsoleHandler(console);
-  }
-
-  @Inject
-  @Order(750)
-  private void startModules(@NonNull ModuleProvider moduleProvider) {
-    moduleProvider.startAll();
   }
 
   @Inject

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultNodeServerProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultNodeServerProvider.java
@@ -34,8 +34,6 @@ import eu.cloudnetservice.node.cluster.LocalNodeServer;
 import eu.cloudnetservice.node.cluster.NodeServer;
 import eu.cloudnetservice.node.cluster.NodeServerProvider;
 import eu.cloudnetservice.node.cluster.sync.DataSyncRegistry;
-import eu.cloudnetservice.node.cluster.task.LocalNodeUpdateTask;
-import eu.cloudnetservice.node.cluster.task.NodeDisconnectTrackerTask;
 import eu.cloudnetservice.node.network.listener.message.NodeChannelMessageListener;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -45,9 +43,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -60,28 +55,11 @@ public class DefaultNodeServerProvider implements NodeServerProvider {
   private final LocalNodeServer localNode;
   private final Collection<NodeServer> nodeServers;
 
-  private final LocalNodeUpdateTask localNodeUpdateTask;
-  private final NodeDisconnectTrackerTask disconnectTrackerTask;
-
-  // this executor handles everything which is needed for the cluster to work properly
-  // as we normally scheduled 2 tasks (1 to send a local node update regularly, 1 to keep track of node disconnects), the
-  // core pool size is set to 2
-  private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
-
   private volatile NodeServer headNode;
 
   @Inject
-  public DefaultNodeServerProvider(
-    @NonNull LocalNodeServer localNode,
-    @NonNull DataSyncRegistry dataSyncRegistry,
-    @NonNull LocalNodeUpdateTask localNodeUpdateTask,
-    @NonNull NodeDisconnectTrackerTask disconnectTrackerTask
-  ) {
+  public DefaultNodeServerProvider(@NonNull LocalNodeServer localNode, @NonNull DataSyncRegistry dataSyncRegistry) {
     this.dataSyncRegistry = dataSyncRegistry;
-    this.localNodeUpdateTask = localNodeUpdateTask;
-    this.disconnectTrackerTask = disconnectTrackerTask;
-
-    // create and register the local node server
     this.localNode = localNode;
     this.nodeServers = new HashSet<>();
   }
@@ -93,10 +71,6 @@ public class DefaultNodeServerProvider implements NodeServerProvider {
 
     // register the listener for node channel messages
     eventManager.registerListener(NodeChannelMessageListener.class);
-
-    // start all update tasks
-    this.executor.scheduleAtFixedRate(this.localNodeUpdateTask, 1, 1, TimeUnit.SECONDS);
-    this.executor.scheduleAtFixedRate(this.disconnectTrackerTask, 5, 5, TimeUnit.SECONDS);
   }
 
   @Override
@@ -258,6 +232,5 @@ public class DefaultNodeServerProvider implements NodeServerProvider {
     });
     // re-select the head node in case some api stored an instance of this class
     this.selectHeadNode();
-    this.executor.shutdownNow();
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultNodeServerProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultNodeServerProvider.java
@@ -16,10 +16,10 @@
 
 package eu.cloudnetservice.node.cluster.defaults;
 
-import dev.derklaro.aerogel.PostConstruct;
 import dev.derklaro.aerogel.auto.Provides;
 import eu.cloudnetservice.common.concurrent.Task;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
+import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.driver.network.NetworkChannel;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
@@ -36,6 +36,7 @@ import eu.cloudnetservice.node.cluster.NodeServerProvider;
 import eu.cloudnetservice.node.cluster.sync.DataSyncRegistry;
 import eu.cloudnetservice.node.cluster.task.LocalNodeUpdateTask;
 import eu.cloudnetservice.node.cluster.task.NodeDisconnectTrackerTask;
+import eu.cloudnetservice.node.network.listener.message.NodeChannelMessageListener;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.io.InputStream;
@@ -85,10 +86,13 @@ public class DefaultNodeServerProvider implements NodeServerProvider {
     this.nodeServers = new HashSet<>();
   }
 
-  @PostConstruct
-  private void finishConstruction() {
+  @Inject
+  private void finishConstruction(@NonNull EventManager eventManager) {
     // register the local node server
     this.nodeServers.add(this.localNode);
+
+    // register the listener for node channel messages
+    eventManager.registerListener(NodeChannelMessageListener.class);
 
     // start all update tasks
     this.executor.scheduleAtFixedRate(this.localNodeUpdateTask, 1, 1, TimeUnit.SECONDS);

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeClusterNodeProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeClusterNodeProvider.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.node.provider;
 import dev.derklaro.aerogel.auto.Provides;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.command.CommandInfo;
-import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.cluster.NetworkClusterNode;
 import eu.cloudnetservice.driver.network.cluster.NodeInfoSnapshot;
@@ -33,7 +32,6 @@ import eu.cloudnetservice.node.command.CommandProvider;
 import eu.cloudnetservice.node.command.source.CommandSource;
 import eu.cloudnetservice.node.command.source.DriverCommandSource;
 import eu.cloudnetservice.node.config.Configuration;
-import eu.cloudnetservice.node.network.listener.message.NodeChannelMessageListener;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.Collection;
@@ -63,13 +61,6 @@ public class NodeClusterNodeProvider implements ClusterNodeProvider {
 
     // add the rpc handler
     rpcFactory.newHandler(ClusterNodeProvider.class, this).registerTo(handlerRegistry);
-  }
-
-  @Inject
-  private void registerChannelMessageListener(@NonNull EventManager eventManager) {
-    // we do this in post as the listener needs the instance of this class, doing it here prevents
-    // the construction of a runtime proxy while creating the instance
-    eventManager.registerListener(NodeChannelMessageListener.class);
   }
 
   @Override


### PR DESCRIPTION
### Motivation
In the current scenario there are two issues with the current node connect handling during the initial startup:
 * The node information of running nodes is not received properly during the startup due to the listener for node updates being registered after the connection process completed
 * For each node connection that we're waiting for a new thread is spawned that just busy waits until the connection is established

### Modification
To fix the first issue, the listener registration was just moved to the NodeServerProvider which is constructed for the node connection process and member injection is executed before the instance is used for the first time. In the old scenario, the handler gets registered by the NodeClusterNodeProvider which is constructed and first used **after** the connection process and therefore the listener was not yet present.

The second issue is fixed by registering all node connections that we need to wait for to a collection and just block the current thread until either:
 * all node connections are established successfully
 * a timeout of 7 seconds is reached
This prevents excessive use of threads (depending on the number of nodes) that the method previously used.

### Result
Connection to nodes in the cluster works again correctly without waiting the full 7 seconds during startup, and there is no longer a thread spawned for each node connection that we're waiting on.
