### PR TITLE
feat: add event to modify a service configuration before creation

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceConfigurationPrePrepareEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceConfigurationPrePrepareEvent.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.node.event.service;
+
+import eu.cloudnetservice.driver.event.Event;
+import eu.cloudnetservice.driver.service.ServiceConfiguration;
+import eu.cloudnetservice.node.service.CloudServiceManager;
+import lombok.NonNull;
+
+/**
+ * An event that is called before the actual preparation (setting the service id, including group templates etc.) of a
+ * service configuration is done. This event is called in the last stage before the service gets created. The
+ * configuration can still be modified without the risk of causing configuration issues.
+ * <p>
+ * Note that this event is only called on the head node, as no other node is allowed to start services nor prepare the
+ * configuration for them.
+ *
+ * @since 4.0
+ */
+public final class CloudServiceConfigurationPrePrepareEvent extends Event {
+
+  private final CloudServiceManager cloudServiceManager;
+  private final ServiceConfiguration originalConfiguration;
+  private final ServiceConfiguration.Builder modifiableConfiguration;
+
+  /**
+   * Constructs a new cloud service configuration pre-prepare event instance.
+   *
+   * @param cloudServiceManager     the service manager which will keep track of the service after the creation.
+   * @param originalConfiguration   the configuration on which basis the service should get created.
+   * @param modifiableConfiguration a modifiable copy of the original configuration with no changes applied.
+   * @throws NullPointerException if the given service manager, original or modifiable configuration is null.
+   */
+  public CloudServiceConfigurationPrePrepareEvent(
+    @NonNull CloudServiceManager cloudServiceManager,
+    @NonNull ServiceConfiguration originalConfiguration,
+    @NonNull ServiceConfiguration.Builder modifiableConfiguration
+  ) {
+    this.cloudServiceManager = cloudServiceManager;
+    this.originalConfiguration = originalConfiguration;
+    this.modifiableConfiguration = modifiableConfiguration;
+  }
+
+  /**
+   * Get the service manager that will keep track of the service after creation.
+   *
+   * @return the service manager that will keep track of the service after creation.
+   */
+  public @NonNull CloudServiceManager cloudServiceManager() {
+    return this.cloudServiceManager;
+  }
+
+  /**
+   * Get the original, unmodifiable version of the service configuration which was passed in to create a service from.
+   *
+   * @return the original service configuration passed to create the service.
+   */
+  public @NonNull ServiceConfiguration originalConfiguration() {
+    return this.originalConfiguration;
+  }
+
+  /**
+   * Get a modifiable version of the original service configuration. Changes made to the configuration will reflect into
+   * the service creation process and take effect immediately.
+   *
+   * @return a modifiable copy of the original configuration which allows changes to be applied to it.
+   */
+  public @NonNull ServiceConfiguration.Builder modifiableConfiguration() {
+    return this.modifiableConfiguration;
+  }
+}

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/NodeCloudServiceFactory.java
@@ -35,6 +35,7 @@ import eu.cloudnetservice.driver.service.ServiceCreateResult;
 import eu.cloudnetservice.driver.service.ServiceCreateRetryConfiguration;
 import eu.cloudnetservice.node.cluster.NodeServer;
 import eu.cloudnetservice.node.cluster.NodeServerProvider;
+import eu.cloudnetservice.node.event.service.CloudServiceConfigurationPrePrepareEvent;
 import eu.cloudnetservice.node.event.service.CloudServiceNodeSelectEvent;
 import eu.cloudnetservice.node.network.listener.message.ServiceChannelMessageListener;
 import eu.cloudnetservice.node.service.CloudServiceManager;
@@ -96,10 +97,16 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
         // copy the configuration into a builder to prevent setting values on multiple objects which are then shared
         // over services which will eventually break the system
         var configurationBuilder = ServiceConfiguration.builder(maybeServiceConfiguration);
+        this.eventManager.callEvent(new CloudServiceConfigurationPrePrepareEvent(
+          this.serviceManager,
+          maybeServiceConfiguration,
+          configurationBuilder));
+
         // prepare the service configuration
         this.replaceServiceId(maybeServiceConfiguration, configurationBuilder);
         this.replaceServiceUniqueId(maybeServiceConfiguration, configurationBuilder);
         this.includeGroupComponents(maybeServiceConfiguration, configurationBuilder);
+
         // disable retries on the new configuration, we only schedule them based on the original one
         configurationBuilder.retryConfiguration(ServiceCreateRetryConfiguration.NO_RETRY);
 


### PR DESCRIPTION
### Motivation
There is currently no event that allows to modify a service configuration on the node (via a module) to change the configuration when required. This can for example be setting process parameters or environment variables.

### Modification
Add an event (`CloudServiceConfigurationPrePrepareEvent`) that holds the service configuration and the builder that is used to modify the service configuration in the cloud service factory. The event is called before the final modifications to the configuration are made (ensuring that the service id is only taken once, adding the templates, deployments, ... of the group components etc.). This ensures that no changes are made to the configuration which could potentially break the whole internal service handling.

### Result
The configuration of a service can be modified from a (head) node module.

##### Other context
Resolves #1074
