### PR TITLE
fix: the server selector types provide the correct comparators

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/ServerSelectorType.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/ServerSelectorType.java
@@ -30,19 +30,17 @@ import lombok.NonNull;
 public enum ServerSelectorType {
 
   /**
-   * The service with the highest player count is preferred.
-   */
-  HIGHEST_PLAYERS(Comparator.comparingInt(o -> o.propertyOr(BridgeServiceProperties.ONLINE_COUNT, 0))),
-  /**
    * The service with the lowest player count is preferred.
    */
-  LOWEST_PLAYERS((o1, o2) -> Integer.compare(
-    o2.propertyOr(BridgeServiceProperties.ONLINE_COUNT, 0),
-    o1.propertyOr(BridgeServiceProperties.ONLINE_COUNT, 0))),
+  LOWEST_PLAYERS(Comparator.comparingInt(ser -> ser.propertyOr(BridgeServiceProperties.ONLINE_COUNT, 0))),
+  /**
+   * The service with the highest player count is preferred.
+   */
+  HIGHEST_PLAYERS(LOWEST_PLAYERS.comparator.reversed()),
   /**
    * A random service is chosen.
    */
-  RANDOM(Comparator.comparingInt(value -> ThreadLocalRandom.current().nextInt(2) - 1));
+  RANDOM(Comparator.comparingInt(value -> ThreadLocalRandom.current().nextInt(-1, 2)));
 
   private final Comparator<ServiceInfoSnapshot> comparator;
 


### PR DESCRIPTION
### Motivation
The server selector types were not sorting how they are supposed to. The HIGHEST_PLAYERS comparator would sort for the lowerst players and vice-versa.

### Modification
Inverted the comparison order by switching the comparator of the HIGHEST_PLAYERS to the LOWEST_PLAYERS and using Comparator#reversed

### Result
The comparators provide the correct comparison result