### PR TITLE
chore: small improvement for platform inject annotation processing

### DIFF
--- a/ext/platform-inject-support/processor/build.gradle.kts
+++ b/ext/platform-inject-support/processor/build.gradle.kts
@@ -14,19 +14,8 @@
  * limitations under the License.
  */
 
-repositories {
-  maven("https://repo.md-5.net/repository/releases/")
-  maven("https://repo.waterdog.dev/artifactory/main/")
-  maven("https://repo.opencollab.dev/maven-snapshots/")
-  maven("https://repo.papermc.io/repository/maven-public/")
-  maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
-}
-
 dependencies {
-  "compileOnly"(libs.bundles.proxyPlatform)
-  "compileOnly"(libs.bundles.serverPlatform)
-
-  "implementation"(libs.javapoet)
-  "implementation"(libs.bundles.nightConfig)
-  "implementation"(projects.ext.platformInjectSupport.platformInjectApi)
+  "api"(libs.javapoet)
+  "api"(libs.bundles.nightConfig)
+  "api"(projects.ext.platformInjectSupport.platformInjectApi)
 }

--- a/ext/platform-inject-support/processor/build.gradle.kts
+++ b/ext/platform-inject-support/processor/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-  "api"(libs.javapoet)
-  "api"(libs.bundles.nightConfig)
-  "api"(projects.ext.platformInjectSupport.platformInjectApi)
+  "implementation"(libs.javapoet)
+  "implementation"(libs.bundles.nightConfig)
+  "implementation"(projects.ext.platformInjectSupport.platformInjectApi)
 }


### PR DESCRIPTION
### Motivation
The current processor module has all dependencies for server and proxy platforms available, but they are not required in the module, and can lead to issues when thinking that these dependencies are actually available for usage.
Most issues reported on the discord were caused by a missing implementation of the new PlatformEntrypoint interface, so we shoud ensure that the interface is actually implemented.

### Modification
* remove all proxy and server platform dependencies
* add a check if the annotated main class is implemented the PlatformEntrypoint interface

### Result
No more accidental usage of platform api in the processor module, and no more main classes that do not implement the PlatformEntrypoint class.
