### PR TITLE
[ci skip] ci: make build action a requirement for merge group

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,6 +6,7 @@ on:
     tags-ignore: [ "**" ]
   pull_request:
   workflow_dispatch:
+  merge_group:
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
### Motivation
To enable merge groups we need an action that reports if a change can be merged into the target branch.

### Modification
Trigger the build action on the `merge_group` dispatch as well. This tells GitHub that the action reports the status check.

### Result
Merge groups have a way to figure out if a change can be merged into the target branch.
