### PR TITLE
fix service lifecycle example

### DIFF
--- a/modules/rest/src/main/resources/documentation/swagger.json
+++ b/modules/rest/src/main/resources/documentation/swagger.json
@@ -1962,7 +1962,7 @@
         "description" : "The target service lifecycle",
         "schema" : {
           "type" : "string",
-          "enum" : [ "start", "stop", "restart", "kill" ]
+          "enum" : [ "start", "stop", "restart"]
         }
       } ],
       "patch" : {


### PR DESCRIPTION
### Motivation
It showed the wrong `Allowed` query-string parameter, making users think that `kill` was an actual parameter, which is not.

### Modification
Remove the `kill` in the allowed list in `PATCH /service/{identifier}/lifecycle` swagger page

### Result
Will only show `Allowed: start | stop | restart` instead of `Allowed: start | stop | restart | kill` in swagger

### Context
https://canary.discord.com/channels/325362837184577536/818777626663321671/1137437198166270183