### PR TITLE
build: move fabric loader dependency to compile only scope

### DIFF
--- a/modules/bridge/build.gradle.kts
+++ b/modules/bridge/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
   "annotationProcessor"(libs.aerogelAuto)
 
   "minecraft"(libs.minecraft)
-  "modImplementation"(libs.fabricLoader)
+  "modCompileOnly"(libs.fabricLoader)
   "mappings"(loom.officialMojangMappings())
 }
 


### PR DESCRIPTION
### Motivation
Currently the fabric loder dependency is added to the implementation configuration. This causes developers which are depending on the bridge to have a runtime dependency on the loader. This is no problem for users that are using maven, however gradle will not use the provided repositories through the bridge pom, causing dependency resolution to fail.

### Modification
Move the fabric loader dependency to modCompileOnly which will remove the dependency from the generated pom.

### Result
No more dependency resolve issues due to the missing fabric loader dependency.
