### PR TITLE
fix: Switch HTTP-Methods for Session Rest-Handler from GET to POST

### DIFF
--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerSession.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerSession.java
@@ -35,7 +35,7 @@ public final class V2HttpHandlerSession extends V2HttpHandler {
     super(configuration.restConfiguration());
   }
 
-  @HttpRequestHandler(paths = "/api/v2/session/refresh")
+  @HttpRequestHandler(paths = "/api/v2/session/refresh", methods = "POST")
   private void handleRefresh(@NonNull HttpContext context, @NonNull @BearerAuth HttpSession session) {
     var jwt = session.issuer().refreshJwt(
       session,
@@ -47,7 +47,7 @@ public final class V2HttpHandlerSession extends V2HttpHandler {
       .cancelNext(true);
   }
 
-  @HttpRequestHandler(paths = "/api/v2/session/logout")
+  @HttpRequestHandler(paths = "/api/v2/session/logout", methods = "POST")
   private void handleLogout(@NonNull HttpContext context, @NonNull @BearerAuth HttpSession session) {
     if (session.issuer().expireSession(session)) {
       this.ok(context)


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
The documented http methods for session rest handler does not match the implementation.

### Modification
Changed the HTTP Methods for the session rest handler from GET to POST as documented.

### Result
Session Handler-Routes are now working as documented.

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
https://discord.com/channels/325362837184577536/818777626663321671/1125877681892905040
