### PR TITLE
fix: added missing methods = "POST" in V2HttpHandlerService inside the Rest Module

### DIFF
--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerService.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerService.java
@@ -220,7 +220,7 @@ public final class V2HttpHandlerService extends V2HttpHandler {
   }
 
   @BearerAuth
-  @HttpRequestHandler(paths = "/api/v2/service/create")
+  @HttpRequestHandler(paths = "/api/v2/service/create", methods = "POST")
   private void handleCreateRequest(@NonNull HttpContext context, @NonNull @RequestBody JsonDocument body) {
     // check for a provided service configuration
     var configuration = body.get("serviceConfiguration", ServiceConfiguration.class);


### PR DESCRIPTION
### Motivation
I wanted to use the api for example create a service from a task but noticed that it tries to return information of a service that does not exists. 

### Modification
I marked the handleCreateRequest method that it takes only http POST requests rather than GET requests to prevent overlapping with other http handlers.

### Result
Now you can create services from a task with the HTTP route again.
