### PR TITLE
fix: use the correct allowed char ranges for fabric mod ids

### DIFF
--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPluginInfoGenerator.java
@@ -31,14 +31,19 @@ import lombok.NonNull;
 
 final class FabricPluginInfoGenerator extends NightConfigInfoGenerator {
 
-  // https://fabricmc.net/wiki/documentation:fabric_mod_json#mandatory_fields
+  // [a-z][a-z0-9-_]{1,63}
   private static final PluginIdGenerator MOD_ID_GENERATOR = PluginIdGenerator.withBoundedLength(1, 63)
     .registerRange(
       0,
+      1,
+      'a',
+      CharRange.range('a', 'z'))
+    .registerRange(
+      1,
       '_',
       CharRange.range('_'),
+      CharRange.range('-'),
       CharRange.range('a', 'z'),
-      CharRange.range('A', 'Z'),
       CharRange.range('0', '9'));
 
   public FabricPluginInfoGenerator() {


### PR DESCRIPTION
### Motivation
The current fabric platform generator is generating invalid mod ids due to a too permissive mod id description in the fabric wiki.

### Modification
Ensure that the mod id is matching the actual mod id pattern `[a-z][a-z0-9-_]{1,63}` of fabric (taken from the [MetadataVerifier](https://github.com/FabricMC/fabric-loader/blob/2a378f1c563b6ec96ae6620a278ecd23fa09da0f/src/main/java/net/fabricmc/loader/impl/metadata/MetadataVerifier.java#L36))

### Result
Mod ids for fabric are now generated correctly and no longer cause a startup crash.

##### Other context
Fixes #1102
