### PR TITLE
feat: split command not found and no permissions into separate messages

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
@@ -48,6 +48,7 @@ public final class BridgeConfiguration {
       .put("proxy-join-cancel-because-maintenance", "§7This proxy is currently in maintenance mode.")
       .put("proxy-join-disconnect-because-no-hub", "§cThere is currently no hub server you can connect to.")
       .put("command-cloud-sub-command-no-permission", "§7You are not allowed to use §b%command%.")
+      .put("command-cloud-sub-command-not-found", "§b%command% §7was not found.")
       .put("already-connected", "§cYou are already connected to this network!")
       .put("error-connecting-to-server", "§cUnable to connect to %server%: %reason%")
       .build()));

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordCloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/command/BungeeCordCloudCommand.java
@@ -61,16 +61,23 @@ public final class BungeeCordCloudCommand extends Command implements TabExecutor
     if (sender instanceof ProxiedPlayer player) {
       // get the command info
       this.clusterNodeProvider.consoleCommandAsync(args[0]).thenAcceptAsync(info -> {
-        // check if the player has the required permission
-        if (info == null || !sender.hasPermission(info.permission())) {
+        if (info == null) {
+          // there is no such command
+          this.management.configuration().handleMessage(
+            player.getLocale(),
+            "command-cloud-sub-command-not-found",
+            message -> this.bungeeHelper.translateToComponent(message.replace("%command%", args[0])),
+            player::sendMessage);
+        } else if (!player.hasPermission(info.permission())) {
+          // no permission to execute the command
           this.management.configuration().handleMessage(
             player.getLocale(),
             "command-cloud-sub-command-no-permission",
             message -> this.bungeeHelper.translateToComponent(message.replace("%command%", args[0])),
-            sender::sendMessage);
+            player::sendMessage);
         } else {
-          // execute command
-          this.executeNow(sender, commandLine);
+          // execute the command
+          this.executeNow(player, commandLine);
         }
       });
     } else {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/commands/VelocityCloudCommand.java
@@ -64,11 +64,19 @@ public final class VelocityCloudCommand implements SimpleCommand {
     } else {
       // get the command info
       this.clusterNodeProvider.consoleCommandAsync(arguments[0]).thenAcceptAsync(info -> {
+        var locale = invocation.source() instanceof Player player ? player.getEffectiveLocale() : Locale.ENGLISH;
         // check if the sender has the required permission to execute the command
-        if (info == null || !invocation.source().hasPermission(info.permission())) {
+        if (info == null) {
+          // there is no such command
+          this.management.configuration().handleMessage(
+            locale,
+            "command-cloud-sub-command-not-found",
+            message -> ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message.replace("%command%", arguments[0])),
+            invocation.source()::sendMessage);
+        } else if (!invocation.source().hasPermission(info.permission())) {
           // no permission to execute the command
           this.management.configuration().handleMessage(
-            invocation.source() instanceof Player player ? player.getEffectiveLocale() : Locale.ENGLISH,
+            locale,
             "command-cloud-sub-command-no-permission",
             message -> ComponentFormats.BUNGEE_TO_ADVENTURE.convert(message.replace("%command%", arguments[0])),
             invocation.source()::sendMessage);

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPECloudCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/command/WaterDogPECloudCommand.java
@@ -63,16 +63,22 @@ public final class WaterDogPECloudCommand extends Command {
     if (sender instanceof ProxiedPlayer) {
       // get the command info
       this.clusterNodeProvider.consoleCommandAsync(args[0]).thenAcceptAsync(info -> {
-        // check if the player has the required permission
-        if (info == null || !sender.hasPermission(info.permission())) {
-          // no permission
+        if (info == null) {
+          // there is no such command
+          this.management.configuration().handleMessage(
+            Locale.ENGLISH,
+            "command-cloud-sub-command-not-found",
+            message -> message.replace("%command%", args[0]),
+            sender::sendMessage);
+        } else if (!sender.hasPermission(info.permission())) {
+          // no permission to execute the command
           this.management.configuration().handleMessage(
             Locale.ENGLISH,
             "command-cloud-sub-command-no-permission",
             message -> message.replace("%command%", args[0]),
             sender::sendMessage);
         } else {
-          // execute command
+          // execute the command
           this.executeNow(sender, commandLine);
         }
       });


### PR DESCRIPTION
### Motivation
When using `/cloud` with a sub-command that does not exist we display a message about missing perms which is misleading.

### Modification
Added an extra message for a sub-command that is unknown.

### Result
The messages are splitted.