### PR TITLE
chore: add a channel initializer that only sets supported options

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyOptionSettingChannelInitializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyOptionSettingChannelInitializer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.netty;
+
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelOption;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A custom channel initializer implementation which activates option in the given channel during the initialization if
+ * they are supported by the implementation.
+ *
+ * @since 4.0
+ */
+@ApiStatus.Internal
+public class NettyOptionSettingChannelInitializer extends ChannelInitializer<Channel> {
+
+  private final Map<ChannelOption<?>, Object> options = new LinkedHashMap<>();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @SuppressWarnings("unchecked")
+  protected void initChannel(@NonNull Channel channel) throws Exception {
+    // set the channel options in the channel if they are supported
+    // this operation is not thread safe as we assume that all options are put into the map at this point
+    for (var optionEntry : this.options.entrySet()) {
+      var option = (ChannelOption<Object>) optionEntry.getKey();
+      if (channel.isOptionSupported(option)) {
+        channel.setOption(option, optionEntry.getValue());
+      }
+    }
+
+    // do further initialization to the channel
+    this.doInitChannel(channel);
+  }
+
+  /**
+   * Adds an option which should be activated in channels initialized by this initializer if it is supported.
+   *
+   * @param option the option to activate if supported.
+   * @param value  the value of the option.
+   * @param <T>    the type of the option value.
+   * @return this initializer instance, for chaining.
+   * @throws NullPointerException if the given option or value is null.
+   */
+  public @NonNull <T> NettyOptionSettingChannelInitializer option(@NonNull ChannelOption<T> option, @NonNull T value) {
+    this.options.put(option, value);
+    return this;
+  }
+
+  /**
+   * Method that gets called when the actual channel initialization finished and all requested channel options were
+   * activated in the channel. This channel removes the need for overriding classes to call {@code super.initChannel} in
+   * order to get all channel options activated.
+   *
+   * @param channel the channel to initialize.
+   * @throws Exception thrown if an error occurs during initialization.
+   */
+  protected void doInitChannel(@NonNull Channel channel) throws Exception {
+  }
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
@@ -130,15 +130,14 @@ public class NettyNetworkClient implements DefaultNetworkComponent, NetworkClien
     new Bootstrap()
       .group(this.eventLoopGroup)
       .channelFactory(NettyUtil.clientChannelFactory())
-      .handler(new NettyNetworkClientInitializer(hostAndPort, this.eventManager, this))
-
-      .option(ChannelOption.IP_TOS, 0x18)
-      .option(ChannelOption.AUTO_READ, true)
-      .option(ChannelOption.TCP_NODELAY, true)
-      .option(ChannelOption.SO_REUSEADDR, true)
-      .option(ChannelOption.TCP_FASTOPEN_CONNECT, true)
-      .option(ChannelOption.WRITE_BUFFER_WATER_MARK, WATER_MARK)
-      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECTION_TIMEOUT_MILLIS)
+      .handler(new NettyNetworkClientInitializer(hostAndPort, this.eventManager, this)
+        .option(ChannelOption.IP_TOS, 0x18)
+        .option(ChannelOption.AUTO_READ, true)
+        .option(ChannelOption.TCP_NODELAY, true)
+        .option(ChannelOption.SO_REUSEADDR, true)
+        .option(ChannelOption.TCP_FASTOPEN_CONNECT, true)
+        .option(ChannelOption.WRITE_BUFFER_WATER_MARK, WATER_MARK)
+        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECTION_TIMEOUT_MILLIS))
 
       .connect(hostAndPort.host(), hostAndPort.port())
       .addListener(future -> {

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClientInitializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClientInitializer.java
@@ -18,12 +18,12 @@ package eu.cloudnetservice.driver.network.netty.client;
 
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.network.HostAndPort;
+import eu.cloudnetservice.driver.network.netty.NettyOptionSettingChannelInitializer;
 import eu.cloudnetservice.driver.network.netty.codec.NettyPacketDecoder;
 import eu.cloudnetservice.driver.network.netty.codec.NettyPacketEncoder;
 import eu.cloudnetservice.driver.network.netty.codec.VarInt32FrameDecoder;
 import eu.cloudnetservice.driver.network.netty.codec.VarInt32FramePrepender;
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelInitializer;
 import lombok.NonNull;
 
 /**
@@ -31,7 +31,7 @@ import lombok.NonNull;
  *
  * @since 4.0
  */
-public class NettyNetworkClientInitializer extends ChannelInitializer<Channel> {
+public class NettyNetworkClientInitializer extends NettyOptionSettingChannelInitializer {
 
   protected final HostAndPort hostAndPort;
   protected final EventManager eventManager;
@@ -59,7 +59,7 @@ public class NettyNetworkClientInitializer extends ChannelInitializer<Channel> {
    * {@inheritDoc}
    */
   @Override
-  protected void initChannel(@NonNull Channel channel) {
+  protected void doInitChannel(@NonNull Channel channel) {
     if (this.nettyNetworkClient.sslContext != null) {
       channel.pipeline().addLast("ssl-handler", this.nettyNetworkClient.sslContext.newHandler(
         channel.bufferAllocator(),

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServerInitializer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServerInitializer.java
@@ -18,12 +18,12 @@ package eu.cloudnetservice.driver.network.netty.server;
 
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.network.HostAndPort;
+import eu.cloudnetservice.driver.network.netty.NettyOptionSettingChannelInitializer;
 import eu.cloudnetservice.driver.network.netty.codec.NettyPacketDecoder;
 import eu.cloudnetservice.driver.network.netty.codec.NettyPacketEncoder;
 import eu.cloudnetservice.driver.network.netty.codec.VarInt32FrameDecoder;
 import eu.cloudnetservice.driver.network.netty.codec.VarInt32FramePrepender;
 import io.netty5.channel.Channel;
-import io.netty5.channel.ChannelInitializer;
 import lombok.NonNull;
 
 /**
@@ -31,7 +31,7 @@ import lombok.NonNull;
  *
  * @since 4.0
  */
-public class NettyNetworkServerInitializer extends ChannelInitializer<Channel> {
+public class NettyNetworkServerInitializer extends NettyOptionSettingChannelInitializer {
 
   private final EventManager eventManager;
   private final HostAndPort serverLocalAddress;
@@ -59,7 +59,7 @@ public class NettyNetworkServerInitializer extends ChannelInitializer<Channel> {
    * {@inheritDoc}
    */
   @Override
-  protected void initChannel(@NonNull Channel ch) {
+  protected void doInitChannel(@NonNull Channel ch) {
     if (this.networkServer.sslContext != null) {
       ch.pipeline().addLast("ssl-handler", this.networkServer.sslContext.newHandler(ch.bufferAllocator()));
     }


### PR DESCRIPTION
### Motivation
Netty prints out a warning when trying to set channel options that are not supported by a transport (only for options added by the (server-) bootstrap). This is no big deal as the warning can be ignored, but there are some users which are reporting it as an issue.

### Modification
Add a new channel initializer that holds the options that should be added to a channel and only sets them if they are supported by the channel that gets initialized. This is the best way to solve the issue, as there is no other way to check if an option is supported. Although some options are bound to epoll or kqueue, it might get over complicated when checking based on that, especially considering the addition of the io_uring transport that is coming into netty main with the next release.

### Result
No more warnings that there was a try to set channel options that are not supported by the channel.