### PR TITLE
fix: only construct one object mapper instance per jvm

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/inject/BootLayerConfigurator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/inject/BootLayerConfigurator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.inject;
+
+import lombok.NonNull;
+
+/**
+ * All classes that are implementing this interface and are registered as a service provider to the class path will be
+ * loaded via the service provider interface when the boot injection layer is constructed for the first time. This
+ * should be used when a reusable binding is made.
+ * <p>
+ * The {@link #configureBootLayer(InjectionLayer)} method is only called once per jvm lifetime. If a new service
+ * provider gets registered after the call, the provider will be ignored.
+ *
+ * @since 4.0
+ */
+@FunctionalInterface
+public interface BootLayerConfigurator {
+
+  /**
+   * Configures the boot injection layer. Note that the given injection layer cannot be closed.
+   *
+   * @param bootLayer the boot injection layer to configure.
+   * @throws NullPointerException if the given boot layer is null.
+   */
+  void configureBootLayer(@NonNull InjectionLayer<?> bootLayer);
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/ObjectMapperInjectRegistration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/ObjectMapperInjectRegistration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.rpc.defaults.object;
+
+import dev.derklaro.aerogel.binding.BindingBuilder;
+import eu.cloudnetservice.driver.inject.BootLayerConfigurator;
+import eu.cloudnetservice.driver.inject.InjectionLayer;
+import eu.cloudnetservice.driver.network.rpc.object.ObjectMapper;
+import lombok.NonNull;
+
+/**
+ * Registers the default object mapper instance to the boot injection layer.
+ *
+ * @since 4.0
+ */
+public final class ObjectMapperInjectRegistration implements BootLayerConfigurator {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void configureBootLayer(@NonNull InjectionLayer<?> bootLayer) {
+    var bindingConstructor = BindingBuilder.create()
+      .bind(ObjectMapper.class)
+      .bindFully(DefaultObjectMapper.class)
+      .toInstance(DefaultObjectMapper.DEFAULT_MAPPER);
+    bootLayer.install(bindingConstructor);
+  }
+}

--- a/driver/src/main/resources/META-INF/services/eu.cloudnetservice.driver.inject.BootLayerConfigurator
+++ b/driver/src/main/resources/META-INF/services/eu.cloudnetservice.driver.inject.BootLayerConfigurator
@@ -1,0 +1,17 @@
+#
+# Copyright 2019-2023 CloudNetService team & contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+eu.cloudnetservice.driver.network.rpc.defaults.object.ObjectMapperInjectRegistration

--- a/modules/bridge/build.gradle.kts
+++ b/modules/bridge/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
   "annotationProcessor"(libs.aerogelAuto)
 
   "minecraft"(libs.minecraft)
-  "modCompileOnly"(libs.fabricLoader)
+  "modImplementation"(libs.fabricLoader)
   "mappings"(loom.officialMojangMappings())
 }
 

--- a/modules/bridge/build.gradle.kts
+++ b/modules/bridge/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
   "annotationProcessor"(libs.aerogelAuto)
 
   "minecraft"(libs.minecraft)
-  "modImplementation"(libs.fabricLoader)
+  "modCompileOnly"(libs.fabricLoader)
   "mappings"(loom.officialMojangMappings())
 }
 


### PR DESCRIPTION
### Motivation
At the moment there are two different instances of the object mapper used internally. An instance created by the dependency injection system, and an instance constructed specifically during the static initialization of the `DefaultObjectMapper` class.

### Modification
Bind the specifically created instance into the boot injection layer when it's created for the first time. For this reason, this PR adds a new interface (`BootLayerConfigurator`) that can be used in combination with the SPI to configure the boot layer at the first creation. This interface is only used for the mapper instance at the moment, but might be nice in the future for other changes as well.

### Result
The same object mapper instance is now passed to users which are using the static accessor field, as well as users that are using dependency injection. This also fixes issues with serializers that are only bound to one of these two instances.

##### Other context
Fixes #1112