### PR TITLE
fix: add missing overrides for PlayerProvider methods on platforms

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerManager.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerManager.java
@@ -48,6 +48,24 @@ abstract class PlatformPlayerManager implements PlayerManager {
   }
 
   @Override
+  public @NonNull PlayerProvider taskOnlinePlayers(@NonNull String task) {
+    return sender.factory().generateRPCChainBasedApi(
+      sender,
+      PlayerProvider.class,
+      GenerationContext.forClass(PlayerProvider.class).build()
+    ).newRPCOnlyInstance(task);
+  }
+
+  @Override
+  public @NonNull PlayerProvider groupOnlinePlayers(@NonNull String group) {
+    return sender.factory().generateRPCChainBasedApi(
+      sender,
+      PlayerProvider.class,
+      GenerationContext.forClass(PlayerProvider.class).build()
+    ).newRPCOnlyInstance(group);
+  }
+
+  @Override
   public @NonNull PlayerExecutor globalPlayerExecutor() {
     return this.globalPlayerExecutor;
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerManager.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/PlatformPlayerManager.java
@@ -49,8 +49,8 @@ abstract class PlatformPlayerManager implements PlayerManager {
 
   @Override
   public @NonNull PlayerProvider taskOnlinePlayers(@NonNull String task) {
-    return sender.factory().generateRPCChainBasedApi(
-      sender,
+    return this.sender.factory().generateRPCChainBasedApi(
+      this.sender,
       PlayerProvider.class,
       GenerationContext.forClass(PlayerProvider.class).build()
     ).newRPCOnlyInstance(task);
@@ -58,8 +58,8 @@ abstract class PlatformPlayerManager implements PlayerManager {
 
   @Override
   public @NonNull PlayerProvider groupOnlinePlayers(@NonNull String group) {
-    return sender.factory().generateRPCChainBasedApi(
-      sender,
+    return this.sender.factory().generateRPCChainBasedApi(
+      this.sender,
       PlayerProvider.class,
       GenerationContext.forClass(PlayerProvider.class).build()
     ).newRPCOnlyInstance(group);


### PR DESCRIPTION
### Motivation
The base implementation of the platform player manager is not overriding the methods which are returning a player provider, causing exceptions when trying to call them as rpc is unable to serialize the return type of the node.

### Modification
Override the missing methods which are returning player provider instances.

### Result
No more exceptions when using the player manager to get a player provider instance.

##### Other context
Fixes #983
