### PR TITLE
build: resolve compile issues after opencollab repo switch

### DIFF
--- a/ext/platform-inject-support/runtime/build.gradle.kts
+++ b/ext/platform-inject-support/runtime/build.gradle.kts
@@ -17,6 +17,7 @@
 repositories {
   maven("https://repo.md-5.net/repository/releases/")
   maven("https://repo.waterdog.dev/artifactory/main/")
+  maven("https://repo.opencollab.dev/maven-releases/")
   maven("https://repo.opencollab.dev/maven-snapshots/")
   maven("https://repo.papermc.io/repository/maven-public/")
   maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -32,6 +32,7 @@ subprojects {
   repositories {
     maven("https://repo.md-5.net/repository/releases/")
     maven("https://repo.waterdog.dev/artifactory/main/")
+    maven("https://repo.opencollab.dev/maven-releases/")
     maven("https://repo.opencollab.dev/maven-snapshots/")
     maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -25,6 +25,7 @@ subprojects {
 
   repositories {
     maven("https://repo.spongepowered.org/maven/")
+    maven("https://repo.opencollab.dev/maven-releases/")
     maven("https://repo.opencollab.dev/maven-snapshots/")
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
   }


### PR DESCRIPTION
### Motivation
Opencollab recently had issues with their old maven repository and moved to a new repository. This causes the snapshot and release versions to be split (as it should be).

### Modification
Add maven-release repository of opencollab alongside the snapshot repository.

### Result
CloudNet compiles correctly again.
