### PR TITLE
chore: update openapi specs due to recent ServiceConfiguration changes

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
@@ -43,6 +43,11 @@ import org.jetbrains.annotations.Nullable;
 @SuppressWarnings("ClassCanBeRecord")
 public final class ServiceCreateResult {
 
+  /**
+   * A static create result indicating that the service creation failed.
+   */
+  public static final ServiceCreateResult FAILED = new ServiceCreateResult(State.FAILED, null, null);
+
   private final State state;
   private final UUID creationId;
   private final ServiceInfoSnapshot serviceInfo;
@@ -70,11 +75,6 @@ public final class ServiceCreateResult {
     this.creationId = creationId;
     this.serviceInfo = serviceInfo;
   }
-
-  /**
-   * A static create result indicating that the service creation failed.
-   */
-  public static final ServiceCreateResult FAILED = new ServiceCreateResult(State.FAILED, null, null);
 
   /**
    * Creates a new result with the state set to deferred and using the given creation id.

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
@@ -38,6 +38,8 @@ import org.jetbrains.annotations.Nullable;
  */
 @ToString
 @EqualsAndHashCode
+// we need to be able to serialize this class and its fields without invoking the getters & setters to respond
+// to service creation requests coming from the REST API
 @SuppressWarnings("ClassCanBeRecord")
 public final class ServiceCreateResult {
 
@@ -54,7 +56,7 @@ public final class ServiceCreateResult {
    * @throws NullPointerException     if the given state is null.
    * @throws IllegalArgumentException if the creation id is missing or the service info depending on the given state.
    */
-  public ServiceCreateResult(
+  private ServiceCreateResult(
     @NonNull State state,
     @Nullable UUID creationId,
     @Nullable ServiceInfoSnapshot serviceInfo

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -4519,6 +4519,15 @@
               "type" : "string"
             },
             "example" : [ "Parameter1", "Parameter2" ]
+          },
+          "environmentVariables" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "example" : {
+              "MYSQL_PASSWORD" : "PASSWORD"
+            }
           }
         }
       },

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -4650,6 +4650,9 @@
           "$ref" : "#/components/schemas/JsonDocPropertyable"
         }, {
           "properties" : {
+            "retryConfiguration" : {
+              "$ref" : "#/components/schemas/ServiceCreateRetryConfiguration"
+            },
             "serviceId" : {
               "$ref" : "#/components/schemas/ServiceId"
             },
@@ -4744,6 +4747,25 @@
             }
           }
         } ]
+      },
+      "ServiceCreateRetryConfiguration" : {
+        "type" : "object",
+        "properties" : {
+          "maxRetries" : {
+            "type" : "integer",
+            "example" : 5
+          },
+          "backoffStrategy" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer",
+              "example" : [ 500, 1500 ]
+            }
+          },
+          "eventReceivers" : {
+            "type" : "object"
+          }
+        }
       },
       "ServiceCreateResult" : {
         "type" : "object",


### PR DESCRIPTION
### Motivation
The OpenAPI specs had to be adapted due to the past changes to the service configuration. In addition, failure to create a service would lead to an exception on the node, as the ServiceCreationResult could not be serialized.

### Modification
Adopted the changes in the OpenAPI specs and made the ServiceCreationResult a class resolving the serialization errors.

### Result
The OpenAPI specs are up-to date and the serialization is working properly