### PR TITLE
fix: set the floating item to null if the material is air

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
@@ -400,6 +400,8 @@ public final class NPCCommand extends BaseTabExecutor {
           if (material == null) {
             sender.sendMessage(String.format("§cNo material found by query: §6%s§c.", args[2]));
             return true;
+          } else if (material == Material.AIR) {
+            updatedNpc = NPC.builder(npc).floatingItem(null).build();
           } else {
             updatedNpc = NPC.builder(npc).floatingItem(material.name()).build();
           }


### PR DESCRIPTION
### Motivation
When trying to remove the floating item of a npc using the material "air" the armor stand becomes visible and some of our infolines disappear.

### Modification
Converted the air material to null to make sure that no item is displayed.

### Result
No item is displayed when using AIR and all armor stands are still correct
