### PR TITLE
chore: replace usages of TypeToken with geantyref

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/MethodInformation.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/MethodInformation.java
@@ -16,11 +16,11 @@
 
 package eu.cloudnetservice.driver.network.rpc.defaults;
 
-import com.google.common.reflect.TypeToken;
 import eu.cloudnetservice.driver.network.rpc.annotation.RPCIgnore;
 import eu.cloudnetservice.driver.network.rpc.defaults.handler.invoker.MethodInvoker;
 import eu.cloudnetservice.driver.network.rpc.defaults.handler.invoker.MethodInvokerGenerator;
 import eu.cloudnetservice.driver.network.rpc.exception.CannotDecideException;
+import io.leangen.geantyref.GenericTypeReflector;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import lombok.NonNull;
@@ -67,7 +67,7 @@ public class MethodInformation {
     this.arguments = arguments;
     this.voidMethod = rType.equals(void.class);
     this.sourceInstance = sourceInstance;
-    this.rawReturnType = TypeToken.of(rType).getRawType();
+    this.rawReturnType = GenericTypeReflector.erase(rType);
     this.definingClass = definingClass;
     this.methodInvoker = generator == null ? null : generator.makeMethodInvoker(this);
   }
@@ -141,8 +141,8 @@ public class MethodInformation {
   }
 
   /**
-   * Get the raw return type of the underlying method. For example a method with a return type of {@code
-   * Collection&lt;String&gt;} would result in {@code Collection}.
+   * Get the raw return type of the underlying method. For example a method with a return type of
+   * {@code Collection&lt;String&gt;} would result in {@code Collection}.
    *
    * @return the raw return type of the method.
    */

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/invoker/MethodInvokerGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/handler/invoker/MethodInvokerGenerator.java
@@ -34,12 +34,12 @@ import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V1_8;
 
-import com.google.common.reflect.TypeToken;
 import eu.cloudnetservice.common.StringUtil;
 import eu.cloudnetservice.driver.network.rpc.defaults.MethodInformation;
 import eu.cloudnetservice.driver.network.rpc.exception.ClassCreationException;
 import eu.cloudnetservice.driver.util.asm.AsmHelper;
 import eu.cloudnetservice.driver.util.define.ClassDefiners;
+import io.leangen.geantyref.GenericTypeReflector;
 import lombok.NonNull;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
