### PR TITLE
fix: integer overflow when handling chunked packets

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkedPacketHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkedPacketHandler.java
@@ -161,6 +161,7 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
    */
   protected void writePacketContent(int chunkPosition, @NonNull DataBuf dataBuf) throws IOException {
     // calculate the index of to which we need to sink in order to write
+    // we need to use a long here as we might be sending many chunks leading to an overflow when multiplying
     var targetIndex = (long) chunkPosition * this.chunkSessionInformation.chunkSize();
     // sink to the index of the chunk position we need to write to
     this.targetFile.seek(targetIndex);

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkedPacketHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/chunk/defaults/DefaultFileChunkedPacketHandler.java
@@ -161,7 +161,7 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
    */
   protected void writePacketContent(int chunkPosition, @NonNull DataBuf dataBuf) throws IOException {
     // calculate the index of to which we need to sink in order to write
-    var targetIndex = chunkPosition * this.chunkSessionInformation.chunkSize();
+    var targetIndex = (long) chunkPosition * this.chunkSessionInformation.chunkSize();
     // sink to the index of the chunk position we need to write to
     this.targetFile.seek(targetIndex);
     // write the content into the file at the current offset we sunk to


### PR DESCRIPTION
### Motivation
While testing an issue described in #1297 it was discovered that sending a large file (around 4Gb in this case) would result in an IOException due to the fact that the random access file does not allow a negative seeking index and the overflow of the int caused the value to become negative.

### Modification
Casted the calculation of the seeking index to a long to prevent overflow issues.

### Result
Chucked packed sending works with large files.
