### PR TITLE
feat: enable injection of services from the service registry

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/registry/DefaultServiceRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/registry/DefaultServiceRegistry.java
@@ -47,7 +47,7 @@ public class DefaultServiceRegistry implements ServiceRegistry {
   public DefaultServiceRegistry(@NonNull InjectionLayer<?> injectionLayer) {
     var bindingConstructor = BindingBuilder.create()
       .bindMatching(element -> {
-        // ensure that the element has special requirements
+        // ensure that the element has at least one special requirement (like the Service annotation)
         if (element.hasSpecialRequirements()) {
           return element.requiredAnnotations()
             .stream()
@@ -72,7 +72,6 @@ public class DefaultServiceRegistry implements ServiceRegistry {
             }
           }).orElse(null);
       });
-
     injectionLayer.install(bindingConstructor);
   }
 

--- a/driver/src/main/java/eu/cloudnetservice/driver/registry/DefaultServiceRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/registry/DefaultServiceRegistry.java
@@ -19,6 +19,11 @@ package eu.cloudnetservice.driver.registry;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import dev.derklaro.aerogel.auto.Provides;
+import dev.derklaro.aerogel.binding.BindingBuilder;
+import dev.derklaro.aerogel.internal.reflect.TypeUtil;
+import eu.cloudnetservice.driver.inject.InjectionLayer;
+import eu.cloudnetservice.driver.registry.injection.Service;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.Collection;
 import java.util.Collections;
