### PR TITLE
fix: only start smart services on allowed nodes

### DIFF
--- a/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetTickListener.java
+++ b/modules/smart/src/main/java/eu/cloudnetservice/modules/smart/listener/CloudNetTickListener.java
@@ -210,7 +210,7 @@ public final class CloudNetTickListener {
     // check if we should decide directly which node server we use
     NodeServer server = null;
     if (config.splitLogicallyOverNodes()) {
-      server = this.selectNodeServer(services);
+      server = this.selectNodeServer(task, services);
     }
     // create a new service based on the task
     var createResult = this.serviceFactory.createCloudService(ServiceConfiguration.builder(task)
@@ -219,10 +219,17 @@ public final class CloudNetTickListener {
     return createResult.state() == ServiceCreateResult.State.CREATED ? createResult.serviceInfo() : null;
   }
 
-  private @Nullable NodeServer selectNodeServer(@NonNull Collection<ServiceInfoSnapshot> services) {
+  private @Nullable NodeServer selectNodeServer(
+    @NonNull ServiceTask serviceTask,
+    @NonNull Collection<ServiceInfoSnapshot> services
+  ) {
     // find the node server with the least services on it
     return this.nodeServerProvider.nodeServers().stream()
       .filter(nodeServer -> nodeServer.available() && !nodeServer.draining())
+      .filter(nodeServer -> {
+        var allowedNodes = serviceTask.associatedNodes();
+        return allowedNodes.isEmpty() || allowedNodes.contains(nodeServer.name());
+      })
       .map(node -> new Tuple2<>(node, services.stream()
         .filter(service -> service.serviceId().nodeUniqueId().equals(node.info().uniqueId()))
         .count()))


### PR DESCRIPTION
### Motivation
A service task can specify which nodes are allowed to pick up a service that is about to start using the `allowedNodes` option.
The smart modules extends some of these tasks options by allowing to choose if the task should be spread evenly onto other nodes using `splitLogicallyOverNodes`. But now these two options are clashing because the smart module would not check if the service is allowed to start on the node that was chosen for logically splitting the services.

### Modification
Added a check to the smart modules `splitLogicallyOverNodes` handling which makes sure that only nodes are chosen that are allowed (if any are specified).

### Result
The smart module options and service task options are not clashing anymore and respecting each other.

##### Other context
Fixes #1312 
