### PR TITLE
[ci skip] ci: automatically remove deleted branches from launchermeta

### DIFF
--- a/.github/workflows/delete-launchermeta-branch.yml
+++ b/.github/workflows/delete-launchermeta-branch.yml
@@ -1,0 +1,28 @@
+name: Remove deleted branch from launchermeta
+on:
+  delete:
+
+jobs:
+  print_deleted:
+    runs-on: ubuntu-latest
+    name: Remove deleted branch
+    if: github.event.ref_type == 'branch'
+
+    steps:
+      - name: Setup ssh agent
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Delete branch from launchermeta
+        run: |
+          # init git configuration
+          git config --global user.name "CloudNetAutomation";
+          git config --global user.email "CloudNetAutomation@users.noreply.github.com";
+
+          # clone the repo from the remote, without objects (partial clone)
+          git clone --filter=blob:none --no-checkout git@github.com:CloudNetService/launchermeta.git del_temp;
+
+          # navigate into the cloned repo and remove the delete branch (while ignoring all errors)
+          cd del_temp;
+          git push origin --delete "${{ github.event.ref }}" || true;

--- a/.github/workflows/delete-launchermeta-branch.yml
+++ b/.github/workflows/delete-launchermeta-branch.yml
@@ -3,7 +3,7 @@ on:
   delete:
 
 jobs:
-  print_deleted:
+  remove_deleted_branch:
     runs-on: ubuntu-latest
     name: Remove deleted branch
     if: github.event.ref_type == 'branch'


### PR DESCRIPTION
### Motivation
At the moment there are a lot of unused branches in the launchermeta repo as there is no automatical delete happening when the development on the branch in this repo finishes and the branch gets deleted.

### Modification
Add an action that catches deletions of branches and automatically deletes them from the launchermeta repo as well.

### Result
No more unused branches in the launchermeta repo that need to be removed manually.
