### PR TITLE
build: add md5 snapshots repo to make cloudnet compile again

### DIFF
--- a/ext/platform-inject-support/runtime/build.gradle.kts
+++ b/ext/platform-inject-support/runtime/build.gradle.kts
@@ -16,6 +16,7 @@
 
 repositories {
   maven("https://repo.md-5.net/repository/releases/")
+  maven("https://repo.md-5.net/repository/snapshots/")
   maven("https://repo.waterdog.dev/artifactory/main/")
   maven("https://repo.opencollab.dev/maven-releases/")
   maven("https://repo.opencollab.dev/maven-snapshots/")

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -31,6 +31,7 @@ subprojects {
 
   repositories {
     maven("https://repo.md-5.net/repository/releases/")
+    maven("https://repo.md-5.net/repository/snapshots/")
     maven("https://repo.waterdog.dev/artifactory/main/")
     maven("https://repo.opencollab.dev/maven-releases/")
     maven("https://repo.opencollab.dev/maven-snapshots/")


### PR DESCRIPTION
### Motivation
Due to some changes in waterdog we need to add the md5 snapshots repo ourselves.

### Modification
Added the md5 snapshots repo to all modules and the platform api runtime

### Result
The build works again