### PR TITLE
fix: offset the parameter index when generating rpc implementations for long types.

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/util/asm/StackIndexHelper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/util/asm/StackIndexHelper.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.util.asm;
+
+import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+/**
+ * A small helper class that helps keeping track of bytecode stack indices while pushing/loading from it.
+ *
+ * @since 4.0
+ */
+@ApiStatus.Internal
+public final class StackIndexHelper {
+
+  private int nextVarIndex;
+
+  /**
+   * Constructs a new stack index helper instance.
+   *
+   * @param initialVarIndex the initial var index for the first element to load/store from/to the stack.
+   */
+  private StackIndexHelper(int initialVarIndex) {
+    this.nextVarIndex = initialVarIndex;
+  }
+
+  /**
+   * Creates a new stack index helper which uses 0 as the initial index.
+   *
+   * @return a stack index helper that uses 0 as the initial index.
+   */
+  public static @NonNull StackIndexHelper create() {
+    return create(0);
+  }
+
+  /**
+   * Constructs a new stack index helper with the given initial var index.
+   *
+   * @param initialVarIndex the initial var index for the first element to load/store from/to the stack.
+   * @return a stack index helper that uses the given initial var index.
+   */
+  public static @NonNull StackIndexHelper create(int initialVarIndex) {
+    return new StackIndexHelper(initialVarIndex);
+  }
+
+  /**
+   * Skips the next (one) element of the current stack. This method implies that the next element has a size of one.
+   *
+   * @return this index helper, for chaining.
+   */
+  public @NonNull StackIndexHelper skipNext() {
+    return this.skip(1);
+  }
+
+  /**
+   * Skips the given amount of indices and uses the resulting value as the next var index to read/write from/to.
+   *
+   * @param depth the stack depth to skip.
+   * @return this index helper, for chaining.
+   */
+  public @NonNull StackIndexHelper skip(int depth) {
+    this.nextVarIndex += depth;
+    return this;
+  }
+
+  /**
+   * Stores an element of the given type on the stack using the appropriate opcode based on the given type and skips to
+   * the next var index based on the size of the type.
+   *
+   * @param methodVisitor the method visitor to notify about the store operation.
+   * @param type          the type to store on the stack.
+   * @return this index helper, for chaining.
+   * @throws NullPointerException if the given visitor or type is null.
+   */
+  public @NonNull StackIndexHelper push(@NonNull MethodVisitor methodVisitor, @NonNull Class<?> type) {
+    var internalType = Type.getType(type);
+    return this.push(methodVisitor, internalType);
+  }
+
+  /**
+   * Stores an element of the given type on the stack using the appropriate opcode based on the given type and skips to
+   * the next var index based on the size of the type.
+   *
+   * @param methodVisitor the method visitor to notify about the store operation.
+   * @param type          the type to store on the stack.
+   * @return this index helper, for chaining.
+   * @throws NullPointerException if the given visitor or type is null.
+   */
+  public @NonNull StackIndexHelper push(@NonNull MethodVisitor methodVisitor, @NonNull Type type) {
+    // store the element on the stack using the associated opcode
+    var opcode = type.getOpcode(Opcodes.ISTORE);
+    methodVisitor.visitVarInsn(opcode, this.nextVarIndex);
+
+    // skip to the next var index based on the size of the type
+    return this.skip(type.getSize());
+  }
+
+  /**
+   * Loads an element of the given type onto the stack using the appropriate opcode based on the given type and skips to
+   * the next var index based on the size of the type.
+   *
+   * @param methodVisitor the method visitor to notify about the load operation.
+   * @param type          the type to load from the stack.
+   * @return this index helper, for chaining.
+   * @throws NullPointerException if the given visitor or type is null.
+   */
+  public @NonNull StackIndexHelper load(@NonNull MethodVisitor methodVisitor, @NonNull Class<?> type) {
+    var internalType = Type.getType(type);
+    return this.load(methodVisitor, internalType);
+  }
+
+  /**
+   * Loads an element of the given type onto the stack using the appropriate opcode based on the given type and skips to
+   * the next var index based on the size of the type.
+   *
+   * @param methodVisitor the method visitor to notify about the load operation.
+   * @param type          the type to load from the stack.
+   * @return this index helper, for chaining.
+   * @throws NullPointerException if the given visitor or type is null.
+   */
+  public @NonNull StackIndexHelper load(@NonNull MethodVisitor methodVisitor, @NonNull Type type) {
+    // load the element from the stack using the associated opcode
+    var opcode = type.getOpcode(Opcodes.ILOAD);
+    methodVisitor.visitVarInsn(opcode, this.nextVarIndex);
+
+    // skip to the next var index based on the size of the type
+    return this.skip(type.getSize());
+  }
+}

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/RPCImplementationGeneratorTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/RPCImplementationGeneratorTest.java
@@ -92,4 +92,14 @@ public class RPCImplementationGeneratorTest {
     Assertions.assertInstanceOf(SenderNeedingManagement.class, management);
     Assertions.assertSame(((SenderNeedingManagement) management).sender, sender);
   }
