### PR TITLE
fix OOME when sending huge files over network

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/builder/DefaultChunkedPacketSenderBuilder.java
@@ -39,7 +39,8 @@ import lombok.NonNull;
  */
 public abstract class DefaultChunkedPacketSenderBuilder implements ChunkedPacketSender.Builder {
 
-  public static final int DEFAULT_CHUNK_SIZE = 50 * 1024 * 1024;
+  // 1 MB for every file chunk should be a good value. Setting this too high causes huge arrays (OOME), too low slow transfer speeds. To note:
+  public static final int DEFAULT_CHUNK_SIZE = 1024 * 1024;
 
   protected InputStream source;
   protected String transferChannel;

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
@@ -99,7 +99,7 @@ public final class NettyUtil {
       maximumPoolSize,
       30L,
       TimeUnit.SECONDS,
-      new LinkedBlockingQueue<>(),
+      new LinkedBlockingQueue<>((int) Math.ceil(maximumPoolSize * 1.1)), // A little delay is fine to prevent OOME
       threadFactory,
       DEFAULT_REJECT_HANDLER));
   }


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
Sending huge files (Hundreds of MBs) over the network causes an OOME
Receiving a lot of packets also makes the packetqueue longer and longer if the PacketDispatchers can't keep up

### Modification
<!-- Describe the modification you've done to the codebase -->
I set a max length for the PacketDispatchers (A little over one packet per thread to ensure using all available performance)

The sending part is fixed by reducing the default chunk size to 1MB (from 50MB). This has to be this low because every ChunkSize byte needs at least 3 bytes of memory (because of copying from one array to another)
I also tested with 5MB default chunk size, but even that caused an OOME.
We could, when sending files, also check if there is enough memory available, and if not try trigger the GC and simply wait for the memory, however this is not yet in the commits

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
No more OOME

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
