### PR TITLE
fix: the npc inventory size should not exceed 54

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -62,7 +62,9 @@ public abstract class BukkitPlatformSelectorEntity
     .findMethod("setColor", ChatColor.class)
     .orElse(null);
 
-  protected static final int MAX_INVENTORY_SIZE = 9 * 6;
+  protected static final int MAX_ROWS = 6;
+  protected static final int MAX_ROW_ITEMS = 9;
+  protected static final int MAX_SIZE = MAX_ROW_ITEMS * MAX_ROWS;
 
   protected final NPC npc;
   protected final Plugin plugin;
@@ -470,11 +472,11 @@ public abstract class BukkitPlatformSelectorEntity
     if (configuration.dynamicSize()) {
       // dynamic size: create the smallest possible inventory that can fit all items (one row can fit 9 items)
       inventorySize = this.serviceItems.size();
-      inventorySize += 9 - (inventorySize % 9);
+      inventorySize += MAX_ROW_ITEMS - (inventorySize % MAX_ROW_ITEMS);
     }
 
     // minecraft inventories have a limit of 54 items
-    return Math.min(MAX_INVENTORY_SIZE, inventorySize);
+    return Math.min(MAX_SIZE, inventorySize);
   }
 
   protected @NonNull PlayerManager playerManager() {

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -62,9 +62,9 @@ public abstract class BukkitPlatformSelectorEntity
     .findMethod("setColor", ChatColor.class)
     .orElse(null);
 
-  protected static final int MAX_ROWS = 6;
-  protected static final int MAX_ROW_ITEMS = 9;
-  protected static final int MAX_SIZE = MAX_ROW_ITEMS * MAX_ROWS;
+  protected static final int MAX_INVENTORY_ROWS = 6;
+  protected static final int MAX_INVENTORY_ROW_ITEMS = 9;
+  protected static final int MAX_INVENTORY_SIZE = MAX_INVENTORY_ROW_ITEMS * MAX_INVENTORY_ROWS;
 
   protected final NPC npc;
   protected final Plugin plugin;
@@ -472,11 +472,11 @@ public abstract class BukkitPlatformSelectorEntity
     if (configuration.dynamicSize()) {
       // dynamic size: create the smallest possible inventory that can fit all items (one row can fit 9 items)
       inventorySize = this.serviceItems.size();
-      inventorySize += MAX_ROW_ITEMS - (inventorySize % MAX_ROW_ITEMS);
+      inventorySize += MAX_INVENTORY_ROW_ITEMS - (inventorySize % MAX_INVENTORY_ROW_ITEMS);
     }
 
     // minecraft inventories have a limit of 54 items
-    return Math.min(MAX_SIZE, inventorySize);
+    return Math.min(MAX_INVENTORY_SIZE, inventorySize);
   }
 
   protected @NonNull PlayerManager playerManager() {


### PR DESCRIPTION
### Motivation
The npc inventory has a dynamic size feature that scales the inventory based on the amount of services to display but that feature misses a upper bound of 54 (which is needed as minecraft inventories cant be bigger)

### Modification
Extracted the inventory size calculation into a separate method and set a upper bound of 54.

### Result
The inventory is created with a maximum of 54 slots.
