### PR TITLE
feat: warn about missing manifests and main classes

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
@@ -341,7 +341,7 @@ public class JVMService extends AbstractService {
           path,
           file -> new ApplicationStartupInformation(
             file.getEntry("META-INF/versions.list") != null,
-            this.preCheckJarManifest(file.getManifest()))
+            this.validateManifest(file.getManifest()).getMainAttributes())
         )).orElse(null);
     } catch (IOException exception) {
       LOGGER.severe("Unable to find application file information in %s for environment %s",
@@ -393,13 +393,13 @@ public class JVMService extends AbstractService {
     return builder.toString();
   }
 
-  protected @NonNull Attributes preCheckJarManifest(@Nullable Manifest manifest) {
+  protected @NonNull Manifest validateManifest(@Nullable Manifest manifest) {
     // make sure that we have a manifest at all
-    Preconditions.checkNotNull(manifest, "Application jar does not contain a META-INF/MANIFEST.MF");
+    Preconditions.checkNotNull(manifest, "Application jar does not contain a META-INF/MANIFEST.MF.");
     // make sure that the manifest at least contains a main class
     Preconditions.checkNotNull(manifest.getMainAttributes().getValue("Main-Class"),
       "Application jar MANIFEST.MF does not contain a Main-Class.");
-    return manifest.getMainAttributes();
+    return manifest;
   }
 
   protected record ApplicationStartupInformation(boolean preloadJarContent, @NonNull Attributes mainAttributes) {

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.node.service.defaults;
 
+import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 import eu.cloudnetservice.common.io.FileUtil;
 import eu.cloudnetservice.common.language.I18n;
@@ -54,6 +55,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.NonNull;
@@ -339,7 +341,7 @@ public class JVMService extends AbstractService {
           path,
           file -> new ApplicationStartupInformation(
             file.getEntry("META-INF/versions.list") != null,
-            file.getManifest().getMainAttributes())
+            this.preCheckJarManifest(file.getManifest()))
         )).orElse(null);
     } catch (IOException exception) {
       LOGGER.severe("Unable to find application file information in %s for environment %s",
@@ -389,6 +391,15 @@ public class JVMService extends AbstractService {
     });
     // contains all paths we need now
     return builder.toString();
+  }
+
+  protected @NonNull Attributes preCheckJarManifest(@Nullable Manifest manifest) {
+    // make sure that we have a manifest at all
+    Preconditions.checkNotNull(manifest, "Application jar does not contain a META-INF/MANIFEST.MF");
+    // make sure that the manifest at least contains a main class
+    Preconditions.checkNotNull(manifest.getMainAttributes().getValue("Main-Class"),
+      "Application jar MANIFEST.MF does not contain a Main-Class.");
+    return manifest.getMainAttributes();
   }
 
   protected record ApplicationStartupInformation(boolean preloadJarContent, @NonNull Attributes mainAttributes) {

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/JVMService.java
@@ -395,10 +395,11 @@ public class JVMService extends AbstractService {
 
   protected @NonNull Manifest validateManifest(@Nullable Manifest manifest) {
     // make sure that we have a manifest at all
-    Preconditions.checkNotNull(manifest, "Application jar does not contain a META-INF/MANIFEST.MF.");
+    Preconditions.checkNotNull(manifest, "Application jar does not contain a manifest.");
     // make sure that the manifest at least contains a main class
-    Preconditions.checkNotNull(manifest.getMainAttributes().getValue("Main-Class"),
-      "Application jar MANIFEST.MF does not contain a Main-Class.");
+    Preconditions.checkNotNull(
+      manifest.getMainAttributes().getValue("Main-Class"),
+      "Application jar manifest does not contain a Main-Class.");
     return manifest;
   }
 


### PR DESCRIPTION
### Motivation
If a application does not contain a manifest reading the attributes will fail as the manifest is null. Same goes for the Main-Class, if the manifest does not contain a main class the main class is passed down into the process builder as null which will result in an exception that does not say anything about the main class as it furtherdown the execution chain.

### Modification
Added a new method `preCheckJarManifest` that takes a nullable manifest and ensures that a manifest is present and the manifest contains a main class. Otherwise two exceptions are thrown for each case.

### Result
It is clear what is the issue with the application jar and the service is deleted afterwards instead of staying prepared.
