### PR TITLE
fix: don't use a client query parameter for ORDER BY field

### DIFF
--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabase.java
@@ -224,7 +224,7 @@ public final class MySQLDatabase extends SQLDatabase {
   @Override
   public @Nullable Map<String, JsonDocument> readChunk(long beginIndex, int chunkSize) {
     return this.databaseProvider.executeQuery(
-      String.format("SELECT * FROM `%s` ORDER BY ? LIMIT ? OFFSET ?;", this.name),
+      String.format("SELECT * FROM `%s` ORDER BY `%s` LIMIT ? OFFSET ?;", this.name, TABLE_COLUMN_KEY),
       resultSet -> {
         Map<String, JsonDocument> result = new HashMap<>();
         while (resultSet.next()) {
@@ -234,7 +234,7 @@ public final class MySQLDatabase extends SQLDatabase {
         }
 
         return result.isEmpty() ? null : result;
-      }, null, TABLE_COLUMN_KEY, chunkSize, beginIndex);
+      }, null, chunkSize, beginIndex);
   }
 
   @Override


### PR DESCRIPTION
### Motivation
The current SQL query to read chunks of data from the database uses a query parameter for the field to order by. To understand the issue that this causes, a small understanding how a query is executed is required:
1. The call the `prepareStatement` is made
2. Some internal pre-parsing happens, then the query is submitted to the mysql server which does some preprocessing and responds with information about the query. This information contains:
   1. The number of query fields that the client is supposed to send
   2. The number of response fields that the server will respond with
   3. The information about the query fields
   4. The information about the response fields
3. The client driver reads the counts from the response and then the information about the response fields based on the supplied counts. Here comes the issue: while the MySQL server understands that a query field should be send for the order by field, the server is not sending any information about the field to the client. This causes the client to read the (as the server responsed with) 3 query fields, but the server only sends 2 query field information (for limit and offset). That means that the first response field is parsed as a query field, and when the client tries to read the information about the response fields, it will wait forever for the fifth field information, as the server only send four.

### Modification
Instead of using a query parameter for the key the name of the field is directly inserted within the string.format call, removing the need to the query parameter.

### Result
The MySQL database no longer wait infinitely for a field information packet to arrive, which never gets send by the server.
