### PR TITLE
[ci skip] chore: update bug issue template & remove exploit report link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
       label: Stacktrace
       description: |
         Attach your stack trace here (if any). Ensure that the stack trace is related to CloudNet
-        and do not cut off any parts of it. Please put your stacktrace either directly into the text 
+        and do not cut off any parts of it. Please put your stacktrace either directly into the text
         field or use https://gist.new for stack traces. Some providers are deleting pastes after some
         time, so please stick to raw logs or gists. DO NOT use attachments for posting logs or exceptions.
       value: |

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,8 +16,9 @@ body:
       label: Stacktrace
       description: |
         Attach your stack trace here (if any). Ensure that the stack trace is related to CloudNet
-        and do not cut off any parts of it. We're prefering pastes over raw stack traces, for exaple
-        via https://gist.new. DO NOT use attachments for posting logs or exceptions.
+        and do not cut off any parts of it. Please put your stacktrace either directly into the text 
+        field or use https://gist.new for stack traces. Some providers are deleting pastes after some
+        time, so please stick to raw logs or gists. DO NOT use attachments for posting logs or exceptions.
       value: |
         ```
         Paste your paste link or the raw stack trace here. DO NOT REMOVE THE BACKTICKS!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,8 +5,3 @@ contact_links:
     about: |
       If you need general support on CloudNet, you should use our Discord server. We and the community can help you
       help you there faster and more targeted.
-  - name: Exploit Report
-    url: https://discord.cloudnetservice.eu
-    about: |
-      GitHub has currently no way for private issues. Please join our discord server and open a ticket there if you
-      found a securitly vulnerability.


### PR DESCRIPTION
### Motivation
We got some bug reports which have stacktraces from hastebin attached. These links are no longer working as they get removed after some time.

### Modification
* Explicitly mention that the stacktrace should either be posted directly into the issue or via github gist instead of using any other third party paste provider
* Remove the "Exploit Report" link from the new issue page as github now allows private issues to report security vulnerabilities

### Result
Hopefully no more dead stacktrace links.
