### PR TITLE
fix: correctly replace placeholders in syncproxy tablist

### DIFF
--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/PlatformSyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/PlatformSyncProxyManagement.java
@@ -290,11 +290,11 @@ public abstract class PlatformSyncProxyManagement<P> implements SyncProxyManagem
     int onlinePlayers,
     int maxPlayers
   ) {
-    input = BridgeServiceHelper.fillCommonPlaceholders(input, null, this.serviceInfoHolder.serviceInfo())
-      .replace("%time%", TIME_FORMATTER.format(LocalTime.now()))
+    input = input.replace("%time%", TIME_FORMATTER.format(LocalTime.now()))
       .replace("%online_players%", String.valueOf(onlinePlayers))
       .replace("%max_players%", String.valueOf(maxPlayers))
       .replace("%player_name%", this.playerName(player));
+    input = BridgeServiceHelper.fillCommonPlaceholders(input, null, this.serviceInfoHolder.serviceInfo());
 
     if (SyncProxyConstants.CLOUD_PERMS_ENABLED) {
       var permissionUser = this.permissionManagement.user(this.playerUniqueId(player));

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/PlatformSyncProxyManagement.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/PlatformSyncProxyManagement.java
@@ -291,8 +291,8 @@ public abstract class PlatformSyncProxyManagement<P> implements SyncProxyManagem
     int maxPlayers
   ) {
     input = input.replace("%time%", TIME_FORMATTER.format(LocalTime.now()))
-      .replace("%online_players%", String.valueOf(onlinePlayers))
-      .replace("%max_players%", String.valueOf(maxPlayers))
+      .replace("%syncproxy_online_players%", String.valueOf(onlinePlayers))
+      .replace("%syncproxy_max_players%", String.valueOf(maxPlayers))
       .replace("%player_name%", this.playerName(player));
     input = BridgeServiceHelper.fillCommonPlaceholders(input, null, this.serviceInfoHolder.serviceInfo());
 


### PR DESCRIPTION
### Motivation
Due to recent changes in syncproxy placeholders the wrong replacements were used.

### Modification
Replaced `max_players` and `online_players` before giving it into the common replacer as it might use wrong values.

### Result
The replacements are correct and the displayed values too.