### PR TITLE
build: move checkstyle to version catalog

### DIFF
--- a/build-extensions/src/main/kotlin/Versions.kt
+++ b/build-extensions/src/main/kotlin/Versions.kt
@@ -19,7 +19,4 @@ object Versions {
   // internal versions
   const val cloudNet = "4.0.0-RC9-SNAPSHOT"
   const val cloudNetCodeName = "Blizzard"
-
-  // external tools
-  const val checkstyleTools = "10.6.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,7 +116,7 @@ subprojects {
   }
 
   extensions.configure<CheckstyleExtension> {
-    toolVersion = Versions.checkstyleTools
+    toolVersion = rootProject.libs.versions.checkstyleTools.get()
   }
 
   extensions.configure<SpotlessExtension> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ juppiter = "0.4.0"
 spotless = "6.18.0"
 fabricLoom = "1.1.13"
 nexusPublish = "1.3.0"
+checkstyleTools = "10.10.0"
 
 # google libs
 gson = "2.10.1"
@@ -181,6 +182,9 @@ npcLibLabymod = { group = "com.github.juliarn.NPC-Lib", name = "npc-lib-labymod"
 # fabric platform special dependencies
 minecraft = { group = "com.mojang", name = "minecraft", version.ref = "minecraft" }
 fabricLoader = { group = "net.fabricmc", name = "fabric-loader", version.ref = "fabricLoader" }
+
+# dummy versions, just here for renovate to detect that there is something to update
+checkstyleTools = { group = "com.puppycrawl.tools", name = "checkstyle", version.ref = "checkstyleTools" }
 
 
 [bundles]


### PR DESCRIPTION
### Motivation
At the moment checkstyle is not updated automatically by renovate because the version is not in the version catalog.

### Modification
Move the checkstyle dependency to the version catalog as a dummy version.

### Result
Renovate should auto detect checkstyle updates.
