### PR TITLE
fix: correctly unregister services in bungeecord

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgeManagement.java
@@ -95,7 +95,7 @@ final class BungeeCordBridgeManagement extends PlatformBridgeManagement<ProxiedP
     // register each service matching the service cache tester
     this.cacheRegisterListener = bungeeHelper.serverRegisterHandler();
     // unregister each service matching the service cache tester
-    this.cacheUnregisterListener = bungeeHelper.serverRegisterHandler();
+    this.cacheUnregisterListener = bungeeHelper.serverUnregisterHandler();
   }
 
   @Override


### PR DESCRIPTION
### Motivation
Currently services that were registered to bungeecord once are not unregistered after they are stopped.

### Modification
Fixed the typo to make sure that the unregister is called instead of the register (twice).

### Result
Services are unregistered on deletion.