### PR TITLE
fix: reverse http handler calling order

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/http/NettyHttpServerHandler.java
@@ -153,7 +153,7 @@ final class NettyHttpServerHandler extends SimpleChannelInboundHandler<HttpReque
 
     // get all handlers which should be tested if they can accept the http request
     var entries = new ArrayList<>(this.nettyHttpServer.registeredHandlers);
-    entries.sort(Comparator.comparingInt(NettyHttpServer.HttpHandlerEntry::priority));
+    entries.sort(Comparator.comparingInt(NettyHttpServer.HttpHandlerEntry::priority).reversed());
 
     // build the context around the http request
     var pathEntries = fullPath.split("/");

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/http/NettyHttpServerHttpTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/http/NettyHttpServerHttpTest.java
@@ -203,7 +203,7 @@ public class NettyHttpServerHttpTest extends NetworkTestCase {
 
     this.httpServer.registerHandler(
       "/test1",
-      HttpHandler.PRIORITY_LOW,
+      HttpHandler.PRIORITY_HIGH,
       new HttpHandler() {
         @Override
         public void handle(String path, HttpContext context) {
@@ -214,7 +214,7 @@ public class NettyHttpServerHttpTest extends NetworkTestCase {
       });
     this.httpServer.registerHandler(
       "/test1",
-      HttpHandler.PRIORITY_HIGH,
+      HttpHandler.PRIORITY_LOW,
       new HttpHandler() {
         @Override
         public void handle(String path, HttpContext context) {

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerNode.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerNode.java
@@ -98,7 +98,7 @@ public final class V2HttpHandlerNode extends V2HttpHandler {
     this.groupConfigurationProvider = groupConfigurationProvider;
   }
 
-  @HttpRequestHandler(paths = "/api/v2/node", priority = HttpHandler.PRIORITY_HIGH)
+  @HttpRequestHandler(paths = "/api/v2/node", priority = HttpHandler.PRIORITY_LOW)
   private void handleNodePing(@NonNull HttpContext context) {
     this.response(context, HttpResponseCode.NO_CONTENT).context().closeAfter(true).cancelNext(true);
   }


### PR DESCRIPTION
### Motivation
The priority is documented as `Handlers with a high priority will get called before handlers with a low priority.` But the current implementation does not follow that documentation therefore we need to reverse the comparator to achieve a correct call chain.

### Modification
Reversed the sorting comperator and inverted the priority in the test cases and the in the node rest handler to ensure that no behavior changes.

### Result
The call chain is as documented
