### PR TITLE
feat: support minecraft 1.20.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ bungeecord = "1.20-R0.2-SNAPSHOT"
 vault = "1.7.1"
 adventure = "4.13.1"
 modlauncher = "8.1.3"
-npcLib = "3.0.0-beta5"
+npcLib = "3.0.0-beta6"
 placeholderApi = "2.11.3"
 
 # fabric platform special dependencies
@@ -176,8 +176,9 @@ vault = { group = "com.github.MilkBowl", name = "VaultAPI", version.ref = "vault
 modLauncher = { group = "cpw.mods", name = "modlauncher", version.ref = "modlauncher" }
 bungeecordChat = { group = "net.md-5", name = "bungeecord-chat", version.ref = "bungeecord" }
 placeholderApi = { group = "me.clip", name = "placeholderapi", version.ref = "placeholderApi" }
-npcLib = { group = "com.github.juliarn.NPC-Lib", name = "npc-lib-bukkit", version.ref = "npcLib" }
-npcLibLabymod = { group = "com.github.juliarn.NPC-Lib", name = "npc-lib-labymod", version.ref = "npcLib" }
+
+npcLib = { group = "io.github.juliarn", name = "npc-lib-bukkit", version.ref = "npcLib" }
+npcLibLabymod = { group = "io.github.juliarn", name = "npc-lib-labymod", version.ref = "npcLib" }
 
 # fabric platform special dependencies
 minecraft = { group = "com.mojang", name = "minecraft", version.ref = "minecraft" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ shadow = "8.1.1"
 blossom = "1.3.1"
 juppiter = "0.4.0"
 spotless = "6.18.0"
-fabricLoom = "1.2.7"
+fabricLoom = "1.3.9"
 nexusPublish = "1.3.0"
 checkstyleTools = "10.11.0"
 
@@ -61,9 +61,9 @@ sponge = "9.0.0"
 velocity = "3.1.1"
 waterdogpe = "1.2.4"
 nukkitX = "1.0-SNAPSHOT"
-minestom = "79ce9570ea"
+minestom = "2cdb3911b0"
 spigot = "1.8.8-R0.1-SNAPSHOT"
-bungeecord = "1.20-R0.1-SNAPSHOT"
+bungeecord = "1.20-R0.2-SNAPSHOT"
 
 # platform extensions
 vault = "1.7.1"
@@ -73,8 +73,8 @@ npcLib = "3.0.0-beta5"
 placeholderApi = "2.11.3"
 
 # fabric platform special dependencies
-minecraft = "1.20"
-fabricLoader = "0.14.21"
+minecraft = "1.20.2"
+fabricLoader = "0.14.22"
 
 
 [libraries]

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
@@ -30,8 +30,8 @@ import lombok.NonNull;
   name = "CloudNet-Bridge",
   version = "{project.build.version}",
   dependencies = {
-    @Dependency(name = "fabricloader", version = ">=0.14.21"),
-    @Dependency(name = "minecraft", version = "~1.20.1"),
+    @Dependency(name = "fabricloader", version = ">=0.14.22"),
+    @Dependency(name = "minecraft", version = "~1.20.2"),
     @Dependency(name = "java", version = ">=17")
   },
   authors = "CloudNetService"

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricCustomPacketPayload.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricCustomPacketPayload.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019-2023 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.modules.bridge.platform.fabric;
+
+import lombok.NonNull;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+record FabricCustomPacketPayload(@NonNull ResourceLocation id, byte[] payload) implements CustomPacketPayload {
+
+  @Override
+  public void write(@NonNull FriendlyByteBuf buf) {
+    buf.writeBytes(this.payload);
+  }
+}

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricDirectPlayerExecutor.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricDirectPlayerExecutor.java
@@ -18,15 +18,13 @@ package eu.cloudnetservice.modules.bridge.platform.fabric;
 
 import eu.cloudnetservice.modules.bridge.platform.PlatformPlayerExecutorAdapter;
 import eu.cloudnetservice.modules.bridge.player.executor.ServerSelectorType;
-import io.netty.buffer.Unpooled;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.NonNull;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
+import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import org.jetbrains.annotations.Nullable;
@@ -80,10 +78,8 @@ public final class FabricDirectPlayerExecutor extends PlatformPlayerExecutorAdap
 
   @Override
   public void sendPluginMessage(@NonNull String key, byte[] data) {
-    var identifier = new ResourceLocation(key);
-    this.forEach(player -> player.connection.send(new ClientboundCustomPayloadPacket(
-      identifier,
-      new FriendlyByteBuf(Unpooled.wrappedBuffer(data)))));
+    var customPayload = new FabricCustomPacketPayload(new ResourceLocation(key), data);
+    this.forEach(player -> player.connection.send(new ClientboundCustomPayloadPacket(customPayload)));
   }
 
   @Override

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ClientIntentionPacketMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ClientIntentionPacketMixin.java
@@ -34,7 +34,7 @@ public final class ClientIntentionPacketMixin {
     at = @At(value = "INVOKE", target = "Lnet/minecraft/network/FriendlyByteBuf;readUtf(I)Ljava/lang/String;"),
     method = "<init>(Lnet/minecraft/network/FriendlyByteBuf;)V"
   )
-  public String read(@NonNull FriendlyByteBuf buf, int amount) {
+  private static String read(@NonNull FriendlyByteBuf buf, int amount) {
     if (FabricBridgeManagement.DISABLE_CLOUDNET_FORWARDING) {
       // default behaviour
       return buf.readUtf(255);

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerLoginPacketListenerMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/forwarding/ServerLoginPacketListenerMixin.java
@@ -37,19 +37,18 @@ public final class ServerLoginPacketListenerMixin {
 
   @Final
   @Shadow
-  public Connection connection;
+  Connection connection;
 
   @Shadow
-  GameProfile gameProfile;
+  private GameProfile authenticatedProfile;
 
-  @Inject(at = @At("HEAD"), method = "handleAcceptedLogin")
+  @Inject(at = @At("TAIL"), method = "startClientVerification")
   private void onAcceptedLogin(@NonNull CallbackInfo callbackInfo) {
     if (!FabricBridgeManagement.DISABLE_CLOUDNET_FORWARDING) {
       var bridged = (BridgedClientConnection) this.connection;
-      // update the profile according to the forwarded data
-      this.gameProfile = new GameProfile(bridged.forwardedUniqueId(), this.gameProfile.getName());
+      this.authenticatedProfile = new GameProfile(bridged.forwardedUniqueId(), this.authenticatedProfile.getName());
       for (var property : bridged.forwardedProfile()) {
-        this.gameProfile.getProperties().put(property.getName(), property);
+        this.authenticatedProfile.getProperties().put(property.name(), property);
       }
     }
   }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/handling/PlayerListMixin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/mixin/handling/PlayerListMixin.java
@@ -23,8 +23,8 @@ import net.fabricmc.api.Environment;
 import net.minecraft.network.Connection;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.CommonListenerCookie;
 import net.minecraft.server.players.PlayerList;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -42,20 +42,21 @@ public final class PlayerListMixin {
 
   @Inject(
     at = @At(
-      by = 2,
-      ordinal = 0,
-      value = "FIELD",
-      shift = At.Shift.BY,
-      opcode = Opcodes.GETFIELD,
-      target = "Lnet/minecraft/server/players/PlayerList;players:Ljava/util/List;"
+      value = "INVOKE",
+      target = "Lnet/minecraft/server/level/ServerLevel;addNewPlayer(Lnet/minecraft/server/level/ServerPlayer;)V"
     ),
     method = "placeNewPlayer"
   )
-  public void onJoin(@NonNull Connection con, @NonNull ServerPlayer player, @NonNull CallbackInfo info) {
+  public void onJoin(
+    @NonNull Connection connection,
+    @NonNull ServerPlayer serverPlayer,
+    @NonNull CommonListenerCookie commonListenerCookie,
+    @NonNull CallbackInfo callbackInfo
+  ) {
     if (this.server instanceof BridgedServer bridgedServer) {
       bridgedServer.injectionHolder().serverPlatformHelper().sendChannelMessageLoginSuccess(
-        player.getUUID(),
-        bridgedServer.management().createPlayerInformation(player));
+        serverPlayer.getUUID(),
+        bridgedServer.management().createPlayerInformation(serverPlayer));
       // update the service info instantly as the player is registered now
       bridgedServer.injectionHolder().serviceInfoHolder().publishServiceInfoUpdate();
     }

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
@@ -66,10 +66,10 @@ public final class BukkitFunctionalityListener implements Listener {
     this.scheduler = scheduler;
     this.management = management;
 
-    var bus = management.npcPlatform().eventBus();
-    bus.subscribe(AttackNpcEvent.class, this::handleNpcAttack);
-    bus.subscribe(InteractNpcEvent.class, this::handleNpcInteract);
-    bus.subscribe(ShowNpcEvent.Post.class, this::handleNpcShow);
+    var bus = management.npcPlatform().eventManager();
+    bus.registerEventHandler(AttackNpcEvent.class, this::handleNpcAttack);
+    bus.registerEventHandler(InteractNpcEvent.class, this::handleNpcInteract);
+    bus.registerEventHandler(ShowNpcEvent.Post.class, this::handleNpcShow);
   }
 
   public void handleNpcShow(@NonNull ShowNpcEvent.Post event) {

--- a/node/src/main/resources/files/velocity/velocity.toml
+++ b/node/src/main/resources/files/velocity/velocity.toml
@@ -1,12 +1,12 @@
 # Config version. Do not change this
-config-version = "1.0"
+config-version = "2.6"
 
 # What port should the proxy be bound to? By default, we'll bind to all addresses on port 25577.
 bind = "0.0.0.0:25577"
 
 # What should be the MOTD? This gets displayed when the player adds your server to
-# their server list. Legacy color codes and JSON are accepted.
-motd = "&bCloudNet &8[&cBlizzard&8] &7Velocity &cProxy &7instance"
+# their server list. Only MiniMessage format is accepted.
+motd = "<#09add3>A Velocity Server"
 
 # What should we display for the maximum number of players? (Velocity does not support a cap
 # on the number of players online.)
@@ -36,8 +36,9 @@ prevent-client-proxy-connections = false
 #                  Velocity's native forwarding. Only applicable for Minecraft 1.13 or higher.
 player-info-forwarding-mode = "legacy"
 
-# If you are using modern or BungeeGuard IP forwarding, configure a unique secret here.
-forwarding-secret = ""
+# If you are using modern or BungeeGuard IP forwarding, configure a file that contains a unique secret here.
+# The file is expected to be UTF-8 encoded and not empty.
+forwarding-secret-file = "forwarding.secret"
 
 # Announce whether or not your server supports Forge. If you run a modded server, we
 # suggest turning this on.

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -479,11 +479,11 @@
             },
             "fetchOverSpongeApi": true,
             "artifact": "spongevanilla",
-            "mcVersion": "1.20"
+            "mcVersion": "1.20.2"
           }
         },
         {
-          "name": "1.20.1",
+          "name": "1.20.2",
           "properties": {
             "copy": {
               "libraries/.*": "/",
@@ -492,7 +492,7 @@
             },
             "fetchOverSpongeApi": true,
             "artifact": "spongevanilla",
-            "mcVersion": "1.20.1"
+            "mcVersion": "1.20.2"
           }
         },
         {

--- a/node/src/main/resources/files/versions.json
+++ b/node/src/main/resources/files/versions.json
@@ -91,11 +91,11 @@
               "-Dpaperclip.patchonly=true"
             ],
             "fetchOverPaperApi": true,
-            "versionGroup": "1.20.1"
+            "versionGroup": "1.20.2"
           }
         },
         {
-          "name": "1.20.1",
+          "name": "1.20.2",
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -106,7 +106,7 @@
               "-Dpaperclip.patchonly=true"
             ],
             "fetchOverPaperApi": true,
-            "versionGroup": "1.20.1"
+            "versionGroup": "1.20.2"
           }
         },
         {
@@ -277,7 +277,7 @@
       "versions": [
         {
           "name": "latest",
-          "url": "https://api.purpurmc.org/v2/purpur/1.20.1/latest/download",
+          "url": "https://api.purpurmc.org/v2/purpur/1.20.2/latest/download",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -291,8 +291,8 @@
           }
         },
         {
-          "name": "1.20.1",
-          "url": "https://api.purpurmc.org/v2/purpur/1.20.1/latest/download",
+          "name": "1.20.2",
+          "url": "https://api.purpurmc.org/v2/purpur/1.20.2/latest/download",
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -438,7 +438,7 @@
       "website": "https://fabricmc.net",
       "versions": [
         {
-          "name": "1.20.1",
+          "name": "1.20.2",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -483,7 +483,7 @@
           }
         },
         {
-          "name": "1.20",
+          "name": "1.20.1",
           "properties": {
             "copy": {
               "libraries/.*": "/",
@@ -492,7 +492,7 @@
             },
             "fetchOverSpongeApi": true,
             "artifact": "spongevanilla",
-            "mcVersion": "1.20"
+            "mcVersion": "1.20.1"
           }
         },
         {
@@ -596,14 +596,6 @@
       "versions": [
         {
           "name": "latest",
-          "cacheFiles": false,
-          "properties": {
-            "fetchOverPaperApi": true,
-            "versionGroup": "3.1.1"
-          }
-        },
-        {
-          "name": "development",
           "cacheFiles": false,
           "properties": {
             "fetchOverPaperApi": true,


### PR DESCRIPTION
### Motivation
Minecraft 1.20.2 was released and all platforms have support for it. We should support it now too.

### Modification
Changed all downloads to 1.20.2. Addressed an issue with bungeecord 1.20.2 being breaking and updated npc-lib to beta6 to support 1.20.2.

### Result
Minecraft 1.20.2 is fully supported.
