### PR TITLE
chore: bump npc lib to beta5, fix some smaller npc issues observed during testing

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ bungeecord = "1.19-R0.1-SNAPSHOT"
 vault = "1.7.1"
 adventure = "4.13.1"
 modlauncher = "8.1.3"
-npcLib = "3.0.0-beta4"
+npcLib = "3.0.0-beta5"
 placeholderApi = "2.11.3"
 
 # fabric platform special dependencies

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
@@ -85,7 +85,9 @@ public class NPCBukkitPlatformSelector extends BukkitPlatformSelectorEntity {
       .flag(Npc.LOOK_AT_PLAYER, this.npc.lookAtPlayer())
       .npcSettings(builder -> builder.profileResolver((player, spawnedNpc) -> {
         if (this.npc.usePlayerSkin()) {
-          return this.platform.profileResolver().resolveProfile(Profile.unresolved(player.getUniqueId()));
+          return this.platform.profileResolver()
+            .resolveProfile(Profile.unresolved(player.getUniqueId()))
+            .thenApply(resolvedProfile -> spawnedNpc.profile().withProperties(resolvedProfile.properties()));
         } else {
           return CompletableFuture.completedFuture(spawnedNpc.profile());
         }


### PR DESCRIPTION
### Motivation
Npc-Lib beta5 released which fixes a problem for all servers that can't use a modern variant to load profiles (like the Paper PlayerProfile api). In addition, the new version had a breaking change in how the parameters for the method related to entitiy metadata are sorted.

### Modification
Bump the npc-lib to beta5 and fix the parameter order of the previously mentioned methods. This PR also introduces a fix for the following two issues (in the CloudNet code):
* When an npc was spawned to a player, the packages needed to update the entity meta and inventory item packets were sent to all tracked players, not just the new player (who is also the only player that needs the packets).
* If the "usePlayerSkin" option was used for an npc, the npc no longer spawned because the npc profile had the same name and uuid as the online player.

### Result
The npc lib has been updated and some minor issues with the npcs have been fixed.