@@ -37,6 +42,39 @@ public class DefaultServiceRegistry implements ServiceRegistry {
   protected final Multimap<Class<?>, RegistryEntry<?>> providers = Multimaps.newMultimap(
     new ConcurrentHashMap<>(),
     ConcurrentHashMap::newKeySet);
+
+  @Inject
+  public DefaultServiceRegistry(@NonNull InjectionLayer<?> injectionLayer) {
+    var bindingConstructor = BindingBuilder.create()
+      .bindMatching(element -> {
+        // ensure that the element has special requirements
+        if (element.hasSpecialRequirements()) {
+          return element.requiredAnnotations()
+            .stream()
+            .anyMatch(predicate -> predicate.annotationType().equals(Service.class));
+        } else {
+          return false;
+        }
+      }).toLazyProvider((element, $) -> () -> {
+        // get the predicate for the Service annotation
+        return element.requiredAnnotations().stream()
+          .filter(predicate -> predicate.annotationType().equals(Service.class))
+          .findFirst()
+          .map(annotationPredicate -> {
+            var annotationValues = annotationPredicate.annotationValues();
+            var serviceClass = TypeUtil.rawType(element.componentType());
+            var serviceName = (String) annotationValues.get("name");
+
+            if (serviceName.isEmpty()) {
+              return this.firstProvider(serviceClass);
+            } else {
+              return this.provider(serviceClass, serviceName);
+            }
+          }).orElse(null);
+      });
+
+    injectionLayer.install(bindingConstructor);
+  }
 
   /**
    * {@inheritDoc}

--- a/driver/src/main/java/eu/cloudnetservice/driver/registry/injection/Service.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/registry/injection/Service.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.registry.injection;
+
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import lombok.NonNull;
+
+/**
+ * This annotation enables the use of registered services from the service registry in an injection context.
+ * <p>
+ * Instead of doing something like:
+ * <pre>
+ * {@code
+ *   @Inject
+ *   public TestClass(ServiceRegistry registry) {
+ *     var playerManager = registry.firstProvider(PlayerManager.class);
+ *     playerManager.onlineCount();
+ *   }
+ * }
+ * </pre>
+ * Using this annotation you can do something like:
+ * <pre>
+ * {@code
+ *   @Inject
+ *   public TestClass(@Service PlayerManager playerManager) {
+ *     playerManager.onlineCount();
+ *   }
+ * }
+ * </pre>
+ * <p>
+ * Note: If a service or a service name is requested that the service registry does not know {@code null} is passed as
+ * parameter value.
+ *
+ * @see eu.cloudnetservice.driver.registry.ServiceRegistry
+ * @since 4.0
+ */
+@Qualifier
+@Documented
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Service {
+
+  /**
+   * The name of the registered provider in the service registry. Leave empty if the name of the provider is not
+   * important and any provider with a matching class is accepted.
+   *
+   * @return name of the registered provider in the service registry.
+   */
+  @NonNull String name() default "";
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/registry/injection/Service.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/registry/injection/Service.java
@@ -55,8 +55,8 @@ import lombok.NonNull;
  */
 @Qualifier
 @Documented
-@Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 public @interface Service {
 
   /**

--- a/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.driver.registry;
 
+import eu.cloudnetservice.driver.inject.InjectionLayer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +24,7 @@ public final class ServiceRegistryTest {
 
   @Test
   public void testDefaultRegistry() {
-    ServiceRegistry registry = new DefaultServiceRegistry();
+    var registry = new DefaultServiceRegistry(InjectionLayer.ext());
 
     registry
       .registerProvider(A.class, "b", new B())

--- a/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
@@ -17,6 +17,8 @@
 package eu.cloudnetservice.driver.registry;
 
 import eu.cloudnetservice.driver.inject.InjectionLayer;
+import eu.cloudnetservice.driver.registry.injection.Service;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +26,7 @@ public final class ServiceRegistryTest {
 
   @Test
   public void testDefaultRegistry() {
-    var registry = new DefaultServiceRegistry(InjectionLayer.ext());
+    var registry = new DefaultServiceRegistry(InjectionLayer.boot());
 
     registry
       .registerProvider(A.class, "b", new B())
@@ -52,6 +54,24 @@ public final class ServiceRegistryTest {
 
     Assertions.assertEquals(0, registry.providers(A.class).size());
     registry.unregisterAll();
+  }
+
+  @Test
+  public void testRegistryInjection() {
+    var registry = new DefaultServiceRegistry(InjectionLayer.boot());
+    registry.registerProvider(A.class, "b", new B());
+
+    var d = InjectionLayer.boot().instance(D.class);
+    Assertions.assertNotNull(d.a());
+    Assertions.assertNotNull(d.b());
+    Assertions.assertNull(d.c());
+  }
+
+  private record D(@Service A a, @Service(name = "b") A b, @Service(name = "non-existing") A c) {
+
+    @Inject
+    D {
+    }
   }
 
   private interface A {

--- a/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
@@ -58,27 +58,28 @@ public final class ServiceRegistryTest {
   @Test
   public void testRegistryInjection() {
     var registry = new DefaultServiceRegistry(InjectionLayer.boot());
-    var b = new B();
+    var instanceB = new B();
 
-    registry.registerProvider(A.class, "b", b);
+    registry.registerProvider(A.class, "b", instanceB);
     registry.registerProvider(A.class, "c", new B());
 
-    var d = InjectionLayer.boot().instance(D.class);
-    Assertions.assertNotNull(d.a());
+    var serviceD = InjectionLayer.boot().instance(D.class);
+    Assertions.assertNotNull(serviceD.withoutSpecialName());
 
-    Assertions.assertNotNull(d.b());
-    Assertions.assertSame(b, d.b());
+    Assertions.assertNotNull(serviceD.specialNameB());
+    Assertions.assertSame(instanceB, serviceD.specialNameB());
 
-    Assertions.assertNotSame(b, d.c());
+    Assertions.assertNotSame(instanceB, serviceD.specialNameC());
 
-    Assertions.assertNull(d.nonExistent());
+    Assertions.assertNull(serviceD.nonExistent());
   }
 
   private record D(
-    @Service A a,
-    @Service(name = "b") A b,
-    @Service(name = "c") A c,
-    @Service(name = "non-existing") A nonExistent) {
+    @Service A withoutSpecialName,
+    @Service(name = "b") A specialNameB,
+    @Service(name = "c") A specialNameC,
+    @Service(name = "non-existing") A nonExistent
+  ) {
 
   }
 

--- a/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/registry/ServiceRegistryTest.java
@@ -18,7 +18,6 @@ package eu.cloudnetservice.driver.registry;
 
 import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.driver.registry.injection.Service;
-import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -59,19 +58,28 @@ public final class ServiceRegistryTest {
   @Test
   public void testRegistryInjection() {
     var registry = new DefaultServiceRegistry(InjectionLayer.boot());
-    registry.registerProvider(A.class, "b", new B());
+    var b = new B();
+
+    registry.registerProvider(A.class, "b", b);
+    registry.registerProvider(A.class, "c", new B());
 
     var d = InjectionLayer.boot().instance(D.class);
     Assertions.assertNotNull(d.a());
+
     Assertions.assertNotNull(d.b());
-    Assertions.assertNull(d.c());
+    Assertions.assertSame(b, d.b());
+
+    Assertions.assertNotSame(b, d.c());
+
+    Assertions.assertNull(d.nonExistent());
   }
 
-  private record D(@Service A a, @Service(name = "b") A b, @Service(name = "non-existing") A c) {
+  private record D(
+    @Service A a,
+    @Service(name = "b") A b,
+    @Service(name = "c") A c,
+    @Service(name = "non-existing") A nonExistent) {
 
-    @Inject
-    D {
-    }
   }
 
   private interface A {


### PR DESCRIPTION
### Motivation
We wanted to replace the service registry fully with injection but that would result in a weird injection tree and instead we can just make it easier to use the service registry when using injection.

### Modification
Added a new `@Service` annotation which retrieves the declared element from the service registry instead of any injection binding.
 
### Result
Injection and the service registry go hand in hand and there is no need to remove the service registry