@@ -113,7 +113,7 @@ public class MethodInvokerGenerator {
         // visit each argument of the method
         var arguments = new Type[methodInfo.arguments().length];
         for (var i = 0; i < methodInfo.arguments().length; i++) {
-          var rawType = TypeToken.of(methodInfo.arguments()[i]).getRawType();
+          var rawType = GenericTypeReflector.erase(methodInfo.arguments()[i]);
           // load the argument supplied for the index
           mv.visitVarInsn(ALOAD, 1);
           AsmHelper.pushInt(mv, i);

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassInvokerGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassInvokerGenerator.java
@@ -33,7 +33,6 @@ import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V1_8;
 
-import com.google.common.reflect.TypeToken;
 import eu.cloudnetservice.common.StringUtil;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.rpc.annotation.RPCFieldGetter;
@@ -42,6 +41,7 @@ import eu.cloudnetservice.driver.network.rpc.exception.ClassCreationException;
 import eu.cloudnetservice.driver.network.rpc.object.ObjectMapper;
 import eu.cloudnetservice.driver.util.asm.AsmHelper;
 import eu.cloudnetservice.driver.util.define.ClassDefiners;
+import io.leangen.geantyref.GenericTypeReflector;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -148,7 +148,7 @@ public final class DataClassInvokerGenerator {
         var parameters = new Type[types.length];
         for (var i = 0; i < types.length; i++) {
           // extract the raw type of the given type
-          var rawType = TypeToken.of(types[i]).getRawType();
+          var rawType = GenericTypeReflector.erase(types[i]);
           // load the mapper, the data buf and the current class to the stack
           mv.visitVarInsn(ALOAD, 2);
           mv.visitVarInsn(ALOAD, 1);
@@ -287,7 +287,7 @@ public final class DataClassInvokerGenerator {
           var getter = fieldGetters.get(field);
           if (getter != null) {
             // extract all needed information from the method
-            rawType = TypeToken.of(getter.getGenericReturnType()).getRawType();
+            rawType = GenericTypeReflector.erase(getter.getGenericReturnType());
             var declaring = Type.getInternalName(getter.getDeclaringClass());
             // cast the object argument to the declaring class of the method
             mv.visitTypeInsn(CHECKCAST, declaring);
@@ -300,7 +300,7 @@ public final class DataClassInvokerGenerator {
               getter.getDeclaringClass().isInterface());
           } else {
             // extract all needed information from the field
-            rawType = TypeToken.of(field.getGenericType()).getRawType();
+            rawType = GenericTypeReflector.erase(field.getGenericType());
             var declaring = Type.getInternalName(field.getDeclaringClass());
             // cast the object argument to the declaring class of the field
             mv.visitTypeInsn(CHECKCAST, declaring);

--- a/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionGroup.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/permission/PermissionGroup.java
@@ -17,8 +17,8 @@
 package eu.cloudnetservice.driver.permission;
 
 import com.google.common.base.Preconditions;
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
+import io.leangen.geantyref.TypeFactory;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashMap;
@@ -38,7 +38,7 @@ import lombok.NonNull;
  */
 public class PermissionGroup extends AbstractPermissible {
 
-  public static final Type COL_GROUPS = TypeToken.getParameterized(Collection.class, PermissionGroup.class).getType();
+  public static final Type COL_GROUPS = TypeFactory.parameterizedClass(Collection.class, PermissionGroup.class);
 
   private final String color;
   private final String prefix;
@@ -51,8 +51,8 @@ public class PermissionGroup extends AbstractPermissible {
   private final Set<String> groups;
 
   /**
-   * Constructs a new permission group. The group is not saved or updated in any way before {@link
-   * PermissionManagement#addPermissionGroup(PermissionGroup)} is called.
+   * Constructs a new permission group. The group is not saved or updated in any way before
+   * {@link PermissionManagement#addPermissionGroup(PermissionGroup)} is called.
    *
    * @param color            the color of the group.
    * @param prefix           the prefix of the group.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceProperties.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceProperties.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.modules.bridge;
 import static eu.cloudnetservice.driver.service.property.JsonServiceProperty.createFromClass;
 import static eu.cloudnetservice.driver.service.property.JsonServiceProperty.createFromType;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.StringUtil;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
@@ -28,6 +27,7 @@ import eu.cloudnetservice.driver.service.property.FunctionalServiceProperty;
 import eu.cloudnetservice.driver.service.property.ServiceProperty;
 import eu.cloudnetservice.driver.service.property.TransformingServiceProperty;
 import eu.cloudnetservice.modules.bridge.player.ServicePlayer;
+import io.leangen.geantyref.TypeFactory;
 import java.util.Collection;
 import lombok.NonNull;
 
@@ -161,8 +161,7 @@ public final class BridgeServiceProperties {
    */
   public static final ServiceProperty<Collection<ServicePlayer>> PLAYERS = TransformingServiceProperty
     .<Collection<JsonDocument>, Collection<ServicePlayer>>wrap(
-      createFromType("Players", new TypeToken<Collection<JsonDocument>>() {
-      }.getType()))
+      createFromType("Players", TypeFactory.parameterizedClass(Collection.class, JsonDocument.class)))
     .modifyGet(($, documents) -> documents.stream().map(ServicePlayer::new).toList());
 
   private BridgeServiceProperties() {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/WorldPosition.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/WorldPosition.java
@@ -16,7 +16,7 @@
 
 package eu.cloudnetservice.modules.bridge;
 
-import com.google.gson.reflect.TypeToken;
+import io.leangen.geantyref.TypeFactory;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import lombok.NonNull;
@@ -44,6 +44,5 @@ public record WorldPosition(
   @Nullable String group
 ) {
 
-  public static final Type COL_TYPE = new TypeToken<Collection<WorldPosition>>() {
-  }.getType();
+  public static final Type COL_TYPE = TypeFactory.parameterizedClass(Collection.class, WorldPosition.class);
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/CloudNetBridgeModule.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/CloudNetBridgeModule.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.modules.bridge.node;
 import static eu.cloudnetservice.modules.bridge.BridgeManagement.BRIDGE_PLAYER_DB_NAME;
 
 import com.google.common.collect.Iterables;
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
@@ -42,6 +41,7 @@ import eu.cloudnetservice.node.cluster.sync.DataSyncRegistry;
 import eu.cloudnetservice.node.command.CommandProvider;
 import eu.cloudnetservice.node.database.NodeDatabaseProvider;
 import eu.cloudnetservice.node.version.ServiceVersionProvider;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -144,19 +144,21 @@ public final class CloudNetBridgeModule extends DriverModule {
     if (!config.empty()) {
       // extract the messages and re-map them
       Map<String, Map<String, String>> messages = new HashMap<>(BridgeConfiguration.DEFAULT_MESSAGES);
-      messages.get("default").putAll(config.get("messages", new TypeToken<Map<String, String>>() {
-      }.getType()));
+      messages.get("default").putAll(config.get(
+        "messages",
+        TypeFactory.parameterizedClass(Map.class, String.class, String.class)));
       // extract all hub commands
-      Collection<String> hubCommands = config.get("hubCommandNames", new TypeToken<Collection<String>>() {
-      }.getType());
+      Collection<String> hubCommands = config.get(
+        "hubCommandNames",
+        TypeFactory.parameterizedClass(Collection.class, String.class));
       // extract the excluded groups
-      Collection<String> excludedGroups = config.get("excludedGroups", new TypeToken<Collection<String>>() {
-      }.getType());
+      Collection<String> excludedGroups = config.get(
+        "excludedGroups",
+        TypeFactory.parameterizedClass(Collection.class, String.class));
       // extract the fallback configurations
       Collection<ProxyFallbackConfiguration> fallbacks = config.get(
         "bungeeFallbackConfigurations",
-        new TypeToken<Collection<ProxyFallbackConfiguration>>() {
-        }.getType());
+        TypeFactory.parameterizedClass(Collection.class, ProxyFallbackConfiguration.class));
       // convert to a new config file
       JsonDocument.newDocument(new BridgeConfiguration(
         config.getString("prefix"),

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/CloudFlareRecordManager.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/CloudFlareRecordManager.java
@@ -18,12 +18,12 @@ package eu.cloudnetservice.modules.cloudflare.cloudflare;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
 import eu.cloudnetservice.modules.cloudflare.config.CloudflareConfigurationEntry;
 import eu.cloudnetservice.modules.cloudflare.dns.DnsRecord;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Singleton;
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -45,7 +45,7 @@ public class CloudFlareRecordManager {
   protected static final String ZONE_RECORDS_ENDPOINT = CLOUDFLARE_ENDPOINT + "zones/%s/dns_records";
   protected static final String ZONE_RECORDS_MANAGEMENT_ENDPOINT = ZONE_RECORDS_ENDPOINT + "/%s";
 
-  protected static final Type LIST_DNS_RECORD_TYPE = TypeToken.getParameterized(List.class, DnsRecord.class).getType();
+  protected static final Type LIST_DNS_RECORD_TYPE = TypeFactory.parameterizedClass(List.class, DnsRecord.class);
 
   protected static final Logger LOGGER = LogManager.logger(CloudFlareRecordManager.class);
 

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/CloudNetMySQLDatabaseModule.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/CloudNetMySQLDatabaseModule.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.modules.mysql;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.module.ModuleLifeCycle;
 import eu.cloudnetservice.driver.module.ModuleTask;
@@ -26,6 +25,7 @@ import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.modules.mysql.config.MySQLConfiguration;
 import eu.cloudnetservice.modules.mysql.config.MySQLConnectionEndpoint;
 import eu.cloudnetservice.node.database.NodeDatabaseProvider;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Singleton;
 import java.util.List;
 import lombok.NonNull;
@@ -44,7 +44,7 @@ public final class CloudNetMySQLDatabaseModule extends DriverModule {
         config.getString("username"),
         config.getString("password"),
         config.getString("database"),
-        config.get("addresses", TypeToken.getParameterized(List.class, MySQLConnectionEndpoint.class).getType())
+        config.get("addresses", TypeFactory.parameterizedClass(List.class, MySQLConnectionEndpoint.class))
       )));
     }
   }

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/CloudNetLabyModModule.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/node/CloudNetLabyModModule.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.modules.labymod.node;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.inject.InjectionLayer;
@@ -33,6 +32,7 @@ import eu.cloudnetservice.modules.labymod.config.LabyModServiceDisplay;
 import eu.cloudnetservice.node.cluster.sync.DataSyncHandler;
 import eu.cloudnetservice.node.cluster.sync.DataSyncRegistry;
 import eu.cloudnetservice.node.module.listener.PluginIncludeListener;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import java.nio.file.Files;
@@ -59,16 +59,18 @@ public class CloudNetLabyModModule extends DriverModule {
             .joinMatch(config.getDocument("discordJoinMatch").toInstanceOf(LabyModDiscordRPC.class))
             .spectateMatch(LabyModDiscordRPC.builder()
               .enabled(config.getBoolean("discordSpectateEnabled"))
-              .excludedGroups(config.get("excludedSpectateGroups",
-                TypeToken.getParameterized(Collection.class, String.class).getType()))
+              .excludedGroups(config.get(
+                "excludedSpectateGroups",
+                TypeFactory.parameterizedClass(Collection.class, String.class)))
               .build())
             .loginDomain(config.getString("loginDomain"))
             .banner(config.get("bannerConfig", LabyModBanner.class))
             .permissions(LabyModPermissions.builder()
               .enabled(config.getDocument("permissionConfig").getBoolean("enabled"))
               .permissions(config.getDocument("permissionConfig")
-                .get("labyModPermissions",
-                  TypeToken.getParameterized(Map.class, String.class, Boolean.class).getType()))
+                .get(
+                  "labyModPermissions",
+                  TypeFactory.parameterizedClass(Map.class, String.class, Boolean.class)))
               .build())
             .build()
         ));

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/NPC.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/NPC.java
@@ -17,10 +17,10 @@
 package eu.cloudnetservice.modules.npc;
 
 import com.google.common.base.Preconditions;
-import com.google.common.reflect.TypeToken;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.common.document.property.JsonDocPropertyHolder;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
+import io.leangen.geantyref.TypeFactory;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,10 +33,8 @@ import org.jetbrains.annotations.Nullable;
 
 public class NPC extends JsonDocPropertyHolder {
 
-  public static final Type COLLECTION_NPC = new TypeToken<Collection<NPC>>() {
-  }.getType();
-  private static final Type PROPERTIES = new TypeToken<Set<ProfileProperty>>() {
-  }.getType();
+  public static final Type COLLECTION_NPC = TypeFactory.parameterizedClass(Collection.class, NPC.class);
+  private static final Type PROPERTIES = TypeFactory.parameterizedClass(Set.class, ProfileProperty.class);
 
   private final NPCType npcType;
   private final String targetGroup;
@@ -55,7 +53,7 @@ public class NPC extends JsonDocPropertyHolder {
 
   private final boolean glowing;
   private final String glowingColor;
-  
+
   private final boolean flyingWithElytra;
   private final boolean burning;
 
@@ -258,7 +256,7 @@ public class NPC extends JsonDocPropertyHolder {
 
     private boolean glowing = false;
     private String glowingColor = "§f";
-    
+
     private boolean flyingWithElytra = false;
     private boolean burning = false;
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
@@ -17,7 +17,6 @@
 package eu.cloudnetservice.modules.npc.node;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.collection.Pair;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.database.DatabaseProvider;
@@ -39,6 +38,7 @@ import eu.cloudnetservice.modules.npc.configuration.NPCPoolOptions;
 import eu.cloudnetservice.node.command.CommandProvider;
 import eu.cloudnetservice.node.console.animation.progressbar.ConsoleProgressWrappers;
 import eu.cloudnetservice.node.console.animation.setup.answer.Parsers;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Singleton;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -99,7 +99,7 @@ public class CloudNetNPCModule extends DriverModule {
         var config = JsonDocument.newDocument(this.configPath());
         List<JsonDocument> entries = config.get(
           "entries",
-          TypeToken.getParameterized(List.class, JsonDocument.class).getType());
+          TypeFactory.parameterizedClass(List.class, JsonDocument.class));
 
         for (var entry : entries) {
           var inventoryConfig = entry.getDocument("inventoryConfiguration").getDocument("defaultItems");

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/listeners/NodeChannelMessageListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/listeners/NodeChannelMessageListener.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.modules.npc.node.listeners;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.driver.event.EventListener;
 import eu.cloudnetservice.driver.event.events.channel.ChannelMessageReceiveEvent;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
@@ -25,13 +24,14 @@ import eu.cloudnetservice.modules.npc.AbstractNPCManagement;
 import eu.cloudnetservice.modules.npc.NPC;
 import eu.cloudnetservice.modules.npc.configuration.NPCConfiguration;
 import eu.cloudnetservice.modules.npc.platform.PlatformNPCManagement;
+import io.leangen.geantyref.TypeFactory;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import lombok.NonNull;
 
 public final class NodeChannelMessageListener {
 
-  private static final Type STRING_COLLECTION = TypeToken.getParameterized(Collection.class, String.class).getType();
+  private static final Type STRING_COLLECTION = TypeFactory.parameterizedClass(Collection.class, String.class);
 
   private final AbstractNPCManagement management;
 

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerDatabase.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerDatabase.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.modules.rest.v2;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.driver.database.DatabaseProvider;
 import eu.cloudnetservice.driver.network.http.HttpContext;
@@ -28,6 +27,7 @@ import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.http.V2HttpHandler;
 import eu.cloudnetservice.node.http.annotation.BearerAuth;
 import eu.cloudnetservice.node.http.annotation.HandlerPermission;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.lang.reflect.Type;
@@ -39,7 +39,7 @@ import lombok.NonNull;
 @HandlerPermission("http.v2.database")
 public final class V2HttpHandlerDatabase extends V2HttpHandler {
 
-  private static final Type MAP_TYPE = TypeToken.getParameterized(Map.class, String.class, String.class).getType();
+  private static final Type MAP_TYPE = TypeFactory.parameterizedClass(Map.class, String.class, String.class);
 
   private final DatabaseProvider databaseProvider;
 

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/Sign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/Sign.java
@@ -16,8 +16,8 @@
 
 package eu.cloudnetservice.modules.signs;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
+import io.leangen.geantyref.TypeFactory;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import lombok.EqualsAndHashCode;
@@ -32,8 +32,7 @@ import org.jetbrains.annotations.Nullable;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Sign {
 
-  public static final Type COLLECTION_TYPE = new TypeToken<Collection<Sign>>() {
-  }.getType();
+  public static final Type COLLECTION_TYPE = TypeFactory.parameterizedClass(Collection.class, Sign.class);
 
   protected final String targetGroup;
   protected final String templatePath;

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/NodeSignsListener.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/node/NodeSignsListener.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.modules.signs.node;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.driver.event.EventListener;
 import eu.cloudnetservice.driver.event.events.channel.ChannelMessageReceiveEvent;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
@@ -30,6 +29,7 @@ import eu.cloudnetservice.modules.signs.node.util.SignEntryTaskSetup;
 import eu.cloudnetservice.modules.signs.platform.PlatformSignManagement;
 import eu.cloudnetservice.node.event.setup.SetupCompleteEvent;
 import eu.cloudnetservice.node.event.setup.SetupInitiateEvent;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.lang.reflect.Type;
@@ -39,7 +39,7 @@ import lombok.NonNull;
 @Singleton
 public class NodeSignsListener {
 
-  private static final Type STRING_COLLECTION = TypeToken.getParameterized(Collection.class, String.class).getType();
+  private static final Type STRING_COLLECTION = TypeFactory.parameterizedClass(Collection.class, String.class);
 
   private final SignManagement signManagement;
   private final SignEntryTaskSetup entryTaskSetup;

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/RemoteNodeServer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/RemoteNodeServer.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.node.cluster.defaults;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.concurrent.Task;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.network.NetworkChannel;
@@ -35,6 +34,7 @@ import eu.cloudnetservice.node.cluster.NodeServerProvider;
 import eu.cloudnetservice.node.cluster.NodeServerState;
 import eu.cloudnetservice.node.cluster.sync.DataSyncRegistry;
 import eu.cloudnetservice.node.cluster.util.NodeDisconnectHandler;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import java.lang.reflect.Type;
 import java.time.Instant;
@@ -48,7 +48,7 @@ import org.jetbrains.annotations.UnknownNullability;
 
 public class RemoteNodeServer implements NodeServer {
 
-  private static final Type COLLECTION_STRING = TypeToken.getParameterized(Set.class, String.class).getType();
+  private static final Type COLLECTION_STRING = TypeFactory.parameterizedClass(Set.class, String.class);
 
   private final NetworkClient networkClient;
   private final DataSyncRegistry dataSyncRegistry;

--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/DefaultCommandProvider.java
@@ -79,7 +79,6 @@ import org.jetbrains.annotations.Nullable;
 @Provides(CommandProvider.class)
 public final class DefaultCommandProvider implements CommandProvider {
 
-  // TODO: TypeFactory
   private static final CommandMeta.Key<Set<String>> ALIAS_KEY = CommandMeta.Key.of(new TypeToken<Set<String>>() {
   }, "cloudnet:alias");
   private static final CommandMeta.Key<String> DESCRIPTION_KEY = CommandMeta.Key.of(

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeGroupConfigurationProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeGroupConfigurationProvider.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.node.provider;
 
-import com.google.gson.reflect.TypeToken;
 import dev.derklaro.aerogel.PostConstruct;
 import dev.derklaro.aerogel.auto.Provides;
 import eu.cloudnetservice.common.Nameable;
@@ -35,6 +34,7 @@ import eu.cloudnetservice.node.cluster.sync.DataSyncRegistry;
 import eu.cloudnetservice.node.event.group.LocalGroupConfigurationAddEvent;
 import eu.cloudnetservice.node.event.group.LocalGroupConfigurationRemoveEvent;
 import eu.cloudnetservice.node.network.listener.message.GroupChannelMessageListener;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.lang.reflect.Type;
@@ -59,7 +59,7 @@ public class NodeGroupConfigurationProvider implements GroupConfigurationProvide
   private static final Path GROUP_DIRECTORY_PATH = Path.of(
     System.getProperty("cloudnet.config.groups.directory.path", "local/groups"));
 
-  private static final Type TYPE = TypeToken.getParameterized(Collection.class, GroupConfiguration.class).getType();
+  private static final Type TYPE = TypeFactory.parameterizedClass(Collection.class, GroupConfiguration.class);
 
   private final EventManager eventManager;
   private final Map<String, GroupConfiguration> groupConfigurations = new ConcurrentHashMap<>();

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeMessenger.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeMessenger.java
@@ -17,7 +17,6 @@
 package eu.cloudnetservice.node.provider;
 
 import com.google.common.collect.Iterables;
-import com.google.gson.reflect.TypeToken;
 import dev.derklaro.aerogel.auto.Provides;
 import eu.cloudnetservice.common.concurrent.CountingTask;
 import eu.cloudnetservice.common.concurrent.Task;
@@ -31,6 +30,7 @@ import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.node.cluster.NodeServerProvider;
 import eu.cloudnetservice.node.service.CloudService;
 import eu.cloudnetservice.node.service.CloudServiceManager;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.lang.reflect.Type;
@@ -47,7 +47,7 @@ import lombok.NonNull;
 @Provides(CloudMessenger.class)
 public class NodeMessenger extends DefaultMessenger implements CloudMessenger {
 
-  protected static final Type COL_MSG = TypeToken.getParameterized(Collection.class, ChannelMessage.class).getType();
+  protected static final Type COL_MSG = TypeFactory.parameterizedClass(Collection.class, ChannelMessage.class);
 
   protected final NodeServerProvider nodeServerProvider;
   protected final CloudServiceManager cloudServiceManager;

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/BuildStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/BuildStepExecutor.java
@@ -16,12 +16,12 @@
 
 package eu.cloudnetservice.node.version.execute.defaults;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
 import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.version.execute.InstallStepExecutor;
 import eu.cloudnetservice.node.version.information.VersionInstaller;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.io.BufferedReader;
@@ -49,7 +49,7 @@ public class BuildStepExecutor implements InstallStepExecutor {
 
   private static final Logger LOGGER = LogManager.logger(BuildStepExecutor.class);
   private static final ExecutorService OUTPUT_READER_EXECUTOR = Executors.newCachedThreadPool();
-  private static final Type STRING_LIST_TYPE = TypeToken.getParameterized(List.class, String.class).getType();
+  private static final Type STRING_LIST_TYPE = TypeFactory.parameterizedClass(List.class, String.class);
 
   private final Configuration configuration;
   private final Collection<Process> runningBuildProcesses = new ConcurrentLinkedQueue<>();

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/CopyFilterStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/CopyFilterStepExecutor.java
@@ -16,11 +16,11 @@
 
 package eu.cloudnetservice.node.version.execute.defaults;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.StringUtil;
 import eu.cloudnetservice.common.collection.Pair;
 import eu.cloudnetservice.node.version.execute.InstallStepExecutor;
 import eu.cloudnetservice.node.version.information.VersionInstaller;
+import io.leangen.geantyref.TypeFactory;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
@@ -34,7 +34,7 @@ import lombok.NonNull;
 
 public class CopyFilterStepExecutor implements InstallStepExecutor {
 
-  private static final Type STRING_MAP = TypeToken.getParameterized(Map.class, String.class, String.class).getType();
+  private static final Type STRING_MAP = TypeFactory.parameterizedClass(Map.class, String.class, String.class);
 
   @Override
   public @NonNull Set<Path> execute(

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/PaperApiVersionFetchStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/PaperApiVersionFetchStepExecutor.java
@@ -16,12 +16,12 @@
 
 package eu.cloudnetservice.node.version.execute.defaults;
 
-import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.common.StringUtil;
 import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.node.version.ServiceVersionType;
 import eu.cloudnetservice.node.version.execute.InstallStepExecutor;
 import eu.cloudnetservice.node.version.information.VersionInstaller;
+import io.leangen.geantyref.TypeFactory;
 import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -33,7 +33,7 @@ public class PaperApiVersionFetchStepExecutor implements InstallStepExecutor {
 
   private static final String VERSION_LIST_URL = "https://api.papermc.io/v2/projects/%s/versions/%s";
   private static final String DOWNLOAD_URL = "https://api.papermc.io/v2/projects/%s/versions/%s/builds/%d/downloads/%s-%s-%d.jar";
-  private static final Type INT_SET_TYPE = TypeToken.getParameterized(Set.class, Integer.class).getType();
+  private static final Type INT_SET_TYPE = TypeFactory.parameterizedClass(Set.class, Integer.class);
 
   @Override
   public @NonNull Set<Path> execute(

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperMessenger.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/provider/WrapperMessenger.java
@@ -16,13 +16,13 @@
 
 package eu.cloudnetservice.wrapper.provider;
 
-import com.google.gson.reflect.TypeToken;
 import dev.derklaro.aerogel.auto.Provides;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.network.NetworkClient;
 import eu.cloudnetservice.driver.network.def.PacketServerChannelMessage;
 import eu.cloudnetservice.driver.provider.CloudMessenger;
 import eu.cloudnetservice.driver.provider.defaults.DefaultMessenger;
+import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.lang.reflect.Type;
@@ -35,7 +35,7 @@ import lombok.NonNull;
 @Provides(CloudMessenger.class)
 public class WrapperMessenger extends DefaultMessenger implements CloudMessenger {
 
-  private static final Type MESSAGES = TypeToken.getParameterized(Collection.class, ChannelMessage.class).getType();
+  private static final Type MESSAGES = TypeFactory.parameterizedClass(Collection.class, ChannelMessage.class);
 
   private final NetworkClient networkClient;
 
@@ -55,7 +55,7 @@ public class WrapperMessenger extends DefaultMessenger implements CloudMessenger
 
   @Override
   public @NonNull Collection<ChannelMessage> sendChannelMessageQuery(@NonNull ChannelMessage channelMessage) {
-    Collection<ChannelMessage> response =  this.networkClient.firstChannel()
+    Collection<ChannelMessage> response = this.networkClient.firstChannel()
       .queryPacketManager()
       .sendQueryPacket(new PacketServerChannelMessage(channelMessage, true))
       .join()


### PR DESCRIPTION
### Motivation
The TypeToken implementation of guava/gson has the downside of always needing to create 2 instances: The TypeToken itself and the Type that is actually captured by it. Furthermore, the old bundled version of gson in minecraft makes it harder to use newer features of TypeToken, especially `TypeToken.getParameterized`.

### Modification
Replace all relevant usages of TypeToken with geantyref (which is a generic type reflection library). This eliminates the need for usages of TypeToken and has some great util methods when it comes to working with generic types. 

### Result
No more usages of TypeToken that are replaceable with geantyref.

##### Other context
Resolves #1036
