### PR TITLE
Removed that the task template is configured in the group configuration

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultTaskSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultTaskSetup.java
@@ -251,7 +251,6 @@ public class DefaultTaskSetup implements DefaultSetup {
     // create a group specifically for the task
     this.groupProvider.addGroupConfiguration(GroupConfiguration.builder()
       .name(taskName)
-      .templates(Set.of(template))
       .build());
 
     // install the service template


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
We found in the group configuration that it contains the template of the tasks (created on the initial setup). I asked on the Discord if this were a bug, because the template were already on the task configuration and that it shouldn't be there was confirmed by: 0utplay#0187 ( https://discord.com/channels/325362837184577536/818777626663321671/1089277611378753597 )

### Modification
<!-- Describe the modification you've done to the codebase -->
I've modified the DefaultTaskSetup class to not include the template of the task to the group

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
Now the template of the tasks (created on the initial setup) will not be inside the group configuration.

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
I've added "mlunkeit" as co-contributor in the commit because we discovered it together.
Fixes #
