### PR TITLE
fix: correctly bind plugin instance to bungee plugin injector

### DIFF
--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformPluginManager.java
@@ -46,7 +46,7 @@ public final class BungeeCordPlatformPluginManager extends BasePlatformPluginMan
       layer.install(createFixedBinding(platformData.getProxy().getPluginManager(), PluginManager.class));
 
       // install the bindings which are specific to the plugin
-      layer.install(fixedBindingWithBound(platformData, Plugin.class));
+      injector.installSpecified(fixedBindingWithBound(platformData, Plugin.class));
     });
   }
 }


### PR DESCRIPTION
### Motivation
The current platform plugin manager for bungeecord incorrectly binds the instance of a plugin to the parent injector instead of the specified injector that is used to construct the plugin instance. This leads to the problem, that the instance passed to the plugin classes is always the plugin instance of the first constructed plugin, not of the current plugin.

### Modification
Correctly bind the plugin instance to the injector responsible for the current plugin instead of the parent injector.

### Result
BungeeCord plugins that are using platform inject are now receiving the correct plugin instance, instead of the instance of the first constructed plugin.
