### PR TITLE
feat: support minecraft 1.19.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ bungeecord = "1.19-R0.1-SNAPSHOT"
 vault = "1.7.1"
 adventure = "4.12.0"
 modlauncher = "8.1.3"
-npcLib = "3.0.0-beta3"
+npcLib = "3.0.0-beta4"
 placeholderApi = "2.11.2"
 
 # fabric platform special dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,7 +71,7 @@ npcLib = "3.0.0-beta3"
 placeholderApi = "2.11.2"
 
 # fabric platform special dependencies
-minecraft = "1.19.3"
+minecraft = "1.19.4"
 fabricLoader = "0.14.17"
 
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
@@ -30,8 +30,8 @@ import lombok.NonNull;
   name = "CloudNet-Bridge",
   version = "{project.build.version}",
   dependencies = {
-    @Dependency(name = "fabricloader", version = ">=0.14.11"),
-    @Dependency(name = "minecraft", version = "~1.19.3"),
+    @Dependency(name = "fabricloader", version = ">=0.14.17"),
+    @Dependency(name = "minecraft", version = "~1.19.4"),
     @Dependency(name = "java", version = ">=17")
   },
   authors = "CloudNetService"

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeManagement.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeManagement.java
@@ -94,7 +94,7 @@ public final class FabricBridgeManagement extends PlatformBridgeManagement<Serve
       player.getUUID(),
       player.getGameProfile().getName(),
       null,
-      BridgeHostAndPortUtil.fromSocketAddress(player.connection.getConnection().getRemoteAddress()),
+      BridgeHostAndPortUtil.fromSocketAddress(player.connection.getRemoteAddress()),
       this.ownNetworkServiceInfo);
   }
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/handling/MinecraftServerMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/handling/MinecraftServerMixin.java
@@ -55,9 +55,8 @@ public abstract class MinecraftServerMixin implements BridgedServer {
 
   @Inject(
     at = @At(
-      ordinal = 0,
       value = "INVOKE",
-      target = "Lnet/minecraft/server/MinecraftServer;updateStatusIcon(Lnet/minecraft/network/protocol/status/ServerStatus;)V"
+      target = "Lnet/minecraft/server/MinecraftServer;buildServerStatus()Lnet/minecraft/network/protocol/status/ServerStatus;"
     ),
     method = "runServer"
   )

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -262,7 +262,7 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://api.purpurmc.org/v2/purpur/1.19.3/latest/download",
+          "url": "https://api.purpurmc.org/v2/purpur/1.19.4/latest/download",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -276,8 +276,8 @@
           }
         },
         {
-          "name": "1.19.3",
-          "url": "https://api.purpurmc.org/v2/purpur/1.19.3/latest/download",
+          "name": "1.19.4",
+          "url": "https://api.purpurmc.org/v2/purpur/1.19.4/latest/download",
           "properties": {
             "copy": {
               "cache/.*": "/",

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -91,11 +91,11 @@
               "-Dpaperclip.patchonly=true"
             ],
             "fetchOverPaperApi": true,
-            "versionGroup": "1.19.3"
+            "versionGroup": "1.19.4"
           }
         },
         {
-          "name": "1.19.3",
+          "name": "1.19.4",
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -106,7 +106,7 @@
               "-Dpaperclip.patchonly=true"
             ],
             "fetchOverPaperApi": true,
-            "versionGroup": "1.19.3"
+            "versionGroup": "1.19.4"
           }
         },
         {
@@ -329,12 +329,12 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://download.getbukkit.org/spigot/spigot-1.19.3.jar",
+          "url": "https://download.getbukkit.org/spigot/spigot-1.19.4.jar",
           "cacheFiles": false
         },
         {
           "name": "1.19.3",
-          "url": "https://download.getbukkit.org/spigot/spigot-1.19.3.jar"
+          "url": "https://download.getbukkit.org/spigot/spigot-1.19.4.jar"
         },
         {
           "name": "1.18.2",
@@ -405,7 +405,7 @@
       "website": "https://fabricmc.net",
       "versions": [
         {
-          "name": "1.19.3",
+          "name": "1.19.4",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -446,11 +446,11 @@
             },
             "fetchOverSpongeApi": true,
             "artifact": "spongevanilla",
-            "mcVersion": "1.19.3"
+            "mcVersion": "1.19.4"
           }
         },
         {
-          "name": "1.19.3",
+          "name": "1.19.4",
           "properties": {
             "copy": {
               "libraries/.*": "/",
@@ -459,7 +459,7 @@
             },
             "fetchOverSpongeApi": true,
             "artifact": "spongevanilla",
-            "mcVersion": "1.19.3"
+            "mcVersion": "1.19.4"
           }
         },
         {
@@ -576,7 +576,7 @@
           "cacheFiles": false,
           "properties": {
             "fetchOverPaperApi": true,
-            "versionGroup": "3.1.2-SNAPSHOT"
+            "versionGroup": "3.2.0-SNAPSHOT"
           }
         }
       ]


### PR DESCRIPTION
### Motivation
Minecraft 1.19.4 was released and we should add support for it.

### Modification
Updated the versions.json to download and install 1.19.4.

### Result
Minecraft 1.19.4 is supported.
