### PR TITLE
fix: properly close buffers to prevent memory leaks

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
@@ -231,8 +231,8 @@ public interface DataBuf extends AutoCloseable {
   <T> T readObject(@NonNull Type type);
 
   /**
-   * Reads the next requested data from the buffer. This method call is equivalent to {@code
-   * readNullable(readerWhenNonNull, null)}.
+   * Reads the next requested data from the buffer. This method call is equivalent to
+   * {@code readNullable(readerWhenNonNull, null)}.
    *
    * @param readerWhenNonNull the reader to read the data from the buffer when the next value is non-null.
    * @param <T>               the generic type of the data to read.
@@ -300,26 +300,31 @@ public interface DataBuf extends AutoCloseable {
   boolean accessible();
 
   /**
-   * Disables that the underlying buffer can be released when the reader index of this buffer reaches the tail or an
-   * explicit call to {@code release()} or {@code close()} is made.
+   * Get the amount of acquires that this data buf has. Initially a data buf is acquired once.
    *
-   * @return the same instance as used to call the method, for chaining.
+   * @return the amount of acquires. A value smaller or equal to zero means that the buffer was released.
    */
-  @NonNull DataBuf disableReleasing();
+  int acquires();
 
   /**
-   * Enables that the underlying buffer can be released when the reader index of this buffer reaches the tail or an
-   * explicit call to {@code release()} or {@code close()} is made.
+   * Acquires this buffer once. If a buffer gets acquired, further calls to {@link #release()} will decrease the count,
+   * but only release the buffer if there were more release than acquire calls.
    *
    * @return the same instance as used to call the method, for chaining.
    */
-  @NonNull DataBuf enableReleasing();
+  @NonNull DataBuf acquire();
+
+  /**
+   * Explicitly releases all data associated with this buffer making it unavailable for further reads. This method only
+   * decreases the acquire count of the buffer in case it was acquired at least once.
+   */
+  void release();
 
   /**
    * Explicitly releases all data associated with this buffer making it unavailable for further reads. This method does
-   * nothing if releasing was disables before calling this method.
+   * not check if anyone acquired the buffer, it will be released in any case.
    */
-  void release();
+  void forceRelease();
 
   /**
    * Explicitly releases all data associated with this buffer making it unavailable for further reads. This method does

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
@@ -117,7 +117,6 @@ public abstract class DefaultChunkedPacketSenderBuilder implements ChunkedPacket
   public @NonNull ChunkedPacketSender.Builder withExtraData(@NonNull DataBuf extraData) {
     // make sure that the old transfer information buffer is released
     this.transferInformation.release();
-
     this.transferInformation = extraData;
     return this;
   }

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
@@ -115,7 +115,10 @@ public abstract class DefaultChunkedPacketSenderBuilder implements ChunkedPacket
    */
   @Override
   public @NonNull ChunkedPacketSender.Builder withExtraData(@NonNull DataBuf extraData) {
-    this.transferInformation = extraData.disableReleasing();
+    // make sure that the old transfer information buffer is released
+    this.transferInformation.release();
+
+    this.transferInformation = extraData;
     return this;
   }
 

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyMutableDataBuf.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/buffer/NettyMutableDataBuf.java
@@ -158,11 +158,14 @@ public class NettyMutableDataBuf extends NettyImmutableDataBuf implements DataBu
   @Override
   public @NonNull DataBuf.Mutable writeDataBuf(@NonNull DataBuf buf) {
     buf.startTransaction();
-    // write the content
-    this.writeInt(buf.readableBytes());
-    this.buffer.writeBytes(((NettyImmutableDataBuf) buf).buffer);
-    // reset the data for later use
-    buf.redoTransaction();
+    try {
+      // write the content
+      this.writeInt(buf.readableBytes());
+      this.buffer.writeBytes(((NettyImmutableDataBuf) buf).buffer);
+    } finally {
+      // reset the data for later use & release the content if it isn't disabled
+      buf.redoTransaction().release();
+    }
 
     return this;
   }

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListenerRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListenerRegistry.java
@@ -138,7 +138,8 @@ public interface PacketListenerRegistry {
    *
    * @param channel the channel from which the packet came.
    * @param packet  the packet which was received.
+   * @return true if a listener handled the packet, false otherwise.
    * @throws NullPointerException if either the given channel or packet is null.
    */
-  void handlePacket(@NonNull NetworkChannel channel, @NonNull Packet packet);
+  boolean handlePacket(@NonNull NetworkChannel channel, @NonNull Packet packet);
 }

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DefaultDataSyncRegistry.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/sync/DefaultDataSyncRegistry.java
@@ -188,8 +188,7 @@ public class DefaultDataSyncRegistry implements DataSyncRegistry {
       // no handler for the result
       LOGGER.fine("No handler for key %s to sync data", null, key);
     }
-    // try to release the input buf
-    input.release();
+
     // return the created result
     return result;
   }

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
@@ -361,6 +361,9 @@ public final class ClusterCommand {
               // the transfer was successful
               source.sendMessage(I18n.trans("command-cluster-push-template-success", templateName));
             }
+          }).exceptionally(th -> {
+            LOGGER.severe("TEMPLATE PUSH", th);
+            return null;
           });
       } else {
         source.sendMessage(I18n.trans("command-template-not-found", templateName));

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketAuthorizationResponseListener.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/network/listener/PacketAuthorizationResponseListener.java
@@ -36,7 +36,12 @@ public final class PacketAuthorizationResponseListener implements PacketListener
   @Override
   public void handle(@NonNull NetworkChannel channel, @NonNull Packet packet) {
     // read the auth result
-    this.result.setRelease(packet.content().readBoolean());
+    var content = packet.content();
+    this.result.setRelease(content.readBoolean());
+
+    // skip the next two booleans from the packet
+    content.readBoolean();
+    content.readBoolean();
 
     // signal all listeners waiting for the auth
     LockSupport.unpark(this.blockedThread);


### PR DESCRIPTION
### Motivation
The current way we handle data bufs is prone to memory "leaks". They are not noticeable by the user directly, as the underlying memory of a buffer gets cleaned when it becomes phantom-reachable, but if a process is allowed to allocate a lot of memory, the consumed memory will rise until the garbage collector takes action (which can be very late considering that we set ZGC as the default in our start scripts).

### Modification
Change the complete internal code in a way that no more memory leaks are occurring. Note that this change might be error prone, as external plugins might use buffers in an invalid way that causes issues after the change. External code is now required to acquire and release a buffer to ensure it's not getting closed, rather than keeping a reference which prevents the buffer from getting released.

### Result
No more internal memory leaks.
