### PR TITLE
fix: Load module dependency first by URL to inline behaviors with jup…

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleProvider.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/DefaultModuleProvider.java
@@ -458,7 +458,13 @@ public class DefaultModuleProvider implements ModuleProvider {
         }
         // ensure that the required properties are set
         dependency.assertDefaultPropertiesSet();
-        // decide which way to go (by url or repository). In this case we start with the more common repository way
+        // decide which way to go (by url or repository). In this case we start with the developer defined url if there's one
+        if (dependency.url() != null) {
+          loadedDependencies.add(this.doLoadDependency(dependency, configuration, handler,
+            () -> this.moduleDependencyLoader.loadModuleDependencyByUrl(configuration, dependency)));
+          continue;
+        }
+        // check if the repository defined a repository for us to use
         if (dependency.repo() != null) {
           var repoUrl = Preconditions.checkNotNull(
             repos.get(dependency.repo()),
@@ -466,12 +472,6 @@ public class DefaultModuleProvider implements ModuleProvider {
             dependency.toString(), dependency.repo());
           loadedDependencies.add(this.doLoadDependency(dependency, configuration, handler,
             () -> this.moduleDependencyLoader.loadModuleDependencyByRepository(configuration, dependency, repoUrl)));
-          continue;
-        }
-        // check if the repository defined a fixed download url for us to use
-        if (dependency.url() != null) {
-          loadedDependencies.add(this.doLoadDependency(dependency, configuration, handler,
-            () -> this.moduleDependencyLoader.loadModuleDependencyByUrl(configuration, dependency)));
           continue;
         }
         // the dependency might be a dependency for a module, save this


### PR DESCRIPTION
…piter docs

### Motivation
As per juppiter docs (README.md), the url field should be checked before repository scans take place, but it's the opposite in the code, causing unexpected behaviors.
On the other hand, URLs are user-defined, so they should also have a higher priority.

### Modification
Changed the module dependency check order to url first then repository

### Result
Behaviors are now inline with the documentations in juppiter

##### Other context
juppiter README.md quote:
https://github.com/CloudNetService/juppiter/blob/stable/.github/README.md?plain=1#LL107C30-L108C69
