### PR TITLE
fix: split basic auth into max. two parts to allow ':' in passwords

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/http/V2HttpAuthentication.java
+++ b/node/src/main/java/eu/cloudnetservice/node/http/V2HttpAuthentication.java
@@ -102,7 +102,7 @@ public class V2HttpAuthentication {
 
     var matcher = BASIC_LOGIN_PATTERN.matcher(authenticationHeader);
     if (matcher.matches()) {
-      var auth = new String(Base64.getDecoder().decode(matcher.group(1)), StandardCharsets.UTF_8).split(":");
+      var auth = new String(Base64.getDecoder().decode(matcher.group(1)), StandardCharsets.UTF_8).split(":", 2);
       if (auth.length == 2) {
         var users = this.permissionManagement.usersByName(auth[0]);
         for (var user : users) {


### PR DESCRIPTION
### Motivation
Splitting the password without any limitation would result in problems when the password of the user contains a ':' by itself.

### Modification
Made sure that the base64 string is only split into two sections: username:password and any ':' in the password are ignored.

### Result
Passwords containing a ':' can be used now. 

##### Other context
Fixes #1073 
