### PR TITLE
build: resolve gradle 8 deprecation warning

### DIFF
--- a/wrapper-jvm/build.gradle.kts
+++ b/wrapper-jvm/build.gradle.kts
@@ -28,7 +28,7 @@ tasks.withType<ShadowJar> {
   val ignoredGroupIds = arrayOf("com.google.guava", "com.google.code.gson")
   dependencies {
     exclude {
-      it.moduleGroup != project.group && !ignoredGroupIds.contains(it.moduleGroup)
+      it.moduleGroup != rootProject.group && !ignoredGroupIds.contains(it.moduleGroup)
     }
   }
 


### PR DESCRIPTION
### Motivation
Gradle 8 emits a deprecation warning (and gradle 9 will fail) when using Task.getProject.

### Modification
Replace the task project access with a direct access to the root project as the module group information is shared between them.

### Result
No more build deprecation warning.
