### PR TITLE
fix: do not set ssl explicitly to false and use mariadb 11.1.1-rc in tests

### DIFF
--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/CloudNetMySQLDatabaseModule.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/CloudNetMySQLDatabaseModule.java
@@ -58,7 +58,7 @@ public final class CloudNetMySQLDatabaseModule extends DriverModule {
         "root",
         "123456",
         "mysql",
-        List.of(new MySQLConnectionEndpoint(false, "cloudnet", new HostAndPort("127.0.0.1", 3306)))),
+        List.of(new MySQLConnectionEndpoint("cloudnet", new HostAndPort("127.0.0.1", 3306)))),
       DocumentFactory.json());
 
     serviceRegistry.registerProvider(

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseProvider.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseProvider.java
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.UnknownNullability;
 
 public final class MySQLDatabaseProvider extends SQLDatabaseProvider {
 
-  private static final String CONNECT_URL_FORMAT = "jdbc:mysql://%s:%d/%s?serverTimezone=UTC&useSSL=%b&trustServerCertificate=%b";
+  private static final String CONNECT_URL_FORMAT = "jdbc:mysql://%s:%d/%s?serverTimezone=UTC";
 
   private final MySQLConfiguration config;
   private volatile HikariDataSource hikariDataSource;
@@ -56,9 +56,7 @@ public final class MySQLDatabaseProvider extends SQLDatabaseProvider {
 
     hikariConfig.setJdbcUrl(String.format(
       CONNECT_URL_FORMAT,
-      endpoint.address().host(), endpoint.address().port(),
-      endpoint.database(), endpoint.useSsl(), endpoint.useSsl()
-    ));
+      endpoint.address().host(), endpoint.address().port(), endpoint.database()));
     hikariConfig.setDriverClassName("com.mysql.cj.jdbc.Driver");
     hikariConfig.setUsername(this.config.username());
     hikariConfig.setPassword(this.config.password());

--- a/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConnectionEndpoint.java
+++ b/modules/database-mysql/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConnectionEndpoint.java
@@ -19,6 +19,6 @@ package eu.cloudnetservice.modules.mysql.config;
 import eu.cloudnetservice.driver.network.HostAndPort;
 import lombok.NonNull;
 
-public record MySQLConnectionEndpoint(boolean useSsl, @NonNull String database, @NonNull HostAndPort address) {
+public record MySQLConnectionEndpoint(@NonNull String database, @NonNull HostAndPort address) {
 
 }

--- a/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
+++ b/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
@@ -35,7 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class MySQLDatabaseTest {
 
   @Container
-  private final GenericContainer<?> mysqlContainer = new GenericContainer<>("mariadb:latest")
+  private final GenericContainer<?> mysqlContainer = new GenericContainer<>("mariadb:11.1.1-rc")
     .withExposedPorts(3306)
     .withEnv("MYSQL_USER", "test")
     .withEnv("MYSQL_PASSWORD", "test")

--- a/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
+++ b/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
@@ -51,7 +51,6 @@ class MySQLDatabaseTest {
       "test",
       "mysql",
       List.of(new MySQLConnectionEndpoint(
-        false,
         "cn_testing",
         new HostAndPort(this.mysqlContainer.getHost(), this.mysqlContainer.getFirstMappedPort())))),
       null);


### PR DESCRIPTION
### Motivation
When using never mysql db servers the module could not connect to the server due to the fact that useSSL is disabled explicitly 

### Modification
The useSSL option was removed completly.

### Result
Connections with never versions are possible.