### PR TITLE
feat: add java 21 to the java version enum

### DIFF
--- a/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
+++ b/common/src/main/java/eu/cloudnetservice/common/JavaVersion.java
@@ -37,7 +37,8 @@ public enum JavaVersion {
   JAVA_17(17, 61D, "Java 17"),
   JAVA_18(18, 62D, "Java 18"),
   JAVA_19(19, 63D, "Java 19"),
-  JAVA_20(20, 64D, "Java 20");
+  JAVA_20(20, 64D, "Java 20"),
+  JAVA_21(21, 65D, "Java 21");
 
   private static final JavaVersion[] JAVA_VERSIONS = resolveActualJavaVersions();
   private static final JavaVersion LATEST_VERSION = JAVA_VERSIONS[JAVA_VERSIONS.length - 1];


### PR DESCRIPTION
### Motivation
Support Java 21 in our java version enum.

### Modification
Added the enum corresponding to JAVA 21

### Result
Java 21 is supported in our version checker

##### Other context
Fixes #1061 
