### PR TITLE
chore: replace service registry usages

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistry.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistry.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import eu.cloudnetservice.driver.inject.InjectionLayer;
 import java.util.Collection;
 import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.UnknownNullability;
 import org.jetbrains.annotations.UnmodifiableView;
 
@@ -42,7 +43,15 @@ public interface ServiceRegistry {
    * @param <T>     the type of the service to query.
    * @return the last registered provider for the given service or null if no provider is registered.
    * @throws NullPointerException if the given service class is null.
+   * @deprecated the method is deprecated as it requires abusing the purpose of dependency injection in order to work.
+   * There are two ways to replace this part of the api
+   * <ul>
+   *   <li>injecting the service registry itself and calling {@link #firstProvider(Class)}.</li>
+   *   <li>injecting the requested service directly using the {@link eu.cloudnetservice.driver.registry.injection.Service} annotation.</li>
+   * </ul>
    */
+  @Deprecated(since = "4.0", forRemoval = true)
+  @ApiStatus.ScheduledForRemoval(inVersion = "4.1")
   static <T> @UnknownNullability T first(@NonNull Class<T> service) {
     var registry = InjectionLayer.boot().instance(ServiceRegistry.class);
     return registry.firstProvider(service);

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
@@ -34,6 +34,7 @@ import eu.cloudnetservice.modules.bridge.BridgeDocProperties;
 import eu.cloudnetservice.modules.bridge.node.player.NodePlayerManager;
 import eu.cloudnetservice.modules.bridge.player.CloudOfflinePlayer;
 import eu.cloudnetservice.modules.bridge.player.CloudPlayer;
+import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
 import eu.cloudnetservice.node.command.annotation.CommandAlias;
 import eu.cloudnetservice.node.command.annotation.Description;
 import eu.cloudnetservice.node.command.exception.ArgumentNotAvailableException;
@@ -222,7 +223,7 @@ public class PlayersCommand {
     var reasonComponent = reason == null
       ? Component.empty()
       : ComponentFormats.BUNGEE_TO_ADVENTURE.convert(reason);
-    player.playerExecutor().kick(reasonComponent);
+    this.playerExecutor(player).kick(reasonComponent);
 
     source.sendMessage(I18n.trans("module-bridge-command-players-kick-player",
       player.name(),
@@ -242,7 +243,7 @@ public class PlayersCommand {
     @NonNull @Argument("player") CloudPlayer player,
     @NonNull @Greedy @Argument("message") String message
   ) {
-    player.playerExecutor().sendChatMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message));
+    this.playerExecutor(player).sendChatMessage(ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message));
     source.sendMessage(
       I18n.trans("module-bridge-command-players-send-player-message", player.name(), player.uniqueId()));
   }
@@ -254,7 +255,7 @@ public class PlayersCommand {
     @NonNull @Argument("server") ServiceInfoSnapshot server
   ) {
     if (server.readProperty(BridgeDocProperties.IS_ONLINE)) {
-      player.playerExecutor().connect(server.name());
+      this.playerExecutor(player).connect(server.name());
 
       source.sendMessage(
         I18n.trans("module-bridge-command-players-send-player-server", player.name(), player.uniqueId()));
@@ -262,5 +263,9 @@ public class PlayersCommand {
       source.sendMessage(
         I18n.trans("module-bridge-command-players-send-player-server-not-found", player.name(), player.uniqueId()));
     }
+  }
+
+  private @NonNull PlayerExecutor playerExecutor(@NonNull CloudPlayer cloudPlayer) {
+    return this.playerManager.playerExecutor(cloudPlayer.uniqueId());
   }
 }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudPlayer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudPlayer.java
@@ -17,8 +17,6 @@
 package eu.cloudnetservice.modules.bridge.player;
 
 import eu.cloudnetservice.driver.document.Document;
-import eu.cloudnetservice.driver.registry.ServiceRegistry;
-import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
@@ -30,6 +28,9 @@ import org.jetbrains.annotations.Nullable;
  * node as long as he is online.
  * <p>
  * Obtain an online player using {@link PlayerManager#onlinePlayer(UUID)}.
+ * <p>
+ * If you want to interact with a player use the
+ * {@link eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor} instead.
  *
  * @since 4.0
  */
@@ -168,16 +169,5 @@ public class CloudPlayer extends CloudOfflinePlayer {
    */
   public void onlineProperties(@NonNull Document onlineProperties) {
     this.onlineProperties = onlineProperties.immutableCopy();
-  }
-
-  /**
-   * Gets a player executor for this cloud player instance by the unique id.
-   * <p>
-   * The method is equivalent to calling {@code playerManager.playerExecutor(uniqueId)}.
-   *
-   * @return the player executor for this player.
-   */
-  public @NonNull PlayerExecutor playerExecutor() {
-    return ServiceRegistry.first(PlayerManager.class).playerExecutor(this.uniqueId());
   }
 }

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/PlatformLabyModManagement.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/PlatformLabyModManagement.java
@@ -331,12 +331,13 @@ public class PlatformLabyModManagement implements LabyModManagement {
         this.sendPluginMessage(player, discordRPCData);
       }
 
-      player.playerExecutor().connect(serviceInfoSnapshot.name());
+      this.playerManager.playerExecutor(player.uniqueId()).connect(serviceInfoSnapshot.name());
     }
   }
 
   protected void sendPluginMessage(@NonNull CloudPlayer player, @NonNull DataBuf dataBuf) {
-    player.playerExecutor().sendPluginMessage(LABYMOD_CLIENT_CHANNEL, dataBuf.toByteArray());
+    this.playerManager.playerExecutor(player.uniqueId())
+      .sendPluginMessage(LABYMOD_CLIENT_CHANNEL, dataBuf.toByteArray());
   }
 
   protected @Nullable LabyModPlayerOptions parsePlayerOptions(@NonNull CloudPlayer player) {

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/PlatformLabyModManagement.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/PlatformLabyModManagement.java
@@ -25,7 +25,7 @@ import eu.cloudnetservice.driver.network.buffer.DataBufFactory;
 import eu.cloudnetservice.driver.network.rpc.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.RPCSender;
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
-import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
@@ -54,12 +54,14 @@ public class PlatformLabyModManagement implements LabyModManagement {
   public PlatformLabyModManagement(
     @NonNull RPCFactory rpcFactory,
     @NonNull NetworkClient networkClient,
-    @NonNull CloudServiceProvider cloudServiceProvider
+    @NonNull @Service PlayerManager playerManager,
+    @NonNull CloudServiceProvider cloudServiceProvider,
+    @NonNull @Service PlatformBridgeManagement<?, ?> bridgeManagement
   ) {
     this.cloudServiceProvider = cloudServiceProvider;
     this.rpcSender = rpcFactory.providerForClass(networkClient, LabyModManagement.class);
-    this.playerManager = ServiceRegistry.first(PlayerManager.class);
-    this.bridgeManagement = ServiceRegistry.first(PlatformBridgeManagement.class);
+    this.playerManager = playerManager;
+    this.bridgeManagement = bridgeManagement;
     this.setConfigurationSilently(this.rpcSender.invokeMethod("configuration").fireSync());
   }
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/node/CloudNetNPCModule.java
@@ -26,6 +26,7 @@ import eu.cloudnetservice.driver.module.ModuleLifeCycle;
 import eu.cloudnetservice.driver.module.ModuleTask;
 import eu.cloudnetservice.driver.module.driver.DriverModule;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.driver.util.ModuleHelper;
 import eu.cloudnetservice.modules.npc.NPC;
 import eu.cloudnetservice.modules.npc.NPCManagement;
@@ -47,6 +48,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
 
 @Singleton
 public class CloudNetNPCModule extends DriverModule {
@@ -206,8 +208,7 @@ public class CloudNetNPCModule extends DriverModule {
   }
 
   @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
-  public void handleReload(@NonNull ServiceRegistry serviceRegistry) {
-    var management = serviceRegistry.firstProvider(NPCManagement.class);
+  public void handleReload(@Nullable @Service NPCManagement management) {
     if (management != null) {
       management.npcConfiguration(this.loadConfig());
     }

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -25,10 +25,12 @@ import com.google.common.base.Preconditions;
 import eu.cloudnetservice.driver.ComponentInfo;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceLifeCycle;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.npc.NPC;
 import eu.cloudnetservice.modules.npc.configuration.NPCConfiguration;
 import eu.cloudnetservice.modules.npc.platform.PlatformNPCManagement;
@@ -59,6 +61,7 @@ public class BukkitPlatformNPCManagement extends
   protected final Plugin plugin;
   protected final Server server;
   protected final BukkitScheduler scheduler;
+  protected final PlayerManager playerManager;
 
   protected final Platform<World, Player, ItemStack, Plugin> npcPlatform;
   protected final BukkitTask knockBackTask;
@@ -72,6 +75,7 @@ public class BukkitPlatformNPCManagement extends
     @NonNull BukkitScheduler scheduler,
     @NonNull EventManager eventManager,
     @NonNull ComponentInfo componentInfo,
+    @NonNull @Service PlayerManager playerManager,
     @NonNull CloudServiceProvider cloudServiceProvider,
     @NonNull WrapperConfiguration wrapperConfiguration
   ) {
@@ -80,6 +84,7 @@ public class BukkitPlatformNPCManagement extends
     this.plugin = plugin;
     this.server = server;
     this.scheduler = scheduler;
+    this.playerManager = playerManager;
 
     // npc pool init
     var entry = this.applicableNPCConfigurationEntry();
@@ -164,8 +169,15 @@ public class BukkitPlatformNPCManagement extends
     @NonNull NPC base
   ) {
     return base.npcType() == NPC.NPCType.ENTITY
-      ? new EntityBukkitPlatformSelectorEntity(base, this.plugin, this.server, this.scheduler, this)
-      : new NPCBukkitPlatformSelector(base, this.plugin, this.server, this.scheduler, this, this.npcPlatform);
+      ? new EntityBukkitPlatformSelectorEntity(base, this.plugin, this.server, this.scheduler, this.playerManager, this)
+      : new NPCBukkitPlatformSelector(
+        base,
+        this.plugin,
+        this.server,
+        this.scheduler,
+        this.playerManager,
+        this,
+        this.npcPlatform);
   }
 
   @Override

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -18,7 +18,6 @@ package eu.cloudnetservice.modules.npc.platform.bukkit.entity;
 
 import dev.derklaro.reflexion.MethodAccessor;
 import dev.derklaro.reflexion.Reflexion;
-import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.modules.bridge.BridgeDocProperties;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
@@ -67,6 +66,7 @@ public abstract class BukkitPlatformSelectorEntity
   protected final Plugin plugin;
   protected final Server server;
   protected final BukkitScheduler scheduler;
+  protected final PlayerManager playerManager;
   protected final BukkitPlatformNPCManagement npcManagement;
 
   protected final UUID uniqueId;
@@ -84,12 +84,14 @@ public abstract class BukkitPlatformSelectorEntity
     @NonNull Plugin plugin,
     @NonNull Server server,
     @NonNull BukkitScheduler scheduler,
+    @NonNull PlayerManager playerManager,
     @NonNull BukkitPlatformNPCManagement npcManagement
   ) {
     this.npc = npc;
     this.plugin = plugin;
     this.server = server;
     this.scheduler = scheduler;
+    this.playerManager = playerManager;
     this.npcManagement = npcManagement;
     this.npcLocation = npcManagement.toPlatformLocation(npc.location());
     // construct the unique id randomly
@@ -469,7 +471,7 @@ public abstract class BukkitPlatformSelectorEntity
   }
 
   protected @NonNull PlayerManager playerManager() {
-    return ServiceRegistry.first(PlayerManager.class);
+    return this.playerManager;
   }
 
   protected double heightAddition(int lineNumber) {

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/EntityBukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/EntityBukkitPlatformSelectorEntity.java
@@ -22,6 +22,7 @@ import static eu.cloudnetservice.modules.npc.platform.bukkit.util.ReflectionUtil
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import dev.derklaro.reflexion.MethodAccessor;
 import dev.derklaro.reflexion.Reflexion;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.npc.NPC;
 import eu.cloudnetservice.modules.npc.platform.bukkit.BukkitPlatformNPCManagement;
 import eu.cloudnetservice.modules.npc.platform.bukkit.util.ReflectionUtil;
@@ -89,9 +90,10 @@ public class EntityBukkitPlatformSelectorEntity extends BukkitPlatformSelectorEn
     @NonNull Plugin plugin,
     @NonNull Server server,
     @NonNull BukkitScheduler scheduler,
+    @NonNull PlayerManager playerManager,
     @NonNull BukkitPlatformNPCManagement npcManagement
   ) {
-    super(npc, plugin, server, scheduler, npcManagement);
+    super(npc, plugin, server, scheduler, playerManager, npcManagement);
   }
 
   @Override

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
@@ -22,6 +22,7 @@ import com.github.juliarn.npclib.api.flag.NpcFlag;
 import com.github.juliarn.npclib.api.profile.Profile;
 import com.github.juliarn.npclib.api.profile.ProfileProperty;
 import com.github.juliarn.npclib.bukkit.util.BukkitPlatformUtil;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.npc.NPC;
 import eu.cloudnetservice.modules.npc.platform.PlatformSelectorEntity;
 import eu.cloudnetservice.modules.npc.platform.bukkit.BukkitPlatformNPCManagement;
@@ -52,10 +53,11 @@ public class NPCBukkitPlatformSelector extends BukkitPlatformSelectorEntity {
     @NonNull Plugin plugin,
     @NonNull Server server,
     @NonNull BukkitScheduler scheduler,
+    @NonNull PlayerManager playerManager,
     @NonNull BukkitPlatformNPCManagement npcManagement,
     @NonNull Platform<World, Player, ItemStack, Plugin> platform
   ) {
-    super(npc, plugin, server, scheduler, npcManagement);
+    super(npc, plugin, server, scheduler, playerManager, npcManagement);
     this.platform = platform;
   }
 

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/CloudNetReportModule.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/CloudNetReportModule.java
@@ -23,6 +23,7 @@ import eu.cloudnetservice.driver.module.ModuleTask;
 import eu.cloudnetservice.driver.module.ModuleWrapper;
 import eu.cloudnetservice.driver.module.driver.DriverModule;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.driver.service.GroupConfiguration;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceTask;
@@ -58,8 +59,7 @@ public final class CloudNetReportModule extends DriverModule {
   }
 
   @ModuleTask(order = 64)
-  public void registerDefaultEmitters() {
-    var emitterRegistry = ServiceRegistry.first(EmitterRegistry.class);
+  public void registerDefaultEmitters(@NonNull @Service EmitterRegistry emitterRegistry) {
     emitterRegistry
       // general emitters
       .registerEmitter(SystemInfoDataEmitter.class)

--- a/modules/report/src/main/java/eu/cloudnetservice/modules/report/command/ReportCommand.java
+++ b/modules/report/src/main/java/eu/cloudnetservice/modules/report/command/ReportCommand.java
@@ -29,7 +29,7 @@ import eu.cloudnetservice.common.log.LogManager;
 import eu.cloudnetservice.common.log.Logger;
 import eu.cloudnetservice.driver.module.ModuleWrapper;
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
-import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.driver.service.GroupConfiguration;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceTask;
@@ -65,10 +65,14 @@ public final class ReportCommand {
   private final CloudServiceProvider serviceProvider;
 
   @Inject
-  public ReportCommand(@NonNull CloudNetReportModule reportModule, @NonNull CloudServiceProvider serviceProvider) {
+  public ReportCommand(
+    @NonNull CloudNetReportModule reportModule,
+    @NonNull CloudServiceProvider serviceProvider,
+    @NonNull @Service EmitterRegistry emitterRegistry
+  ) {
     this.reportModule = reportModule;
     this.serviceProvider = serviceProvider;
-    this.emitterRegistry = ServiceRegistry.first(EmitterRegistry.class);
+    this.emitterRegistry = emitterRegistry;
   }
 
   @Parser(suggestions = "pasteServer")

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSign.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.modules.signs.platform;
 
-import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
 import eu.cloudnetservice.modules.bridge.player.PlayerManager;
@@ -33,14 +32,18 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class PlatformSign<P, C> implements Comparable<PlatformSign<P, C>> {
 
-  private static final PlayerManager PLAYER_MANAGER = ServiceRegistry.first(PlayerManager.class);
-
   protected final Sign base;
+  protected final PlayerManager playerManager;
   protected final Function<String, C> lineMapper;
   protected volatile ServiceInfoSnapshot target;
 
-  public PlatformSign(@NonNull Sign base, @NonNull Function<String, C> lineMapper) {
+  public PlatformSign(
+    @NonNull Sign base,
+    @NonNull PlayerManager playerManager,
+    @NonNull Function<String, C> lineMapper
+  ) {
     this.base = base;
+    this.playerManager = playerManager;
     this.lineMapper = lineMapper;
   }
 
@@ -76,7 +79,7 @@ public abstract class PlatformSign<P, C> implements Comparable<PlatformSign<P, C
       return;
     }
 
-    PLAYER_MANAGER.playerExecutor(playerUniqueId).connect(target.name());
+    this.playerManager.playerExecutor(playerUniqueId).connect(target.name());
   }
 
   public int priority() {

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitPlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitPlatformSign.java
@@ -18,6 +18,7 @@ package eu.cloudnetservice.modules.signs.platform.bukkit;
 
 import eu.cloudnetservice.common.util.StringUtil;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.configuration.SignLayout;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -39,8 +40,13 @@ final class BukkitPlatformSign extends PlatformSign<Player, String> {
   private final Server server;
   private final PluginManager pluginManager;
 
-  public BukkitPlatformSign(@NonNull Sign base, @NonNull Server server, @NonNull PluginManager pluginManager) {
-    super(base, input -> ChatColor.translateAlternateColorCodes('&', input));
+  public BukkitPlatformSign(
+    @NonNull Sign base,
+    @NonNull Server server,
+    @NonNull PluginManager pluginManager,
+    @NonNull PlayerManager playerManager
+  ) {
+    super(base, playerManager, input -> ChatColor.translateAlternateColorCodes('&', input));
     this.server = server;
 
     this.pluginManager = pluginManager;

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignManagement.java
@@ -18,8 +18,10 @@ package eu.cloudnetservice.modules.signs.platform.bukkit;
 
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.ext.platforminject.api.stereotype.ProvidesFor;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.SignManagement;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -44,6 +46,7 @@ public class BukkitSignManagement extends PlatformSignManagement<Player, Locatio
 
   protected final Plugin plugin;
   protected final PluginManager pluginManager;
+  protected final PlayerManager playerManager;
   protected final BukkitScheduler scheduler;
 
   @Inject
@@ -53,6 +56,7 @@ public class BukkitSignManagement extends PlatformSignManagement<Player, Locatio
     @NonNull BukkitScheduler scheduler,
     @NonNull EventManager eventManager,
     @NonNull PluginManager pluginManager,
+    @NonNull @Service PlayerManager playerManager,
     @NonNull WrapperConfiguration wrapperConfig,
     @NonNull CloudServiceProvider serviceProvider,
     @NonNull @Named("taskScheduler") ScheduledExecutorService executorService
@@ -69,6 +73,7 @@ public class BukkitSignManagement extends PlatformSignManagement<Player, Locatio
     this.plugin = plugin;
     this.scheduler = scheduler;
     this.pluginManager = pluginManager;
+    this.playerManager = playerManager;
   }
 
   @Override
@@ -127,6 +132,6 @@ public class BukkitSignManagement extends PlatformSignManagement<Player, Locatio
 
   @Override
   protected @NonNull PlatformSign<Player, String> createPlatformSign(@NonNull Sign base) {
-    return new BukkitPlatformSign(base, this.plugin.getServer(), this.pluginManager);
+    return new BukkitPlatformSign(base, this.plugin.getServer(), this.pluginManager, this.playerManager);
   }
 }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomPlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomPlatformSign.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.common.tuple.Tuple2;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.ext.adventure.AdventureTextFormatLookup;
 import eu.cloudnetservice.ext.component.ComponentFormats;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.configuration.SignLayout;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -45,10 +46,11 @@ public class MinestomPlatformSign extends PlatformSign<Player, String> {
 
   public MinestomPlatformSign(
     @NonNull Sign base,
+    @NonNull PlayerManager playerManager,
     @NonNull GlobalEventHandler eventHandler,
     @NonNull InstanceManager instanceManager
   ) {
-    super(base, input -> {
+    super(base, playerManager, input -> {
       var coloredComponent = ComponentFormats.BUNGEE_TO_ADVENTURE.convert(input);
       return GsonComponentSerializer.gson().serialize(coloredComponent);
     });

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignManagement.java
@@ -20,8 +20,10 @@ import com.google.common.util.concurrent.MoreExecutors;
 import eu.cloudnetservice.common.tuple.Tuple2;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.ext.platforminject.api.stereotype.ProvidesFor;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.SignManagement;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -47,6 +49,7 @@ import org.jetbrains.annotations.Nullable;
 @ProvidesFor(platform = "minestom", types = {PlatformSignManagement.class, SignManagement.class})
 public class MinestomSignManagement extends PlatformSignManagement<Player, Tuple2<Point, Instance>, String> {
 
+  private final PlayerManager playerManager;
   private final GlobalEventHandler eventHandler;
   private final InstanceManager instanceManager;
   private final SchedulerManager schedulerManager;
@@ -54,6 +57,7 @@ public class MinestomSignManagement extends PlatformSignManagement<Player, Tuple
   @Inject
   protected MinestomSignManagement(
     @NonNull EventManager eventManager,
+    @NonNull @Service PlayerManager playerManager,
     @NonNull GlobalEventHandler eventHandler,
     @NonNull InstanceManager instanceManager,
     @NonNull SchedulerManager schedulerManager,
@@ -62,6 +66,8 @@ public class MinestomSignManagement extends PlatformSignManagement<Player, Tuple
     @NonNull @Named("taskScheduler") ScheduledExecutorService executorService
   ) {
     super(eventManager, MoreExecutors.directExecutor(), wrapperConfig, serviceProvider, executorService);
+
+    this.playerManager = playerManager;
     this.eventHandler = eventHandler;
     this.instanceManager = instanceManager;
     this.schedulerManager = schedulerManager;
@@ -121,6 +127,6 @@ public class MinestomSignManagement extends PlatformSignManagement<Player, Tuple
 
   @Override
   protected @NonNull PlatformSign<Player, String> createPlatformSign(@NonNull Sign base) {
-    return new MinestomPlatformSign(base, this.eventHandler, this.instanceManager);
+    return new MinestomPlatformSign(base, this.playerManager, this.eventHandler, this.instanceManager);
   }
 }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitPlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitPlatformSign.java
@@ -28,6 +28,7 @@ import cn.nukkit.utils.Faceable;
 import cn.nukkit.utils.TextFormat;
 import com.google.common.primitives.Ints;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.configuration.SignLayout;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -45,8 +46,13 @@ public class NukkitPlatformSign extends PlatformSign<Player, String> {
 
   private Location signLocation;
 
-  public NukkitPlatformSign(@NonNull Sign base, @NonNull Server server, @NonNull PluginManager pluginManager) {
-    super(base, input -> TextFormat.colorize('&', input));
+  public NukkitPlatformSign(
+    @NonNull Sign base,
+    @NonNull Server server,
+    @NonNull PluginManager pluginManager,
+    @NonNull PlayerManager playerManager
+  ) {
+    super(base, playerManager, input -> TextFormat.colorize('&', input));
 
     this.server = server;
     this.pluginManager = pluginManager;

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignManagement.java
@@ -25,8 +25,10 @@ import cn.nukkit.plugin.PluginManager;
 import cn.nukkit.scheduler.ServerScheduler;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.ext.platforminject.api.stereotype.ProvidesFor;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.SignManagement;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -47,6 +49,7 @@ public class NukkitSignManagement extends PlatformSignManagement<Player, Locatio
   private final Plugin plugin;
   private final ServerScheduler scheduler;
   private final PluginManager pluginManager;
+  private final PlayerManager playerManager;
 
   @Inject
   protected NukkitSignManagement(
@@ -55,6 +58,7 @@ public class NukkitSignManagement extends PlatformSignManagement<Player, Locatio
     @NonNull ServerScheduler scheduler,
     @NonNull EventManager eventManager,
     @NonNull PluginManager pluginManager,
+    @NonNull @Service PlayerManager playerManager,
     @NonNull WrapperConfiguration wrapperConfig,
     @NonNull CloudServiceProvider serviceProvider,
     @NonNull @Named("taskScheduler") ScheduledExecutorService executorService
@@ -76,6 +80,7 @@ public class NukkitSignManagement extends PlatformSignManagement<Player, Locatio
     this.server = server;
     this.scheduler = scheduler;
     this.pluginManager = pluginManager;
+    this.playerManager = playerManager;
   }
 
   @Override
@@ -134,6 +139,6 @@ public class NukkitSignManagement extends PlatformSignManagement<Player, Locatio
 
   @Override
   protected @NonNull PlatformSign<Player, String> createPlatformSign(@NonNull Sign base) {
-    return new NukkitPlatformSign(base, this.server, this.pluginManager);
+    return new NukkitPlatformSign(base, this.server, this.pluginManager, this.playerManager);
   }
 }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongePlatformSign.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongePlatformSign.java
@@ -18,6 +18,7 @@ package eu.cloudnetservice.modules.signs.platform.sponge;
 
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.ext.component.ComponentFormats;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.configuration.SignLayout;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -50,9 +51,10 @@ final class SpongePlatformSign extends PlatformSign<ServerPlayer, Component> {
     @NonNull Sign base,
     @NonNull Game game,
     @NonNull EventManager eventManager,
-    @NonNull WorldManager worldManager
+    @NonNull WorldManager worldManager,
+    @NonNull PlayerManager playerManager
   ) {
-    super(base, ComponentFormats.BUNGEE_TO_ADVENTURE::convert);
+    super(base, playerManager, ComponentFormats.BUNGEE_TO_ADVENTURE::convert);
 
     this.game = game;
     this.eventManager = eventManager;

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignManagement.java
@@ -17,8 +17,10 @@
 package eu.cloudnetservice.modules.signs.platform.sponge;
 
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.ext.platforminject.api.stereotype.ProvidesFor;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.SignManagement;
 import eu.cloudnetservice.modules.signs.platform.PlatformSign;
@@ -51,6 +53,7 @@ public class SpongeSignManagement extends PlatformSignManagement<ServerPlayer, S
 
   private final Game game;
   private final WorldManager worldManager;
+  private final PlayerManager playerManager;
   private final TaskExecutorService syncExecutor;
   private final EventManager eventManager;
 
@@ -59,6 +62,7 @@ public class SpongeSignManagement extends PlatformSignManagement<ServerPlayer, S
     @NonNull Game game,
     @NonNull Server server,
     @NonNull WorldManager worldManager,
+    @NonNull @Service PlayerManager playerManager,
     @NonNull EventManager spongeEventManager,
     @NonNull PluginContainer pluginContainer,
     @NonNull WrapperConfiguration wrapperConfig,
@@ -78,6 +82,7 @@ public class SpongeSignManagement extends PlatformSignManagement<ServerPlayer, S
 
     this.game = game;
     this.worldManager = worldManager;
+    this.playerManager = playerManager;
     this.eventManager = spongeEventManager;
     this.syncExecutor = syncScheduler.executor(pluginContainer);
   }
@@ -139,6 +144,6 @@ public class SpongeSignManagement extends PlatformSignManagement<ServerPlayer, S
 
   @Override
   protected @NonNull PlatformSign<ServerPlayer, Component> createPlatformSign(@NonNull Sign base) {
-    return new SpongePlatformSign(base, this.game, this.eventManager, this.worldManager);
+    return new SpongePlatformSign(base, this.game, this.eventManager, this.worldManager, this.playerManager);
   }
 }

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/CloudNetSyncProxyModule.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/node/CloudNetSyncProxyModule.java
@@ -23,6 +23,7 @@ import eu.cloudnetservice.driver.module.ModuleLifeCycle;
 import eu.cloudnetservice.driver.module.ModuleTask;
 import eu.cloudnetservice.driver.module.driver.DriverModule;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.driver.util.ModuleHelper;
 import eu.cloudnetservice.modules.syncproxy.SyncProxyManagement;
@@ -38,6 +39,7 @@ import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import java.nio.file.Files;
 import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
 
 @Singleton
 public final class CloudNetSyncProxyModule extends DriverModule {
@@ -114,8 +116,7 @@ public final class CloudNetSyncProxyModule extends DriverModule {
   }
 
   @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
-  public void handleReload(@NonNull ServiceRegistry serviceRegistry) {
-    var management = serviceRegistry.firstProvider(SyncProxyManagement.class);
+  public void handleReload(@Nullable @Service SyncProxyManagement management) {
     if (management != null) {
       management.configuration(this.loadConfiguration());
     }

--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -41,6 +41,7 @@ import eu.cloudnetservice.driver.network.netty.NettyUtil;
 import eu.cloudnetservice.driver.network.rpc.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.RPCHandlerRegistry;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.driver.template.TemplateStorage;
 import eu.cloudnetservice.driver.util.ExecutorServiceUtil;
 import eu.cloudnetservice.node.cluster.NodeServerProvider;
@@ -184,7 +185,7 @@ public final class Node {
   @Order(300)
   private void convertDatabase(
     @NonNull Configuration configuration,
-    @NonNull ServiceRegistry serviceRegistry
+    @NonNull @Service(name = "xodus") NodeDatabaseProvider xodusProvider
   ) throws Exception { // TODO: remove in 4.1
     var configuredDatabase = configuration.properties().getString("database_provider", "xodus");
     // check if we need to migrate the old h2 database into a new xodus database
@@ -193,7 +194,6 @@ public final class Node {
       var h2Provider = new H2DatabaseProvider(System.getProperty("cloudnet.database.h2.path", "local/database/h2"));
       h2Provider.init();
       // initialize the provider for our new xodus database
-      var xodusProvider = serviceRegistry.provider(NodeDatabaseProvider.class, "xodus");
       xodusProvider.init();
       // run the migration on all tables in the h2 database
       for (var databaseName : h2Provider.databaseNames()) {


### PR DESCRIPTION
### Motivation
#1232 introduced a new `@Service` annotation that allows to injection providers from the service registry directly instead of injecting the service registry and retrieving it from the registry afterwards. This PR makes use of the new annotation and replaces the service registry where possible.

### Modification
Deprecated the ServiceRegistry.first(Class) method as it requires injection abuse to work. Replaced other usages of the service registry with the new annotation where possible. 

### Result
We are using the new Service annotation.