### PR TITLE
fix: properly convert adventure components into bungee basecomponents

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ adventure = "4.13.1"
 modlauncher = "8.1.3"
 npcLib = "3.0.0-beta5"
 placeholderApi = "2.11.3"
+adventure-serializer-bungee = "4.3.0"
 
 # fabric platform special dependencies
 minecraft = "1.20"
@@ -170,6 +171,7 @@ waterdogpe = { group = "dev.waterdog.waterdogpe", name = "waterdog", version.ref
 adventureApi = { group = "net.kyori", name = "adventure-api", version.ref = "adventure" }
 adventureSerializerGson = { group = "net.kyori", name = "adventure-text-serializer-gson", version.ref = "adventure" }
 adventureSerializerLegacy = { group = "net.kyori", name = "adventure-text-serializer-legacy", version.ref = "adventure" }
+adventureSerializerBungee = { group = "net.kyori", name = "adventure-text-serializer-bungeecord", version.ref = "adventure-serializer-bungee" }
 
 # platform extensions
 vault = { group = "com.github.MilkBowl", name = "VaultAPI", version.ref = "vault" }

--- a/modules/bridge/build.gradle.kts
+++ b/modules/bridge/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
 
   "runtimeImpl"(libs.bundles.adventure)
   "runtimeImpl"(projects.ext.adventureHelper)
+  "runtimeImpl"(libs.adventureSerializerBungee)
 
   // processing
   "annotationProcessor"(libs.aerogelAuto)

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
@@ -38,7 +38,7 @@ final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
 
   // the first minecraft version to support hex colors
   // https://minecraft.fandom.com/wiki/Java_Edition_1.16
-  private static final int MODERN_PROTOCOL = 735;
+  private static final int PROTOCOL_VERSION_1_16 = 735;
 
   private final ProxyServer proxyServer;
   private final PluginManager pluginManager;
@@ -149,7 +149,7 @@ final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
 
   private @NonNull BaseComponent[] convertComponent(@NonNull Component component, @NonNull ProxiedPlayer player) {
     // check if we have to use legacy colors because the client is on an old version
-    if (player.getPendingConnection().getVersion() < MODERN_PROTOCOL) {
+    if (player.getPendingConnection().getVersion() < PROTOCOL_VERSION_1_16) {
       return BungeeComponentSerializer.legacy().serialize(component);
     } else {
       return BungeeComponentSerializer.get().serialize(component);

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
@@ -16,9 +16,6 @@
 
 package eu.cloudnetservice.modules.bridge.platform.bungeecord;
 
-import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
-import static net.md_5.bungee.api.chat.TextComponent.fromLegacyText;
-
 import eu.cloudnetservice.common.tuple.Tuple2;
 import eu.cloudnetservice.modules.bridge.platform.PlatformBridgeManagement;
 import eu.cloudnetservice.modules.bridge.platform.PlatformPlayerExecutorAdapter;
@@ -29,13 +26,19 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.NonNull;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ServerConnectEvent.Reason;
 import net.md_5.bungee.api.plugin.PluginManager;
 import org.jetbrains.annotations.Nullable;
 
 final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter<ProxiedPlayer> {
+
+  // the first minecraft version to support hex colors
+  // https://minecraft.fandom.com/wiki/Java_Edition_1.16
+  private static final int MODERN_PROTOCOL = 735;
 
   private final ProxyServer proxyServer;
   private final PluginManager pluginManager;
@@ -107,14 +110,14 @@ final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
 
   @Override
   public void kick(@NonNull Component message) {
-    this.forEach(player -> player.disconnect(fromLegacyText(legacySection().serialize(message))));
+    this.forEach(player -> player.disconnect(this.convertComponent(message, player)));
   }
 
   @Override
   protected void sendTitle(@NonNull Component title, @NonNull Component subtitle, int fadeIn, int stay, int fadeOut) {
     this.forEach(player -> this.proxyServer.createTitle()
-      .title(fromLegacyText(legacySection().serialize(title)))
-      .subTitle(fromLegacyText(legacySection().serialize(subtitle)))
+      .title(this.convertComponent(title, player))
+      .subTitle(this.convertComponent(subtitle, player))
       .fadeIn(fadeIn)
       .stay(stay)
       .fadeOut(fadeOut)
@@ -125,7 +128,7 @@ final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
   public void sendChatMessage(@NonNull Component message, @Nullable String permission) {
     this.forEach(player -> {
       if (permission == null || player.hasPermission(permission)) {
-        player.sendMessage(fromLegacyText(legacySection().serialize(message)));
+        player.sendMessage(this.convertComponent(message, player));
       }
     });
   }
@@ -142,5 +145,14 @@ final class BungeeCordDirectPlayerExecutor extends PlatformPlayerExecutorAdapter
         player.chat('/' + command);
       }
     });
+  }
+
+  private @NonNull BaseComponent[] convertComponent(@NonNull Component component, @NonNull ProxiedPlayer player) {
+    // check if we have to use legacy colors because the client is on an old version
+    if (player.getPendingConnection().getVersion() < MODERN_PROTOCOL) {
+      return BungeeComponentSerializer.legacy().serialize(component);
+    } else {
+      return BungeeComponentSerializer.get().serialize(component);
+    }
   }
 }


### PR DESCRIPTION
### Motivation
When converting between adventure components and bungeecord basecomponents we loose some styling features like the hover & clickevent.

### Modification
Added the adventure-text-serializer-bungeecord lib to handle the conversion between the components.

### Result
All features provided in the adventure component get passed into the BaseComponent.

### Other
Fixes #1216
