### PR TITLE
chore: bump npc-lib to beta3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -171,11 +171,11 @@ adventureSerializerLegacy = { group = "net.kyori", name = "adventure-text-serial
 
 # platform extensions
 vault = { group = "com.github.MilkBowl", name = "VaultAPI", version.ref = "vault" }
+modLauncher = { group = "cpw.mods", name = "modlauncher", version.ref = "modlauncher" }
+bungeecordChat = { group = "net.md-5", name = "bungeecord-chat", version.ref = "bungeecord" }
+placeholderApi = { group = "me.clip", name = "placeholderapi", version.ref = "placeholderApi" }
 npcLib = { group = "com.github.juliarn.NPC-Lib", name = "npc-lib-bukkit", version.ref = "npcLib" }
 npcLibLabymod = { group = "com.github.juliarn.NPC-Lib", name = "npc-lib-labymod", version.ref = "npcLib" }
-modLauncher = { group = "cpw.mods", name = "modlauncher", version.ref = "modlauncher" }
-placeholderApi = { group = "me.clip", name = "placeholderapi", version.ref = "placeholderApi" }
-bungeecordChat = { group = "net.md-5", name = "bungeecord-chat", version.ref = "bungeecord" }
 
 # fabric platform special dependencies
 minecraft = { group = "com.mojang", name = "minecraft", version.ref = "minecraft" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ bungeecord = "1.19-R0.1-SNAPSHOT"
 vault = "1.7.1"
 adventure = "4.12.0"
 modlauncher = "8.1.3"
-npcLib = "3.0.0-beta2"
+npcLib = "3.0.0-beta3"
 placeholderApi = "2.11.2"
 
 # fabric platform special dependencies
@@ -169,8 +169,8 @@ adventureSerializerLegacy = { group = "net.kyori", name = "adventure-text-serial
 
 # platform extensions
 vault = { group = "com.github.MilkBowl", name = "VaultAPI", version.ref = "vault" }
-npcLib = { group = "com.github.juliarn.NPC-Lib", name = "bukkit", version.ref = "npcLib" }
-npcLibLabymod = { group = "com.github.juliarn.NPC-Lib", name = "labymod", version.ref = "npcLib" }
+npcLib = { group = "com.github.juliarn.NPC-Lib", name = "npc-lib-bukkit", version.ref = "npcLib" }
+npcLibLabymod = { group = "com.github.juliarn.NPC-Lib", name = "npc-lib-labymod", version.ref = "npcLib" }
 modLauncher = { group = "cpw.mods", name = "modlauncher", version.ref = "modlauncher" }
 placeholderApi = { group = "me.clip", name = "placeholderapi", version.ref = "placeholderApi" }
 bungeecordChat = { group = "net.md-5", name = "bungeecord-chat", version.ref = "bungeecord" }


### PR DESCRIPTION
### Motivation
NPC-Lib beta3 was released and we should use the new version of it.

### Modification
Bump npc lib to beta3.

### Result
We use npc-lib beta3.
