### PR TITLE
disable compression for zip

### DIFF
--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/ZipUtil.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/ZipUtil.java
@@ -115,6 +115,7 @@ public final class ZipUtil {
   public static @Nullable Path zipToFile(@NonNull Path dir, @NonNull Path target, @Nullable Predicate<Path> filter) {
     if (Files.exists(dir)) {
       try (var out = new ZipOutputStream(Files.newOutputStream(target), StandardCharsets.UTF_8)) {
+        out.setLevel(ZipOutputStream.STORED); // Disable compression
         zipDir(out, dir, filter);
         return target;
       } catch (IOException exception) {


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
Creating a zip for a directory that should be sent over the network takes very long.
Disabling compression makes quite a noticeable improvement in the time it takes for the file to start being sent over the network. Actually sending the file doesn't even take longer most of the time because large files for minecraft servers (region files, jars) are compressed by default and trying to compress them is pointless

### Modification
<!-- Describe the modification you've done to the codebase -->
Disabled compression for creating zip files

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
Faster creating of zips

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
An argument can be made to filter for the file extension before zipping, to only disable compression for already compressed entries like jars and region files
