### PR TITLE
[ci skip] chore: only rebase renovate PRs in case of a conflict

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":rebaseStalePrs"
+    "config:base"
   ],
   "labels": [
     "t: dependencies"
   ],
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
### Motivation
At the moment we're getting a lot of force-pushes by renovate due to dependency PRs that are getting updated when the base branch changes. That is really not nessacary due to the new merge queue functionality and can be disabled.

### Modification
Configure renovate to only rebase conflicting PRs.

### Result
No more dependency updates force pushes when the base branch updates.