### PR TITLE
chore: bring the module documentation up to our standard

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleWrapper.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleWrapper.java
@@ -293,6 +293,7 @@ public class DefaultModuleWrapper implements ModuleWrapper {
    *
    * @param module the module instance (better known as the module main class) to resolve the tasks of.
    * @return all sorted resolved tasks mapped to the lifecycle they will be called in.
+   * @throws NullPointerException if the given module is null.
    */
   protected @NonNull Map<ModuleLifeCycle, List<ModuleTaskEntry>> resolveModuleTasks(@NonNull Module module) {
     Map<ModuleLifeCycle, List<ModuleTaskEntry>> result = new EnumMap<>(ModuleLifeCycle.class);
@@ -320,6 +321,7 @@ public class DefaultModuleWrapper implements ModuleWrapper {
    *
    * @param lifeCycle      the lifecycle to fire the tasks of.
    * @param notifyProvider if the module provider should be notified about the change or not.
+   * @throws NullPointerException if the given lifecycle is null.
    */
   protected void pushLifecycleChange(@NonNull ModuleLifeCycle lifeCycle, boolean notifyProvider) {
     var tasks = this.tasks.get(lifeCycle);
@@ -356,10 +358,11 @@ public class DefaultModuleWrapper implements ModuleWrapper {
   }
 
   /**
-   * Fires a specific module task entry.
+   * Fires a specific module task entry and notifies about the failure of the call.
    *
    * @param entry the entry to fire.
-   * @return true if the entry couldn't be fired successfully, false otherwise.
+   * @return true if firing the entry failed, false if it succeeded.
+   * @throws NullPointerException if the given task entry is null.
    */
   protected boolean fireModuleTaskEntry(@NonNull ModuleTaskEntry entry) {
     try {

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfiguration.java
@@ -81,6 +81,7 @@ public record ModuleConfiguration(
    * @param baseDirectory the base directory of the module provider used to resolve the data folder if no data folder is
    *                      specified explicitly.
    * @return the data folder in path form of this module.
+   * @throws NullPointerException if the given path is null.
    */
   public @NonNull Path dataFolder(@NonNull Path baseDirectory) {
     if (this.dataFolder == null) {
@@ -106,6 +107,7 @@ public record ModuleConfiguration(
    *
    * @param javaVersion the runtime version to check.
    * @return if this module can run on the specified java version.
+   * @throws NullPointerException if the given java version is null.
    */
   public boolean canRunOn(@NonNull JavaVersion javaVersion) {
     var minJavaVersion = this.minJavaVersion();

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfigurationNotFoundException.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleConfigurationNotFoundException.java
@@ -31,6 +31,7 @@ public class ModuleConfigurationNotFoundException extends RuntimeException {
    * Creates a new instance of this class.
    *
    * @param url the url of the module which didn't contain a module.json file.
+   * @throws NullPointerException if the given url is null.
    */
   public ModuleConfigurationNotFoundException(@NonNull URL url) {
     super("No module configuration found in " + url.toExternalForm());

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleURLClassLoader.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleURLClassLoader.java
@@ -124,8 +124,8 @@ public class ModuleURLClassLoader extends URLClassLoader implements InjectionLay
    * @param name    the name of the class to load.
    * @param resolve if the class should be resolved.
    * @param global  if all loaders registered in {@link ModuleURLClassLoader#LOADERS} should be checked.
-   * @return The resulting Class object
-   * @throws ClassNotFoundException if the class could not be found
+   * @return the newly loaded class.
+   * @throws ClassNotFoundException if no class was found to load
    */
   protected @NonNull Class<?> loadClass(String name, boolean resolve, boolean global) throws ClassNotFoundException {
     try {

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/driver/DriverModule.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/driver/DriverModule.java
@@ -49,11 +49,12 @@ public class DriverModule extends DefaultModule {
 
   /**
    * Reads the configuration file of this module from the default or overridden configuration path (via module.json)
-   * into a json document, throwing an exception when the document is invalid.
+   * into a document, throwing an exception when the document is invalid.
    *
    * @param factory the config factory to use when parsing the configuration.
    * @return the config at the default path.
    * @throws DocumentParseException if the document cannot be parsed from the given path.
+   * @throws NullPointerException   if the given document factory is null.
    */
   public @NonNull Document readConfig(@NonNull DocumentFactory factory) {
     return factory.parse(this.configPath());
@@ -63,6 +64,7 @@ public class DriverModule extends DefaultModule {
    * Writes the given configuration document to the default configuration path {@link DriverModule#configPath()}.
    *
    * @param config the config to write.
+   * @throws NullPointerException if the given document is null.
    */
   public void writeConfig(@NonNull Document config) {
     config.writeTo(this.configPath());
@@ -80,7 +82,7 @@ public class DriverModule extends DefaultModule {
    * @param documentFactory      the document factory to use when reading the configuration file.
    * @param <T>                  the type of the configuration model.
    * @return a newly created default config instance or the read config instance from the config path.
-   * @throws NullPointerException                if either the given config model or config factory is null.
+   * @throws NullPointerException                if one of the given parameters is null.
    * @throws ModuleConfigurationInvalidException if the reader is unable to read the configuration model from the file.
    */
   public @NonNull <T> T readConfig(

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/util/ModuleDependencyUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/util/ModuleDependencyUtil.java
@@ -51,7 +51,7 @@ public final class ModuleDependencyUtil {
   /**
    * Creating an instance of this helper class is not allowed, results in {@link UnsupportedOperationException}.
    *
-   * @throws UnsupportedOperationException on invocation
+   * @throws UnsupportedOperationException on invocation.
    */
   private ModuleDependencyUtil() {
     throw new UnsupportedOperationException();

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
@@ -27,9 +27,12 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
 
 /**
- * The player manager is the main api point to access cloud offline and online players. Accessing the player manager is
- * possible using either {@code ServiceRegistry.first(PlayerManager.class)} or
- * {@code bridgeManagement.playerManager()}.
+ * The player manager is the main api point to access cloud offline and online players.
+ * <p>
+ * The player manager can be accessed using the service registry. Either using the {@link eu.cloudnetservice.driver.registry.injection.Service}
+ * annotation to inject the player manager directly into a constructor or field, or otherwise use the
+ * {@link eu.cloudnetservice.driver.registry.ServiceRegistry} like this:
+ * {@code serviceRegistry.firstProvider(PlayerManager.class)}
  *
  * @since 4.0
  */
@@ -311,8 +314,8 @@ public interface PlayerManager {
   }
 
   /**
-   * Gets all registered cloud players that have the given case-sensitive name asynchronously. The player must have
-   * been previously connected.
+   * Gets all registered cloud players that have the given case-sensitive name asynchronously. The player must have been
+   * previously connected.
    *
    * @param name the name of the registered cloud players.
    * @return a task containing a list of all registered players with the given name.

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
@@ -29,9 +29,9 @@ import org.jetbrains.annotations.Range;
 /**
  * The player manager is the main api point to access cloud offline and online players.
  * <p>
- * The player manager can be accessed using the service registry. Either using the {@link eu.cloudnetservice.driver.registry.injection.Service}
- * annotation to inject the player manager directly into a constructor or field, or otherwise use the
- * {@link eu.cloudnetservice.driver.registry.ServiceRegistry} like this:
+ * The player manager can be accessed using the service registry. Either using the
+ * {@link eu.cloudnetservice.driver.registry.injection.Service} annotation to inject the player manager directly into a
+ * constructor or field, or otherwise use the {@link eu.cloudnetservice.driver.registry.ServiceRegistry} like this:
  * {@code serviceRegistry.firstProvider(PlayerManager.class)}
  *
  * @since 4.0


### PR DESCRIPTION
### Motivation
When documenting our classes and methods we make sure to document all exceptions that are thrown too. The module package was not up-to these standards.

### Modification
Documented thrown NullPointerExceptions

### Result
The thrown NullPointerExceptions are documented.