### PR TITLE
[ci skip] chore: reduce dependency pr count

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
     ":rebaseStalePrs"
@@ -7,6 +8,27 @@
     "t: dependencies"
   ],
   "packageRules": [
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions"
+    },
+    {
+      "matchSourceUrlPrefixes": [
+        "https://github.com/KyoriPowered/adventure"
+      ],
+      "groupName": "adventure monorepo"
+    },
+    {
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "excludePackageNames": [
+        "gradle"
+      ],
+      "groupName": "patch dependency updates"
+    },
     {
       "description": "Correct Guava version handling",
       "matchPackagePrefixes": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,8 +56,7 @@
     {
       "description": "Version is based on the latest push to a git repo and never needs updates",
       "matchPackagePrefixes": [
-        "com.github.juliarn:",
-        "com.github.dmulloy2:"
+        "com.github.juliarn:"
       ],
       "enabled": false
     }


### PR DESCRIPTION
### Motivation
At the moment we're getting a lot of dependency update PRs for each individual dependency and version.

### Modification
Add more matching rules for renovate to:
1. Group all updates of GitHub Actions (one PR for all updates at once)
2. Group all updates of adventure (one PR for all updates at once)
3. Group all patch dependency updates (one PR for all updates at once)

### Result
Less renovate dependency PRs.
