### PR TITLE
chore: drop getter prefixes in the service version provider

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/CloudNetBridgeModule.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/CloudNetBridgeModule.java
@@ -105,7 +105,7 @@ public final class CloudNetBridgeModule extends DriverModule {
             serviceId.append("environmentName", environment);
 
             // try to set the new environment
-            var env = versionProvider.getEnvironmentType(environment);
+            var env = versionProvider.environmentType(environment);
             serviceId.append("environment", env);
             serviceId.append("nameSplitter", "-");
 

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/NodeSetupListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/NodeSetupListener.java
@@ -88,7 +88,7 @@ public final class NodeSetupListener {
         })
         .possibleResults(taskProvider.serviceTasks().stream().filter(
             task -> {
-              var env = versionProvider.getEnvironmentType(task.processConfiguration().environment());
+              var env = versionProvider.environmentType(task.processConfiguration().environment());
               // only minecraft servers are allowed to be a fallback
               return env != null && ServiceEnvironmentType.minecraftServer(env);
             })

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerServiceVersionProvider.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerServiceVersionProvider.java
@@ -63,7 +63,7 @@ public final class V2HttpHandlerServiceVersionProvider extends V2HttpHandler {
   @BearerAuth
   @HttpRequestHandler(paths = "/api/v2/serviceversion/{version}")
   private void handleVersionRequest(@NonNull HttpContext ctx, @NonNull @RequestPathParam("version") String version) {
-    var serviceVersion = this.versionProvider.getServiceVersionType(version);
+    var serviceVersion = this.versionProvider.serviceVersionType(version);
     if (serviceVersion == null) {
       this.badRequest(ctx)
         .body(this.failure().append("reason", "Unknown service version").toString())

--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTemplate.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerTemplate.java
@@ -268,7 +268,7 @@ public final class V2HttpHandlerTemplate extends V2HttpHandler {
     this.handleWithTemplateContext(context, storageName, prefix, templateName, (template, storage) -> {
       var versionType = body.readObject("type", ServiceVersionType.class);
       if (versionType == null) {
-        versionType = this.versionProvider.getServiceVersionType(body.getString("typeName", ""));
+        versionType = this.versionProvider.serviceVersionType(body.getString("typeName", ""));
         if (versionType == null) {
           this.badRequest(context)
             .body(this.failure().append("reason", "No service type or type name provided").toString())

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TemplateCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TemplateCommand.java
@@ -163,7 +163,7 @@ public final class TemplateCommand {
     @NonNull Queue<String> input
   ) {
     var env = input.remove();
-    var type = this.serviceVersionProvider.getEnvironmentType(env);
+    var type = this.serviceVersionProvider.environmentType(env);
     if (type != null) {
       return type;
     }

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/VersionCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/VersionCommand.java
@@ -95,7 +95,7 @@ public final class VersionCommand {
 
   @Parser(suggestions = "serviceVersionType")
   public @NonNull ServiceVersionType parseVersionType(@NonNull CommandContext<?> $, @NonNull Queue<String> input) {
-    var versionType = this.serviceVersionProvider.getServiceVersionType(input.remove());
+    var versionType = this.serviceVersionProvider.serviceVersionType(input.remove());
     if (versionType != null) {
       return versionType;
     }

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
@@ -108,7 +108,7 @@ public final class Parsers {
         throw ParserException.INSTANCE;
       }
       // get the type
-      var type = this.versionProvider.getServiceVersionType(result[0]);
+      var type = this.versionProvider.serviceVersionType(result[0]);
       if (type == null) {
         throw ParserException.INSTANCE;
       }
@@ -126,7 +126,7 @@ public final class Parsers {
 
   public @NonNull QuestionAnswerType.Parser<ServiceEnvironmentType> serviceEnvironmentType() {
     return input -> {
-      var type = this.versionProvider.getEnvironmentType(input);
+      var type = this.versionProvider.environmentType(input);
       if (type != null) {
         return type;
       }

--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/BaseLocalCloudServiceFactory.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/factory/BaseLocalCloudServiceFactory.java
@@ -50,7 +50,7 @@ public abstract class BaseLocalCloudServiceFactory implements LocalCloudServiceF
     // set the environment type
     if (configuration.serviceId().environment() == null) {
       var env = Objects.requireNonNull(
-        this.versionProvider.getEnvironmentType(configuration.serviceId().environmentName()),
+        this.versionProvider.environmentType(configuration.serviceId().environmentName()),
         "Unknown environment type " + configuration.serviceId().environmentName());
       // set the environment type
       configurationBuilder.environment(env);

--- a/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/version/ServiceVersionProvider.java
@@ -133,7 +133,7 @@ public class ServiceVersionProvider {
   public void registerServiceVersionType(@NonNull ServiceVersionType versionType) {
     // ensure that we know the target environment for the service version
     Preconditions.checkNotNull(
-      this.getEnvironmentType(versionType.environmentType()),
+      this.environmentType(versionType.environmentType()),
       "Missing environment %s for service version %s",
       versionType.environmentType(),
       versionType.name());
@@ -141,7 +141,7 @@ public class ServiceVersionProvider {
     this.serviceVersionTypes.put(StringUtil.toLower(versionType.name()), versionType);
   }
 
-  public @Nullable ServiceVersionType getServiceVersionType(@NonNull String name) {
+  public @Nullable ServiceVersionType serviceVersionType(@NonNull String name) {
     return this.serviceVersionTypes.get(StringUtil.toLower(name));
   }
 
@@ -149,7 +149,7 @@ public class ServiceVersionProvider {
     this.serviceEnvironmentTypes.put(StringUtil.toUpper(environmentType.name()), environmentType);
   }
 
-  public @Nullable ServiceEnvironmentType getEnvironmentType(@NonNull String name) {
+  public @Nullable ServiceEnvironmentType environmentType(@NonNull String name) {
     return this.serviceEnvironmentTypes.get(StringUtil.toUpper(name));
   }
 


### PR DESCRIPTION
### Motivation
We've dropped all getter and setter prefixes while introducing Java 17. Some getters in the ServiceVersionProvider still had some prefixes, remove them.

### Modification
Removed getter prefixes in the ServiceVersionProvider.

### Result
No more getter prefixes.