### PR TITLE
fix: draining causes jvm halt instead of a stop

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -461,11 +461,14 @@ public final class Node {
   @Inject
   @Order(10_000)
   private void installShutdownHook(@NonNull Provider<ShutdownHandler> shutdownHandlerProvider) {
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+    var shutdownHookThread = new Thread(() -> {
       // get the shutdown handler instance & execute the shutdown process
       var shutdownHandler = shutdownHandlerProvider.get();
       shutdownHandler.shutdown();
-    }));
+    });
+    shutdownHookThread.setName(ShutdownHandler.SHUTDOWN_THREAD_NAME);
+
+    Runtime.getRuntime().addShutdownHook(shutdownHookThread);
   }
 
   @Inject

--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -461,14 +461,11 @@ public final class Node {
   @Inject
   @Order(10_000)
   private void installShutdownHook(@NonNull Provider<ShutdownHandler> shutdownHandlerProvider) {
-    var shutdownHookThread = new Thread(() -> {
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
       // get the shutdown handler instance & execute the shutdown process
       var shutdownHandler = shutdownHandlerProvider.get();
       shutdownHandler.shutdown();
-    });
-    shutdownHookThread.setName(ShutdownHandler.SHUTDOWN_THREAD_NAME);
-
-    Runtime.getRuntime().addShutdownHook(shutdownHookThread);
+    }, ShutdownHandler.SHUTDOWN_THREAD_NAME));
   }
 
   @Inject

--- a/node/src/main/java/eu/cloudnetservice/node/ShutdownHandler.java
+++ b/node/src/main/java/eu/cloudnetservice/node/ShutdownHandler.java
@@ -39,6 +39,7 @@ import lombok.NonNull;
 @Singleton
 public final class ShutdownHandler {
 
+  public static final String SHUTDOWN_THREAD_NAME = "CloudNet Shutdown Thread";
   private static final Logger LOGGER = LogManager.logger(ShutdownHandler.class);
 
   private final Console console;
@@ -126,10 +127,11 @@ public final class ShutdownHandler {
         LOGGER.severe("Caught exception while trying to cleanly stop CloudNet", exception);
       }
 
-      // exit cleanly in all cases, this tricks the jvm into thinking that all shutdown hooks should
-      // get executed. If we call exit with a non-zero exit code, and the jvm is already shutting down
-      // this would cause the jvm the directly halt
-      System.exit(0);
+      // exit if this was not called from a shutdown thread. We have to check this to prevent calling System.exit(0)
+      // twice which results in the jvm stalling due to a lock
+      if (!Thread.currentThread().getName().equals(SHUTDOWN_THREAD_NAME)) {
+        System.exit(0);
+      }
     }
   }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/TickLoop.java
+++ b/node/src/main/java/eu/cloudnetservice/node/TickLoop.java
@@ -29,6 +29,7 @@ import eu.cloudnetservice.node.event.instance.CloudNetTickEvent;
 import eu.cloudnetservice.node.event.instance.CloudNetTickServiceStartEvent;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import java.util.Queue;
 import java.util.concurrent.Callable;
