### PR TITLE
fix: spawn all npcs in already loaded chunks on start

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -105,6 +105,19 @@ public class BukkitPlatformNPCManagement extends
         .build();
     }
 
+    // spawn all npcs that are in chunks that were loaded before the plugin was enabled
+    for (var entries : this.npcs.entrySet()) {
+      var world = this.server.getWorld(entries.getKey().world());
+      if (world != null) {
+        var x = NumberConversions.floor(entries.getKey().x()) >> 4;
+        var z = NumberConversions.floor(entries.getKey().z()) >> 4;
+        // only spawn in already loaded chunks
+        if (world.isChunkLoaded(x, z)) {
+          this.trackedEntities.get(entries.getKey()).spawn();
+        }
+      }
+    }
+
     // start the emote player
     this.startEmoteTask(false);
     // start the knock back task

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -170,7 +170,7 @@ public class BukkitPlatformNPCManagement extends
 
     // spawn all npcs that are in chunks that were loaded before the plugin was enabled
     for (var entity : this.trackedEntities.values()) {
-      if (entity != null && entity.canSpawn()) {
+      if (entity.canSpawn()) {
         entity.spawn();
       }
     }

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -105,14 +105,6 @@ public class BukkitPlatformNPCManagement extends
         .build();
     }
 
-    // spawn all npcs that are in chunks that were loaded before the plugin was enabled
-    for (var entries : this.npcs.entrySet()) {
-      var entity = this.trackedEntities().get(entries.getKey());
-      if (entity != null && entity.canSpawn()) {
-        entity.spawn();
-      }
-    }
-
     // start the emote player
     this.startEmoteTask(false);
     // start the knock back task
@@ -170,6 +162,18 @@ public class BukkitPlatformNPCManagement extends
         }
       }
     }, 20, 5);
+  }
+
+  @Override
+  public void initialize() {
+    super.initialize();
+
+    // spawn all npcs that are in chunks that were loaded before the plugin was enabled
+    for (var entity : this.trackedEntities.values()) {
+      if (entity != null && entity.canSpawn()) {
+        entity.spawn();
+      }
+    }
   }
 
   @Override

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -107,14 +107,9 @@ public class BukkitPlatformNPCManagement extends
 
     // spawn all npcs that are in chunks that were loaded before the plugin was enabled
     for (var entries : this.npcs.entrySet()) {
-      var world = this.server.getWorld(entries.getKey().world());
-      if (world != null) {
-        var x = NumberConversions.floor(entries.getKey().x()) >> 4;
-        var z = NumberConversions.floor(entries.getKey().z()) >> 4;
-        // only spawn in already loaded chunks
-        if (world.isChunkLoaded(x, z)) {
-          this.trackedEntities.get(entries.getKey()).spawn();
-        }
+      var entity = this.trackedEntities().get(entries.getKey());
+      if (entity != null && entity.canSpawn()) {
+        entity.spawn();
       }
     }
 


### PR DESCRIPTION
### Motivation
When a npc is located in the spawn chunks of the world the npc won't get spawned. This is caused by the fact that the chunk load event is called before our plugin is started.

### Modification
Spawned all npcs on start that are located in already loaded chunks

### Result
No non existing npcs
