### PR TITLE
fix: rest docs wording & change command POST endpoint

### DIFF
--- a/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerCluster.java
+++ b/modules/rest/src/main/java/eu/cloudnetservice/modules/rest/v2/V2HttpHandlerCluster.java
@@ -82,7 +82,7 @@ public final class V2HttpHandlerCluster extends V2HttpHandler {
   }
 
   @BearerAuth
-  @HttpRequestHandler(paths = "/api/v2/cluster/{node}", methods = "POST")
+  @HttpRequestHandler(paths = "/api/v2/cluster/{node}/command", methods = "POST")
   private void handleNodeCommandRequest(
     @NonNull HttpContext context,
     @NonNull @RequestPathParam("node") String node,

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -1588,7 +1588,7 @@
           }
         },
         "tags" : [ "Tasks" ],
-        "summary" : "Create or update a task",
+        "summary" : "Create or edit a task",
         "responses" : {
           "200" : {
             "description" : "The request was ok but the task couldn't be created/edited",

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -1607,7 +1607,7 @@
             }
           },
           "201" : {
-            "description" : "The task was created/updated successfully",
+            "description" : "The task was created / updated successfully",
             "content" : {
               "application/json" : {
                 "schema" : {

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -1578,7 +1578,7 @@
       "post" : {
         "requestBody" : {
           "required" : true,
-          "description" : "The task to create",
+          "description" : "The task to create or edit",
           "content" : {
             "application/json" : {
               "schema" : {
@@ -1588,10 +1588,10 @@
           }
         },
         "tags" : [ "Tasks" ],
-        "summary" : "Creates a task",
+        "summary" : "Create or update task",
         "responses" : {
           "200" : {
-            "description" : "The request was ok but the task couldn't be created",
+            "description" : "The request was ok but the task couldn't be created/edited",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1607,7 +1607,7 @@
             }
           },
           "201" : {
-            "description" : "The task was created successfully",
+            "description" : "The task was created/edited successfully",
             "content" : {
               "application/json" : {
                 "schema" : {

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -1588,7 +1588,7 @@
           }
         },
         "tags" : [ "Tasks" ],
-        "summary" : "Create or update task",
+        "summary" : "Create or update a task",
         "responses" : {
           "200" : {
             "description" : "The request was ok but the task couldn't be created/edited",
@@ -1607,7 +1607,7 @@
             }
           },
           "201" : {
-            "description" : "The task was created/edited successfully",
+            "description" : "The task was created/updated successfully",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4003,6 +4003,13 @@
               "$ref" : "#/components/schemas/ServiceTemplate"
             },
             "excludes" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              },
+              "example" : [ "spigot.jar", "plugins/cool.jar" ]
+            },
+            "includes" : {
               "type" : "array",
               "items" : {
                 "type" : "string"

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -1607,7 +1607,7 @@
             }
           },
           "201" : {
-            "description" : "The task was created / updated successfully",
+            "description" : "The task was created / edited successfully",
             "content" : {
               "application/json" : {
                 "schema" : {

--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -1591,7 +1591,7 @@
         "summary" : "Create or edit a task",
         "responses" : {
           "200" : {
-            "description" : "The request was ok but the task couldn't be created/edited",
+            "description" : "The request was ok but the task couldn't be created / edited",
             "content" : {
               "application/json" : {
                 "schema" : {


### PR DESCRIPTION
### Motivation
Docs did not say correct method/endpoints

### Modification
Fix docs wording & added node command endpoint to be the same as docs

### Result
Now docs properly explains what it does and how to use it.

### Fixes
Fixes #1270 