### PR TITLE
ci: update action configuration

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,8 @@ on:
     - cron: '00 2 * * *'
 
 concurrency:
-  group: cq-${{ github.event.pull_request.number || github.job }}
   cancel-in-progress: true
+  group: cq-${{ github.event.pull_request.number || github.job }}
 
 jobs:
   analyze:
@@ -22,10 +22,14 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
           java-version: 17
           check-latest: true
-          cache: 'gradle'
+          distribution: 'zulu'
+
+      - name: Setup gradle cache
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -20,10 +20,14 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
           java-version: 17
           check-latest: true
-          cache: 'gradle'
+          distribution: 'zulu'
+
+      - name: Setup gradle cache
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
 
       - name: Publish release to Sonatype
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,8 +45,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '.gradle/loom-cache'
-          restore-keys: ${{ runner.os }}-gradle-
-          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-loom-
+          key: ${{ runner.os }}-gradle-loom-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Execute build and tests
         run: ./gradlew build test shadowJar genUpdaterInformation --stacktrace

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,8 +9,8 @@ on:
   merge_group:
 
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+  group: build-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
   build:
@@ -21,15 +21,11 @@ jobs:
       matrix:
         java:
           - 17
-          - 19
+          - 20
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v6
 
       - name: Validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
@@ -37,17 +33,38 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v3
         with:
+          check-latest: true
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
-          check-latest: true
-          cache: 'gradle'
 
-      - name: Run build lifecycle
-        run: ./gradlew build test shadowJar genUpdaterInformation --no-daemon --stacktrace
+      - name: Setup gradle cache
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/nightly' || matrix.java != 17 }}
+
+      - name: Setup Loom cache
+        uses: actions/cache@v3
+        with:
+          path: '.gradle/loom-cache'
+          restore-keys: ${{ runner.os }}-gradle-
+          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Execute build and tests
+        run: ./gradlew build test shadowJar genUpdaterInformation --stacktrace
+
+      - name: Publish test summary
+        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && matrix.java == 17 }}
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          junit_files: "**/build/test-results/test/TEST-*.xml"
+
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v6
 
       - name: Publish updater metadata
         uses: s0/git-publish-subdir-action@develop
-        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/renovate/') && matrix.java == 17 }}
+        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/renovate/') && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && matrix.java == 17 }}
         env:
           REPO: git@github.com:CloudNetService/launchermeta.git
           BRANCH: ${{ steps.branch-name.outputs.current_branch }}
@@ -68,14 +85,14 @@ jobs:
           fi
 
       - name: Publish snapshot to Sonatype
-        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') && matrix.java == 17 }}
+        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && matrix.java == 17 }}
         run: ./gradlew publish
         env:
           SONATYPE_USER: "${{ secrets.SONATYPE_USER }}"
           SONATYPE_TOKEN: "${{ secrets.SONATYPE_TOKEN }}"
 
       - name: Prepare artifacts zip
-        if: ${{ github.event_name == 'push' && matrix.java == 17 }}
+        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && matrix.java == 17 }}
         run: |
           mkdir -p temp/;
           mkdir -p temp/plugins;
@@ -88,7 +105,7 @@ jobs:
 
       - name: Upload artifacts zip
         uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'push' && matrix.java == 17 }}
+        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && matrix.java == 17 }}
         with:
           name: CloudNet
           path: temp/

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         java:
           - 17
-          - 20
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Motivation
The current action configuration does no longer properly keep up with our requirements.

### Modification
A list of all modifications:
* There are no longer caches stored for each branch. While the action will be able to restore a cache, it's always based on nightly and only the nightly branch will update the cache. This should reduce the amount of stored caches.
* The `gradle-build-action` is now used to manage the caches. The action manages the cache way better than the current, default configuration for gradle caches shipped with the `setup-java` action.
* A specified action step was added that just caches the created Fabric Loom cache. The cache restore is based on the dependency versions and gradle version (it doesn't seems like there is a better way to cache the loom output rather than based off on all dependencies).
* An action step was added that attaches the test results to pull requests and the workflow run.
* Both CodeQL and the Maven Central publish action now use the read-only gradle cache as well.
* The build process is no longer executed on Java 19 alongside Java 17. This will be re-enabled when Kotlin finally supports Java 20 or 21, and it actually makes sense again to test.

### Result
Faster build times and a better action configuration.
