### PR TITLE
chore: replace remaining gson usages outside the document package

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleDependencyLoader.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleDependencyLoader.java
@@ -22,7 +22,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
-import kong.unirest.Unirest;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 
 /**

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/driver/DriverModule.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/driver/DriverModule.java
@@ -16,12 +16,12 @@
 
 package eu.cloudnetservice.driver.module.driver;
 
-import com.google.gson.JsonSyntaxException;
 import dev.derklaro.aerogel.Element;
 import dev.derklaro.aerogel.InjectionContext;
 import dev.derklaro.aerogel.util.Qualifiers;
 import eu.cloudnetservice.driver.document.Document;
 import eu.cloudnetservice.driver.document.DocumentFactory;
+import eu.cloudnetservice.driver.document.DocumentParseException;
 import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.driver.module.DefaultModule;
 import eu.cloudnetservice.driver.module.Module;
@@ -53,7 +53,7 @@ public class DriverModule extends DefaultModule {
    *
    * @param factory the config factory to use when parsing the configuration.
    * @return the config at the default path.
-   * @throws JsonSyntaxException if the document is invalid.
+   * @throws DocumentParseException if the document cannot be parsed from the given path.
    */
   public @NonNull Document readConfig(@NonNull DocumentFactory factory) {
     return factory.parse(this.configPath());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,8 +47,8 @@ awsSdk = "2.20.47"
 reflexion = "1.8.0"
 geantyref = "1.3.14"
 dockerJava = "3.3.0"
-unirestCore = "4.0.0-RC2"
-unirestMapper = "4.0.0-RC7"
+unirestCore = "4.0.0-RC9"
+unirestMapper = "4.0.0-RC9"
 nightConfig = "3.6.6"
 annotations = "24.0.1"
 influxClient = "6.7.0"
@@ -118,7 +118,7 @@ testContainers = { group = "org.testcontainers", name = "testcontainers", versio
 testContainersJunit = { group = "org.testcontainers", name = "junit-jupiter", version.ref = "testcontainers" }
 
 # unirest
-unirest = { group = "com.konghq", name = "unirest-java", version.ref = "unirestCore" }
+unirest = { group = "com.konghq", name = "unirest-java-core", version.ref = "unirestCore" }
 unirestGson = { group = "com.konghq", name = "unirest-object-mappers-gson", version.ref = "unirestMapper" }
 
 # docker-java

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerHandshakePacketListenerMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerHandshakePacketListenerMixin.java
@@ -42,9 +42,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerHandshakePacketListenerImpl.class)
 public final class ServerHandshakePacketListenerMixin {
 
+  private static final Gson GSON = new Gson();
   private static final Component IP_INFO_MISSING = Component.literal(
     "If you wish to use IP forwarding, please enable it in your BungeeCord config as well!");
-  private static final Gson GSON = new Gson();
 
   @Final
   @Shadow
@@ -65,7 +65,6 @@ public final class ServerHandshakePacketListenerMixin {
           new InetSocketAddress(split[1], ((InetSocketAddress) this.connection.getRemoteAddress()).getPort()));
         // check if properties were supplied
         if (split.length == 4) {
-          // currently there is no way for us to convert a json array to a java array therefore we use gson here
           bridged.forwardedProfile(GSON.fromJson(split[3], Property[].class));
         }
       } else {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerHandshakePacketListenerMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerHandshakePacketListenerMixin.java
@@ -16,9 +16,9 @@
 
 package eu.cloudnetservice.modules.bridge.platform.fabric.mixin.forwarding;
 
-import com.google.gson.Gson;
 import com.mojang.authlib.properties.Property;
 import com.mojang.util.UUIDTypeAdapter;
+import eu.cloudnetservice.driver.document.DocumentFactory;
 import eu.cloudnetservice.modules.bridge.platform.fabric.FabricBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.fabric.util.BridgedClientConnection;
 import java.net.InetSocketAddress;
@@ -42,7 +42,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerHandshakePacketListenerImpl.class)
 public final class ServerHandshakePacketListenerMixin {
 
-  private static final Gson GSON = new Gson();
   private static final Component IP_INFO_MISSING = Component.literal(
     "If you wish to use IP forwarding, please enable it in your BungeeCord config as well!");
 
@@ -65,7 +64,7 @@ public final class ServerHandshakePacketListenerMixin {
           new InetSocketAddress(split[1], ((InetSocketAddress) this.connection.getRemoteAddress()).getPort()));
         // check if properties were supplied
         if (split.length == 4) {
-          bridged.forwardedProfile(GSON.fromJson(split[3], Property[].class));
+          bridged.forwardedProfile(DocumentFactory.json().parse(split[3]).toInstanceOf(Property[].class));
         }
       } else {
         // disconnect will not send the packet - it will just close the channel and set the disconnect reason

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerHandshakePacketListenerMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerHandshakePacketListenerMixin.java
@@ -16,9 +16,9 @@
 
 package eu.cloudnetservice.modules.bridge.platform.fabric.mixin.forwarding;
 
+import com.google.gson.Gson;
 import com.mojang.authlib.properties.Property;
 import com.mojang.util.UUIDTypeAdapter;
-import eu.cloudnetservice.driver.document.DocumentFactory;
 import eu.cloudnetservice.modules.bridge.platform.fabric.FabricBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.fabric.util.BridgedClientConnection;
 import java.net.InetSocketAddress;
@@ -44,6 +44,7 @@ public final class ServerHandshakePacketListenerMixin {
 
   private static final Component IP_INFO_MISSING = Component.literal(
     "If you wish to use IP forwarding, please enable it in your BungeeCord config as well!");
+  private static final Gson GSON = new Gson();
 
   @Final
   @Shadow
@@ -64,7 +65,8 @@ public final class ServerHandshakePacketListenerMixin {
           new InetSocketAddress(split[1], ((InetSocketAddress) this.connection.getRemoteAddress()).getPort()));
         // check if properties were supplied
         if (split.length == 4) {
-          bridged.forwardedProfile(DocumentFactory.json().parse(split[3]).toInstanceOf(Property[].class));
+          // currently there is no way for us to convert a json array to a java array therefore we use gson here
+          bridged.forwardedProfile(GSON.fromJson(split[3], Property[].class));
         }
       } else {
         // disconnect will not send the packet - it will just close the channel and set the disconnect reason

--- a/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/CloudFlareRecordManager.java
+++ b/modules/cloudflare/src/main/java/eu/cloudnetservice/modules/cloudflare/cloudflare/CloudFlareRecordManager.java
@@ -33,9 +33,9 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import kong.unirest.ContentType;
-import kong.unirest.HttpRequestWithBody;
-import kong.unirest.Unirest;
+import kong.unirest.core.ContentType;
+import kong.unirest.core.HttpRequestWithBody;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/NPCConstants.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/_deprecated/NPCConstants.java
@@ -16,13 +16,13 @@
 
 package eu.cloudnetservice.modules.npc._deprecated;
 
-import com.google.gson.reflect.TypeToken;
+import io.leangen.geantyref.TypeFactory;
 import java.lang.reflect.Type;
 import java.util.Collection;
 
 public class NPCConstants {
 
-  public static final Type NPC_COLLECTION_TYPE = TypeToken.getParameterized(Collection.class, CloudNPC.class).getType();
+  public static final Type NPC_COLLECTION_TYPE = TypeFactory.parameterizedClass(Collection.class, CloudNPC.class);
 
   public static final String NPC_CHANNEL_NAME = "cloudnet_npc_channel";
   public static final String NPC_CHANNEL_ADD_NPC_MESSAGE = "add_npc";

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
@@ -41,7 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
-import kong.unirest.Unirest;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/config/PasteServer.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/config/PasteServer.java
@@ -20,7 +20,7 @@ import eu.cloudnetservice.common.Named;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import kong.unirest.Unirest;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 
 public record PasteServer(

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/ConsoleProgressWrappers.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/progressbar/ConsoleProgressWrappers.java
@@ -28,7 +28,7 @@ import jakarta.inject.Singleton;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Iterator;
-import kong.unirest.Unirest;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 
 @Singleton

--- a/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLoadInclusionEvent.java
+++ b/node/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLoadInclusionEvent.java
@@ -19,7 +19,7 @@ package eu.cloudnetservice.node.event.service;
 import eu.cloudnetservice.driver.event.Cancelable;
 import eu.cloudnetservice.driver.service.ServiceRemoteInclusion;
 import eu.cloudnetservice.node.service.CloudService;
-import kong.unirest.GetRequest;
+import kong.unirest.core.GetRequest;
 import lombok.NonNull;
 
 public final class CloudServicePreLoadInclusionEvent extends CloudServiceEvent implements Cancelable {

--- a/node/src/main/java/eu/cloudnetservice/node/module/updater/ModuleUpdater.java
+++ b/node/src/main/java/eu/cloudnetservice/node/module/updater/ModuleUpdater.java
@@ -25,7 +25,7 @@ import eu.cloudnetservice.ext.updater.Updater;
 import eu.cloudnetservice.ext.updater.util.ChecksumUtil;
 import jakarta.inject.Singleton;
 import java.nio.file.StandardCopyOption;
-import kong.unirest.Unirest;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 
 @Singleton

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
@@ -79,8 +79,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiPredicate;
 import java.util.regex.Pattern;
-import kong.unirest.Unirest;
-import kong.unirest.UnirestException;
+import kong.unirest.core.Unirest;
+import kong.unirest.core.UnirestException;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
+++ b/node/src/main/java/eu/cloudnetservice/node/setup/DefaultConfigSetup.java
@@ -42,7 +42,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import kong.unirest.Unirest;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 
 @Singleton

--- a/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionProvider.java
@@ -49,7 +49,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import kong.unirest.Unirest;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;

--- a/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionProvider.java
@@ -16,7 +16,7 @@
 
 package eu.cloudnetservice.node.version;
 
-import static com.google.gson.reflect.TypeToken.getParameterized;
+import static io.leangen.geantyref.TypeFactory.parameterizedClass;
 
 import com.google.common.base.Preconditions;
 import eu.cloudnetservice.common.io.FileUtil;
@@ -64,8 +64,8 @@ public class ServiceVersionProvider {
 
   private static final int VERSIONS_FILE_VERSION = 3;
 
-  private static final Type COL_SER_VERSION = getParameterized(Collection.class, ServiceVersionType.class).getType();
-  private static final Type COL_ENV_TYPE = getParameterized(Collection.class, ServiceEnvironmentType.class).getType();
+  private static final Type COL_SER_VERSION = parameterizedClass(Collection.class, ServiceVersionType.class);
+  private static final Type COL_ENV_TYPE = parameterizedClass(Collection.class, ServiceEnvironmentType.class);
 
   private final Map<String, ServiceVersionType> serviceVersionTypes = new ConcurrentHashMap<>();
   private final Map<String, ServiceEnvironmentType> serviceEnvironmentTypes = new ConcurrentHashMap<>();

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/FabricApiVersionFetch.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/FabricApiVersionFetch.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
-import kong.unirest.JsonNode;
-import kong.unirest.Unirest;
-import kong.unirest.json.JSONObject;
+import kong.unirest.core.JsonNode;
+import kong.unirest.core.Unirest;
+import kong.unirest.core.json.JSONObject;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -47,7 +47,7 @@ public class FabricApiVersionFetch implements InstallStepExecutor {
         throw new IllegalStateException("Unable to retrieve latest installer for fabric");
       }
 
-
+      // search for a stable fabric version
       for (var entry : jsonNode.getArray()) {
         if (entry instanceof JSONObject jsonObject) {
           // only allow stable fabric versions

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/FabricApiVersionFetch.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/FabricApiVersionFetch.java
@@ -54,11 +54,10 @@ public class FabricApiVersionFetch implements InstallStepExecutor {
           if (jsonObject.getBoolean("stable")) {
             // set the fabric loader download url
             installer.serviceVersion().url(jsonObject.getString("url"));
+            // we don't have any paths
+            return Collections.emptySet();
           }
         }
-
-        // we don't have any paths
-        return Collections.emptySet();
       }
       // could not find any stable fabric version
       throw new IllegalStateException("Unable to retrieve latest installer for fabric (no stable version found)");

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/PaperApiVersionFetchStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/PaperApiVersionFetchStepExecutor.java
@@ -27,7 +27,7 @@ import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
-import kong.unirest.Unirest;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 
 public class PaperApiVersionFetchStepExecutor implements InstallStepExecutor {
@@ -78,10 +78,10 @@ public class PaperApiVersionFetchStepExecutor implements InstallStepExecutor {
     var response = Unirest.get(apiUrl)
       .accept("application/json")
       .asString();
-
     if (response.isSuccess()) {
       return DocumentFactory.json().parse(response.getBody());
     }
+
     return Document.newJsonDocument();
   }
 

--- a/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/SpongeApiVersionFetchStepExecutor.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/execute/defaults/SpongeApiVersionFetchStepExecutor.java
@@ -24,8 +24,8 @@ import eu.cloudnetservice.node.version.information.VersionInstaller;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Set;
-import kong.unirest.HttpStatus;
-import kong.unirest.Unirest;
+import kong.unirest.core.HttpStatus;
+import kong.unirest.core.Unirest;
 import lombok.NonNull;
 
 public class SpongeApiVersionFetchStepExecutor implements InstallStepExecutor {


### PR DESCRIPTION
### Motivation
We've replaced gson at most places with out own document api but some places still used gson.

### Modification
Removed usages of gson outside the document package and in order to do that updated unirest.

### Result
Gson is not used in any other package than the document package.