### PR TITLE
update ProtocolLib download url

### DIFF
--- a/cloudnet-modules/cloudnet-npcs/src/main/java/eu/cloudnetservice/cloudnet/ext/npcs/node/listener/IncludePluginListener.java
+++ b/cloudnet-modules/cloudnet-npcs/src/main/java/eu/cloudnetservice/cloudnet/ext/npcs/node/listener/IncludePluginListener.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
 
 public class IncludePluginListener {
 
-  private static final String PROTOCOLLIB_DOWNLOAD_URL = "https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/target/ProtocolLib.jar";
+  private static final String PROTOCOLLIB_DOWNLOAD_URL = "https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/build/libs/ProtocolLib.jar";
   private static final Path PROTOCOLLIB_CACHE_PATH = Paths
     .get(System.getProperty("cloudnet.tempDir", "temp"), "caches", "ProtocolLib.jar");
 


### PR DESCRIPTION
### Motivation
ProtocolLib transitioned from maven to gradle recently. This causes the build url to change.

### Modification
Changed the old download url to the new one.

### Result
ProtocolLib is downloaded again.
