### PR TITLE
[ci skip] chore: bridge message typo

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
@@ -41,7 +41,7 @@ public final class BridgeConfiguration {
     new HashMap<>(ImmutableMap.<String, String>builder()
       .put("command-hub-success-connect", "§7You did successfully connect to %server%.")
       .put("command-hub-already-in-hub", "§cYou are already connected to a hub service.")
-      .put("command-hub-no-server-found", "§7The is currently §cno §7hub server available.")
+      .put("command-hub-no-server-found", "§7There is currently §cno §7hub server available.")
       .put("server-join-cancel-because-maintenance", "§7This server is currently in maintenance mode.")
       .put("server-join-cancel-because-permission", "§7You do not have the required permissions to join this server.")
       .put("proxy-join-cancel-because-permission", "§7You do not have the required permissions to join this proxy.")


### PR DESCRIPTION
### Motivation
Typo in the default bridge messages.

### Modification
Fixed the typo in the default bridge message.

### Result
No typo anymore.