@@ -54,6 +55,7 @@ public final class TickLoop {
   private final ServiceTaskProvider taskProvider;
   private final CloudServiceManager serviceManager;
   private final NodeServerProvider nodeServerProvider;
+  private final Provider<ShutdownHandler> shutdownHandlerProvider;
 
   private final AtomicInteger tickPauseRequests = new AtomicInteger();
 
@@ -68,12 +70,14 @@ public final class TickLoop {
     @NonNull EventManager eventManager,
     @NonNull ServiceTaskProvider taskProvider,
     @NonNull CloudServiceManager serviceManager,
-    @NonNull NodeServerProvider nodeServerProvider
+    @NonNull NodeServerProvider nodeServerProvider,
+    @NonNull Provider<ShutdownHandler> shutdownHandlerProvider
   ) {
     this.eventManager = eventManager;
     this.taskProvider = taskProvider;
     this.serviceManager = serviceManager;
     this.nodeServerProvider = nodeServerProvider;
+    this.shutdownHandlerProvider = shutdownHandlerProvider;
   }
 
   public @NonNull Task<Void> runTask(@NonNull Runnable runnable) {
@@ -169,7 +173,7 @@ public final class TickLoop {
             // check if there are no services on the node
             if (this.serviceManager.localCloudServices().isEmpty()) {
               // stop the node as it's marked for draining
-              System.exit(0);
+              this.shutdownHandlerProvider.get().shutdown();
               return;
             }
           }

--- a/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultLocalNodeServer.java
+++ b/node/src/main/java/eu/cloudnetservice/node/cluster/defaults/DefaultLocalNodeServer.java
@@ -30,6 +30,7 @@ import eu.cloudnetservice.driver.network.NetworkChannel;
 import eu.cloudnetservice.driver.provider.CloudServiceFactory;
 import eu.cloudnetservice.driver.provider.SpecificCloudServiceProvider;
 import eu.cloudnetservice.driver.service.ProcessSnapshot;
+import eu.cloudnetservice.node.ShutdownHandler;
 import eu.cloudnetservice.node.cluster.LocalNodeServer;
 import eu.cloudnetservice.node.cluster.NodeServerProvider;
 import eu.cloudnetservice.node.cluster.NodeServerState;
@@ -39,6 +40,7 @@ import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.event.cluster.LocalNodeSnapshotConfigureEvent;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import java.time.Instant;
 import java.util.Collection;
@@ -60,6 +62,7 @@ public class DefaultLocalNodeServer implements LocalNodeServer {
   private final CommandProvider commandProvider;
   private final CloudServiceFactory cloudServiceFactory;
   private final CloudServiceManager cloudServiceProvider;
+  private final Provider<ShutdownHandler> shutdownHandlerProvider;
 
   private final long creationMillis = System.currentTimeMillis();
 
@@ -82,7 +85,8 @@ public class DefaultLocalNodeServer implements LocalNodeServer {
     @NonNull ModuleProvider moduleProvider,
     @NonNull CommandProvider commandProvider,
     @NonNull CloudServiceFactory cloudServiceFactory,
-    @NonNull CloudServiceManager cloudServiceProvider
+    @NonNull CloudServiceManager cloudServiceProvider,
+    @NonNull Provider<ShutdownHandler> shutdownHandlerProvider
   ) {
     this.version = version;
     this.eventManager = eventManager;
@@ -92,6 +96,7 @@ public class DefaultLocalNodeServer implements LocalNodeServer {
     this.commandProvider = commandProvider;
     this.cloudServiceFactory = cloudServiceFactory;
     this.cloudServiceProvider = cloudServiceProvider;
+    this.shutdownHandlerProvider = shutdownHandlerProvider;
   }
 
   @Override
@@ -111,7 +116,7 @@ public class DefaultLocalNodeServer implements LocalNodeServer {
 
   @Override
   public void shutdown() {
-    System.exit(0);
+    this.shutdownHandlerProvider.get().shutdown();
   }
 
   @Override

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/ClusterCommand.java
@@ -37,6 +37,7 @@ import eu.cloudnetservice.driver.network.chunk.TransferStatus;
 import eu.cloudnetservice.driver.provider.ClusterNodeProvider;
 import eu.cloudnetservice.driver.service.ServiceTemplate;
 import eu.cloudnetservice.driver.template.TemplateStorageProvider;
+import eu.cloudnetservice.node.ShutdownHandler;
 import eu.cloudnetservice.node.cluster.NodeServer;
 import eu.cloudnetservice.node.cluster.NodeServerProvider;
 import eu.cloudnetservice.node.command.annotation.CommandAlias;
@@ -48,6 +49,7 @@ import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import eu.cloudnetservice.node.util.NetworkUtil;
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -97,6 +99,7 @@ public final class ClusterCommand {
   private final NodeServerProvider nodeServerProvider;
   private final ClusterNodeProvider clusterNodeProvider;
   private final TemplateStorageProvider templateStorageProvider;
+  private final Provider<ShutdownHandler> shutdownHandlerProvider;
 
   @Inject
   public ClusterCommand(
@@ -104,13 +107,15 @@ public final class ClusterCommand {
     @NonNull CloudServiceManager serviceProvider,
     @NonNull NodeServerProvider nodeServerProvider,
     @NonNull ClusterNodeProvider clusterNodeProvider,
-    @NonNull TemplateStorageProvider templateStorageProvider
+    @NonNull TemplateStorageProvider templateStorageProvider,
+    @NonNull Provider<ShutdownHandler> shutdownHandlerProvider
   ) {
     this.configuration = configuration;
     this.nodeServerProvider = nodeServerProvider;
     this.clusterNodeProvider = clusterNodeProvider;
     this.serviceProvider = serviceProvider;
     this.templateStorageProvider = templateStorageProvider;
+    this.shutdownHandlerProvider = shutdownHandlerProvider;
   }
 
   @Parser(suggestions = "clusterNodeServer")
@@ -236,7 +241,7 @@ public final class ClusterCommand {
       }
     }
 
-    System.exit(0);
+    this.shutdownHandlerProvider.get().shutdown();
   }
 
   @CommandMethod("cluster|clu add <nodeId> <host>")


### PR DESCRIPTION
### Motivation
When enabling draining on a node and stopping all already running services the node should be stopped. Currently instead of stopping the node we cause the jvm to halt therefore the node does not stop correctly and does not exit at all.

### Modification
Used the shutdown method in the shutdown handler to stop the node and exit.

### Result
The node exits successfully.
