### PR TITLE
feat: implement a method to delete a directory from a template.

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/template/TemplateStorage.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/template/TemplateStorage.java
@@ -221,6 +221,17 @@ public interface TemplateStorage extends AutoCloseable, Named {
   boolean deleteFile(@NonNull ServiceTemplate template, @NonNull String path);
 
   /**
+   * Deletes the given directory at the given path in the given template in this storage.
+   * This method recursively deletes all files and directories inside the given directory.
+   *
+   * @param template the template in which the directory to delete is located in.
+   * @param path     the path to the directory in the template to delete.
+   * @return         true if the directory at the given path was deleted successfully, false otherwise.
+   * @throws NullPointerException if the given template or path is null.
+   */
+  boolean deleteDirectory(@NonNull ServiceTemplate template, @NonNull String path);
+
+  /**
    * Opens a new input stream to read the content of the file at the given path in the given template in this storage.
    * This method returns null if either the file doesn't exist or is a directory.
    *
@@ -478,6 +489,19 @@ public interface TemplateStorage extends AutoCloseable, Named {
    */
   default @NonNull Task<Boolean> deleteFileAsync(@NonNull ServiceTemplate template, @NonNull String path) {
     return Task.supply(() -> this.deleteFile(template, path));
+  }
+
+  /**
+   * Deletes the given directory at the given path in the given template in this storage. This method recursively
+   * deletes all files and directories inside the given directory.
+   *
+   * @param template the template in which the directory to delete is located in.
+   * @param path     the path to the directory in the template to delete.
+   * @return a task completed with true if the directory at the given path was deleted successfully, false otherwise.
+   * @throws NullPointerException if the given template or path is null.
+   */
+  default @NonNull Task<Boolean> deleteDirectoryAsync(@NonNull ServiceTemplate template, @NonNull String path) {
+    return Task.supply(() -> this.deleteDirectory(template, path));
   }
 
   /**

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTemplate.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTemplate.java
@@ -239,6 +239,25 @@ public final class V2HttpHandlerTemplate extends V2HttpHandler {
   }
 
   @BearerAuth
+  @HttpRequestHandler(paths = "/api/v2/template/{storage}/{prefix}/{name}/directory", methods = "DELETE")
+  private void handleDirectoryDeleteRequest(
+    @NonNull HttpContext context,
+    @NonNull @RequestPathParam("storage") String storageName,
+    @NonNull @RequestPathParam("prefix") String prefix,
+    @NonNull @RequestPathParam("name") String templateName,
+    @NonNull @FirstRequestQueryParam("path") String path
+  ) {
+    this.handleWithTemplateContext(context, storageName, prefix, templateName, (template, storage) -> {
+      var status = storage.deleteDirectory(template, path);
+      this.ok(context)
+        .body(status ? this.success().toString() : this.failure().toString())
+        .context()
+        .closeAfter(true)
+        .cancelNext(true);
+    });
+  }
+
+  @BearerAuth
   @HttpRequestHandler(paths = "/api/v2/template/{storage}/{prefix}/{name}", methods = "DELETE")
   private void handleTemplateDeleteRequest(
     @NonNull HttpContext context,

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -3235,6 +3235,55 @@
         }
       }
     },
+    "/template/{storage}/{prefix}/{name}/directory" : {
+      "delete" : {
+        "parameters" : [ {
+          "name" : "storage",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "prefix",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "name",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "path",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "tags" : [ "Templates" ],
+        "summary" : "Deletes a directory and all its contents recursively from a template",
+        "responses" : {
+          "200" : {
+            "$ref" : "#/components/responses/Success"
+          },
+          "400" : {
+            "$ref" : "#/components/responses/BadRequest"
+          },
+          "401" : {
+            "$ref" : "#/components/responses/Unauthorized"
+          },
+          "403" : {
+            "$ref" : "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
     "/serviceversion" : {
       "get" : {
         "tags" : [ "Service Versions" ],

--- a/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorage.java
+++ b/modules/storage-s3/src/main/java/eu/cloudnetservice/modules/s3/S3TemplateStorage.java
@@ -350,6 +350,29 @@ public class S3TemplateStorage implements TemplateStorage {
   }
 
   @Override
+  public boolean deleteDirectory(@NonNull ServiceTemplate template, @NonNull String path) {
+    try {
+      // get the contents we want to delete
+      Set<ObjectIdentifier> toDelete = new HashSet<>();
+      this.listAllObjects(
+        this.getBucketPath(template, path),
+        null,
+        object -> toDelete.add(ObjectIdentifier.builder().key(object.key()).build()));
+
+      // build the delete request
+      var deleteRequest = DeleteObjectsRequest.builder()
+        .bucket(this.config().bucket())
+        .delete(Delete.builder().quiet(true).objects(toDelete).build())
+        .build();
+      this.client.deleteObjects(deleteRequest);
+      // success
+      return true;
+    } catch (Exception exception) {
+      return false;
+    }
+  }
+
+  @Override
   public @Nullable InputStream newInputStream(@NonNull ServiceTemplate template, @NonNull String path) {
     try {
       var request = GetObjectRequest.builder()

--- a/modules/storage-s3/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
+++ b/modules/storage-s3/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
@@ -201,4 +201,15 @@ class S3TemplateStorageTest {
     Assertions.assertFalse(storage.contains(TEMPLATE));
     Assertions.assertFalse(storage.hasFile(TEMPLATE, "test.txt"));
   }
+
+  @Test
+  @Order(120)
+  void testDeleteDirectory() {
+    var directory = "hello";
+    Assertions.assertTrue(storage.createDirectory(TEMPLATE, directory));
+    Assertions.assertTrue(storage.createFile(TEMPLATE, directory + "/test.txt"));
+    Assertions.assertTrue(storage.hasFile(TEMPLATE, directory + "/test.txt"));
+    Assertions.assertTrue(storage.deleteDirectory(TEMPLATE, directory));
+    Assertions.assertFalse(storage.hasFile(TEMPLATE, directory + "/test.txt"));
+  }
 }

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -277,7 +277,6 @@ public class SFTPTemplateStorage implements TemplateStorage {
   public boolean deleteDirectory(@NonNull ServiceTemplate template, @NonNull String path) {
     return this.executeWithClient(client -> {
       this.deleteDir(client, this.constructRemotePath(template, path));
-      client.rmdir(this.constructRemotePath(template, path));
       return true;
     }, false);
   }

--- a/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/src/main/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorage.java
@@ -274,6 +274,15 @@ public class SFTPTemplateStorage implements TemplateStorage {
   }
 
   @Override
+  public boolean deleteDirectory(@NonNull ServiceTemplate template, @NonNull String path) {
+    return this.executeWithClient(client -> {
+      this.deleteDir(client, this.constructRemotePath(template, path));
+      client.rmdir(this.constructRemotePath(template, path));
+      return true;
+    }, false);
+  }
+
+  @Override
   public @Nullable InputStream newInputStream(@NonNull ServiceTemplate st, @NonNull String path) throws IOException {
     var client = this.pool.takeClient();
     // open the file

--- a/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
+++ b/modules/storage-sftp/src/test/java/eu/cloudnetservice/modules/sftp/SFTPTemplateStorageTest.java
@@ -193,4 +193,15 @@ public final class SFTPTemplateStorageTest {
     Assertions.assertFalse(storage.contains(TEMPLATE));
     Assertions.assertFalse(storage.hasFile(TEMPLATE, "test.txt"));
   }
+
+  @Test
+  @Order(120)
+  void testDeleteDirectory() {
+    var directory = "hello";
+    Assertions.assertTrue(storage.createDirectory(TEMPLATE, directory));
+    Assertions.assertTrue(storage.createFile(TEMPLATE, directory + "/test.txt"));
+    Assertions.assertTrue(storage.hasFile(TEMPLATE, directory + "/test.txt"));
+    Assertions.assertTrue(storage.deleteDirectory(TEMPLATE, directory));
+    Assertions.assertFalse(storage.hasFile(TEMPLATE, directory + "/test.txt"));
+  }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/template/LocalTemplateStorage.java
+++ b/node/src/main/java/eu/cloudnetservice/node/template/LocalTemplateStorage.java
@@ -194,6 +194,17 @@ public class LocalTemplateStorage implements TemplateStorage {
   }
 
   @Override
+  public boolean deleteDirectory(@NonNull ServiceTemplate template, @NonNull String path) {
+    var dirPath = this.getTemplatePath(template).resolve(path);
+    if (Files.exists(dirPath) && Files.isDirectory(dirPath)) {
+      FileUtil.delete(dirPath);
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
   public @Nullable InputStream newInputStream(
     @NonNull ServiceTemplate template,
     @NonNull String path

--- a/node/src/test/java/eu/cloudnetservice/node/template/LocalTemplateStorageTest.java
+++ b/node/src/test/java/eu/cloudnetservice/node/template/LocalTemplateStorageTest.java
@@ -177,4 +177,15 @@ class LocalTemplateStorageTest {
     Assertions.assertFalse(storage.contains(TEMPLATE));
     Assertions.assertFalse(storage.hasFile(TEMPLATE, "test.txt"));
   }
+
+  @Test
+  @Order(120)
+  void testDeleteDirectory() {
+    var directory = "hello";
+    Assertions.assertTrue(storage.createDirectory(TEMPLATE, directory));
+    Assertions.assertTrue(storage.createFile(TEMPLATE, directory + "/test.txt"));
+    Assertions.assertTrue(storage.hasFile(TEMPLATE, directory + "/test.txt"));
+    Assertions.assertTrue(storage.deleteDirectory(TEMPLATE, directory));
+    Assertions.assertFalse(storage.hasFile(TEMPLATE, directory + "/test.txt"));
+  }
 }


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
See #1198.

### Modification
<!-- Describe the modification you've done to the codebase -->
This change allows developers to directly delete a directory and all its containing files and directories from a given service template.

As an additional functionality, this method is also exposed to the HTTP Rest API much like the file deletion method already is.

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
Developers can now delete entire directory trees from a given template.


##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
Closes #1198.

Local template storage has already been tested on my machine, I will check whether SFTP and S3 storage can be tested. If not, I may seek help from your end.