+
+  @Test
+  void testGenerationOfMethods() {
+    var testInstance = ApiImplementationGenerator.generateApiImplementation(
+      TestRPCParameters.class,
+      GenerationContext.forClass(TestRPCParameters.class).implementAllMethods(true).build(),
+      Mockito.mock(RPCSender.class)
+    ).newInstance(1, 2L, "World", new int[0], new long[]{1L}, new String[]{"Hello"});
+    Assertions.assertNotNull(testInstance);
+  }
 }

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/TestRPCParameters.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/rpc/generation/api/TestRPCParameters.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.rpc.generation.api;
+
+public abstract class TestRPCParameters {
+
+  public TestRPCParameters(int a, long b, String c, int[] d, long[] e, String[] f) {
+  }
+
+  public abstract void testVoid();
+
+  public abstract void testString(String string);
+
+  public abstract void testInt(int i);
+
+  public abstract void testLong(long l);
+
+  public abstract void testFloat(float f);
+
+  public abstract void testDouble(double d);
+
+  public abstract void testBoolean(boolean b);
+
+  public abstract void testChar(char c);
+
+  public abstract void testByte(byte b);
+
+  public abstract void testShort(short s);
+
+  public abstract void testObject(Object o);
+
+  public abstract void testStringArray(String[] strings);
+
+  public abstract void testIntArray(int[] ints);
+
+  public abstract void testLongArray(long[] longs);
+
+  public abstract void testFloatArray(float[] floats);
+
+  public abstract void testDoubleArray(double[] doubles);
+
+  public abstract void testBooleanArray(boolean[] booleans);
+
+  public abstract void testCharArray(char[] chars);
+
+  public abstract void testByteArray(byte[] bytes);
+
+  public abstract void testShortArray(short[] shorts);
+
+  public abstract void testObjectArray(Object[] objects);
+
+  public abstract void testLongInt(long l, int i);
+
+  public abstract void testLongIntString(long l, int i, String s);
+
+  public abstract void testLongIntStringArray(long l, int i, String[] s);
+
+  public abstract void testLongIntStringObject(long l, int i, String s, Object o);
+
+  public abstract void testLongIntStringObjectArray(long l, int i, String s, Object[] o);
+}


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
See #1122

### Modification
This change fixes an issue with the code generation of RPC handler methods. Before this patch, RPC methods that used parameters of `long` or `double` types that had another parameter following that, would fail to generate valid code. The generated code would attempt to read the second half of the previous parameter as the current one. This would fail at the code validation step of the class definition and break plugins or modules.

### Result
When generating code for storing parameters that occupy two slots, the second half is skipped in order to properly read the next parameter.

You may undo the changes in https://github.com/CloudNetService/CloudNet-v3/blob/c73ffb665a572a3f362dee5b9b0667a5a243d0be/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ApiImplementationGenerator.java and verify that the test actually accomplishes its task.

Fixes #1122 
