### PR TITLE
[ci skip] chore: update patch group name and disable netty updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,7 +27,7 @@
       "excludePackageNames": [
         "gradle"
       ],
-      "groupName": "patch dependency updates"
+      "groupName": "all dependencies with patch changes"
     },
     {
       "description": "Correct Guava version handling",
@@ -43,6 +43,13 @@
       ],
       "matchPackagePrefixes": [
         "cpw.mods:"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disabled until netty5 stable release",
+      "matchPackagePrefixes": [
+        "io.netty:"
       ],
       "enabled": false
     },


### PR DESCRIPTION
### Motivation
Renovate tries to update netty to a `Final-SNAPSHOT` version instead of staying on the `Alpha` cycle.

### Modification
Disabled netty updates completly.

### Result
No netty updates from renovate.
