### PR TITLE
fix: update ProtocolLib download url

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
@@ -32,6 +32,7 @@ import eu.cloudnetservice.modules.npc.node.listeners.NodeSetupListener;
 import eu.cloudnetservice.node.console.animation.progressbar.ConsoleProgressWrappers;
 import eu.cloudnetservice.node.console.animation.setup.answer.Parsers;
 import eu.cloudnetservice.node.module.listener.PluginIncludeListener;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
@@ -71,7 +72,9 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
     });
 
     // download protocol lib
-    progressWrappers.wrapDownload(PROTOCOL_LIB_DOWNLOAD_URL, stream -> FileUtil.copy(stream, PROTOCOL_LIB_CACHE_PATH));
+    progressWrappers.wrapDownload(PROTOCOL_LIB_DOWNLOAD_URL, stream -> {
+      FileUtil.copy(stream, PROTOCOL_LIB_CACHE_PATH);
+    });
 
     // listener register
     eventManager.registerListener(new NodeSetupListener(this, parsers));
@@ -87,7 +90,10 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
         .anyMatch(entry -> service.serviceConfiguration().groups().contains(entry.targetGroup())),
       (service, $) -> {
         var protocolLibPath = service.pluginDirectory().resolve("ProtocolLib.jar");
-        FileUtil.copy(PROTOCOL_LIB_CACHE_PATH, protocolLibPath);
+        // make sure to only copy the cached protocollib jar if it exists
+        if (Files.exists(PROTOCOL_LIB_CACHE_PATH)) {
+          FileUtil.copy(PROTOCOL_LIB_CACHE_PATH, protocolLibPath);
+        }
       }));
   }
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
@@ -72,9 +72,7 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
     });
 
     // download protocol lib
-    progressWrappers.wrapDownload(PROTOCOL_LIB_DOWNLOAD_URL, stream -> {
-      FileUtil.copy(stream, PROTOCOL_LIB_CACHE_PATH);
-    });
+    progressWrappers.wrapDownload(PROTOCOL_LIB_DOWNLOAD_URL, stream -> FileUtil.copy(stream, PROTOCOL_LIB_CACHE_PATH));
 
     // listener register
     eventManager.registerListener(new NodeSetupListener(this, parsers));

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/NodeNPCManagement.java
@@ -42,6 +42,9 @@ import lombok.NonNull;
 public final class NodeNPCManagement extends AbstractNPCManagement {
 
   private static final Path PROTOCOL_LIB_CACHE_PATH = FileUtil.TEMP_DIR.resolve("caches/ProtocolLib.jar");
+  private static final String PROTOCOL_LIB_DOWNLOAD_URL = System.getProperty(
+    "cloudnet.protocollib.download",
+    "https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/build/libs/ProtocolLib.jar");
 
   private final Database database;
   private final Path configurationPath;
@@ -68,9 +71,7 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
     });
 
     // download protocol lib
-    progressWrappers.wrapDownload(
-      "https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/target/ProtocolLib.jar",
-      stream -> FileUtil.copy(stream, PROTOCOL_LIB_CACHE_PATH));
+    progressWrappers.wrapDownload(PROTOCOL_LIB_DOWNLOAD_URL, stream -> FileUtil.copy(stream, PROTOCOL_LIB_CACHE_PATH));
 
     // listener register
     eventManager.registerListener(new NodeSetupListener(this, parsers));


### PR DESCRIPTION
### Motivation
ProtocolLib transitioned from maven to gradle recently. This causes the build url to change.

### Modification
Changed the old download url to the new one.

### Result
ProtocolLib is downloaded again.
