### PR TITLE
fix: log throwable catched when ticking signs

### DIFF
--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
@@ -252,7 +252,7 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
         try {
           this.tick(signsNeedingTicking);
         } catch (Throwable throwable) {
-          LOGGER.severe("Exception ticking signs");
+          LOGGER.severe("Exception ticking signs", throwable);
         }
       }, 0, 1000 / this.tps(), TimeUnit.MILLISECONDS);
       this.startKnockbackTask();


### PR DESCRIPTION
### Motivation
We catch all throwables while ticking a sign. If any exception occurs we log a warning but that warning is missing the catched throwable and therefore we don't have any information about the reason for the error.

### Modification
Made sure to print the throwable too.

### Result
We have information if something goes wrong
