### PR TITLE
chore: add better equals/hashCode implementation for NetworkClusterNode

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NetworkClusterNode.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NetworkClusterNode.java
@@ -21,6 +21,7 @@ import eu.cloudnetservice.common.document.property.DefaultedDocPropertyHolder;
 import eu.cloudnetservice.driver.network.HostAndPort;
 import java.util.List;
 import lombok.NonNull;
+import lombok.ToString;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -29,6 +30,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @since 4.0
  */
+@ToString
 public final class NetworkClusterNode implements DefaultedDocPropertyHolder<JsonDocument, NetworkClusterNode> {
 
   private final String uniqueId;
@@ -111,13 +113,5 @@ public final class NetworkClusterNode implements DefaultedDocPropertyHolder<Json
   @Override
   public int hashCode() {
     return this.uniqueId.hashCode();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public @NonNull String toString() {
-    return "NetworkClusterNode(uniqueId=" + this.uniqueId + ")";
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NetworkClusterNode.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/cluster/NetworkClusterNode.java
@@ -20,9 +20,8 @@ import eu.cloudnetservice.common.document.gson.JsonDocument;
 import eu.cloudnetservice.common.document.property.DefaultedDocPropertyHolder;
 import eu.cloudnetservice.driver.network.HostAndPort;
 import java.util.List;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.ToString;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a general information holder about a node running in a cluster. Every node knows this information about
@@ -30,9 +29,7 @@ import lombok.ToString;
  *
  * @since 4.0
  */
-@ToString
-@EqualsAndHashCode
-public class NetworkClusterNode implements DefaultedDocPropertyHolder<JsonDocument, NetworkClusterNode> {
+public final class NetworkClusterNode implements DefaultedDocPropertyHolder<JsonDocument, NetworkClusterNode> {
 
   private final String uniqueId;
   private final List<HostAndPort> listeners;
@@ -92,5 +89,35 @@ public class NetworkClusterNode implements DefaultedDocPropertyHolder<JsonDocume
   @Override
   public @NonNull JsonDocument propertyHolder() {
     return this.properties;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (obj == this) {
+      return true;
+    } else if (obj instanceof NetworkClusterNode other) {
+      return other.uniqueId().equals(this.uniqueId);
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int hashCode() {
+    return this.uniqueId.hashCode();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull String toString() {
+    return "NetworkClusterNode(uniqueId=" + this.uniqueId + ")";
   }
 }


### PR DESCRIPTION
### Motivation
The current way lombok implements equals and hashCode is to include all fields. This is incorrect as a network nodes are identified by the unique id, not by unique id, listeners and properties.

### Modification
Add a custom hashCode and equals method to NetworkClusterNode that only takes the unique id into account.

### Result
NetworkClusterNode instances are now only identified by the unique id.
