### PR TITLE
fix: register missing database provider rpc handler

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -239,7 +239,9 @@ public final class Node {
   private void initializeDatabaseProvider(
     @NonNull Configuration configuration,
     @NonNull ServiceRegistry serviceRegistry,
-    @NonNull InjectionLayer<?> bootLayer
+    @NonNull InjectionLayer<?> bootLayer,
+    @NonNull RPCFactory rpcFactory,
+    @NonNull RPCHandlerRegistry rpcHandlerRegistry
   ) throws Exception {
     // initialize the default database provider
     var configuredProvider = configuration.properties().getString("database_provider", "xodus");
@@ -259,6 +261,9 @@ public final class Node {
       .bindAll(DatabaseProvider.class, NodeDatabaseProvider.class)
       .toInstance(provider);
     bootLayer.install(binding);
+
+    // register the rpc handler for the database provider
+    rpcFactory.newHandler(DatabaseProvider.class, provider).registerTo(rpcHandlerRegistry);
 
     // notify the user about the selected database
     LOGGER.info(I18n.trans("start-connect-database", provider.name()));


### PR DESCRIPTION
### Motivation
During the switch to dependency injection, the database provider rpc handler was no longer registered to the handler factory by accident. This is causing timeout exceptions when trying to access the database provider from the wrapper via rpc.

### Modification
Register the database provider rpc handler again.

### Result
No more timeout exceptions when calling the database provider from the wrapper.
