### PR TITLE
chore: remove ip address scope when checking if an ip address is whitelisted

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/network/DefaultNetworkServerChannelHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/DefaultNetworkServerChannelHandler.java
@@ -132,7 +132,7 @@ public final class DefaultNetworkServerChannelHandler implements NetworkChannelH
 
   private boolean shouldDenyConnection(@NonNull NetworkChannel channel) {
     var ipWhitelist = this.configuration.ipWhitelist();
-    var sourceClientAddress = channel.clientAddress().host();
+    var sourceClientAddress = NetworkUtil.removeAddressScope(channel.clientAddress().host());
 
     // check if any address added to the ip whitelist matches the source client address
     for (var allowedIpAddress : ipWhitelist) {

--- a/node/src/main/java/eu/cloudnetservice/node/network/DefaultNetworkServerChannelHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/DefaultNetworkServerChannelHandler.java
@@ -33,6 +33,7 @@ import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.network.listener.PacketClientAuthorizationListener;
 import eu.cloudnetservice.node.service.CloudService;
 import eu.cloudnetservice.node.service.CloudServiceManager;
+import eu.cloudnetservice.node.util.NetworkUtil;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -130,6 +131,18 @@ public final class DefaultNetworkServerChannelHandler implements NetworkChannelH
   }
 
   private boolean shouldDenyConnection(@NonNull NetworkChannel channel) {
-    return this.configuration.ipWhitelist().stream().noneMatch(channel.clientAddress().host()::equals);
+    var ipWhitelist = this.configuration.ipWhitelist();
+    var sourceClientAddress = channel.clientAddress().host();
+
+    // check if any address added to the ip whitelist matches the source client address
+    for (var allowedIpAddress : ipWhitelist) {
+      var allowedAddressWithoutScope = NetworkUtil.removeAddressScope(allowedIpAddress);
+      if (allowedAddressWithoutScope.equals(sourceClientAddress)) {
+        return false;
+      }
+    }
+
+    // no allowed ip found that matches the given client address
+    return true;
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
+++ b/node/src/main/java/eu/cloudnetservice/node/util/NetworkUtil.java
@@ -69,6 +69,19 @@ public final class NetworkUtil {
     return InetAddresses.forString(hostAndPort.host()).isAnyLocalAddress();
   }
 
+  public static @NonNull String removeAddressScope(@NonNull String inputAddress) {
+    // check if the host address contains '%' which separates the address
+    // from the associated network interface or scope id
+    var scopeSeparatorIndex = inputAddress.indexOf('%');
+    if (scopeSeparatorIndex != -1) {
+      // network if or scope set
+      return inputAddress.substring(0, scopeSeparatorIndex);
+    } else {
+      // raw address
+      return inputAddress;
+    }
+  }
+
   public static boolean checkAssignable(@NonNull HostAndPort hostAndPort) {
     try (var socket = new ServerSocket()) {
       // try to bind on the given address
@@ -159,14 +172,7 @@ public final class NetworkUtil {
     if (address instanceof Inet6Address) {
       // get the host address of the inet address
       var hostAddress = address.getHostAddress();
-      // check if the host address contains '%' which separates the address from the source adapter name
-      var percentile = hostAddress.indexOf('%');
-      if (percentile != -1) {
-        // strip the host address from the "full" address
-        hostAddress = hostAddress.substring(0, percentile);
-      }
-      // the "better" host address
-      return hostAddress;
+      return removeAddressScope(hostAddress);
     } else {
       // just add the address
       return address.getHostAddress();


### PR DESCRIPTION
### Motivation
At the moment the ip address scope of ipv6 addresses is required to be appended to the a whitelisted address, as the scope is added to the ip by default. While we're already removing the address scopes during the initial setup, we're not removing them when actually checking, leading to the issue that people need to find out and append the scope to addresses in the whitelist.

### Modification
Ensure that we strip the scope from addresses in the whitelist (to not break existing setups) and remove the scope from client addresses when checking.

### Result
The address scope is no longer taken into account when checking whether a client is allowed to connect to the node.

##### Other context
Fixes #965
