### PR TITLE
chore: update gradle to 8.4

### DIFF
--- a/build-extensions/src/main/kotlin/extensions.kt
+++ b/build-extensions/src/main/kotlin/extensions.kt
@@ -78,7 +78,7 @@ fun snapshotsOnly(repository: MavenArtifactRepository) {
 }
 
 fun Project.exportLanguageFileInformation(): String {
-  val file = project.buildDir.resolve("languages.txt")
+  val file = project.layout.buildDirectory.file("languages.txt").get().asFile
   file.writeText(project.projectDir.resolve("src/main/resources/lang").listFiles()?.joinToString(separator = "\n") { it.name }!!)
 
   return file.absolutePath
@@ -120,7 +120,7 @@ fun Project.exportCnlFile(fileName: String, ignoredDependencyGroups: Array<Strin
   }
 
   // write to the output file
-  val target = project.buildDir.resolve(fileName)
+  val target = project.layout.buildDirectory.file(fileName).get().asFile
   target.writeText(stringBuilder.toString())
 
   return target.absolutePath

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,7 @@ subprojects {
     "compileOnly"(rootProject.libs.annotations)
     // testing
     "testImplementation"(rootProject.libs.mockito)
+    "testRuntimeOnly"(rootProject.libs.junitLauncher)
     "testImplementation"(rootProject.libs.bundles.junit)
     "testImplementation"(rootProject.libs.bundles.testContainers)
   }
@@ -148,7 +149,7 @@ tasks.register("globalJavaDoc", Javadoc::class) {
   val options = options as? StandardJavadocDocletOptions ?: return@register
 
   title = "CloudNet JavaDocs"
-  setDestinationDir(buildDir.resolve("javadocs"))
+  setDestinationDir(layout.buildDirectory.dir("javadocs").get().asFile)
   // options
   applyDefaultJavadocOptions(options)
   options.windowTitle = "CloudNet JavaDocs"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 
 # plugins
 shadow = "8.1.1"
-blossom = "1.3.1"
 juppiter = "0.4.0"
 spotless = "6.18.0"
 fabricLoom = "1.3.9"
@@ -16,6 +15,7 @@ guava = "32.1.1-jre"
 # testing
 junit = "5.9.3"
 mockito = "5.3.1"
+junitLauncher = "1.10.0"
 testcontainers = "1.18.3"
 
 # compile time processing
@@ -111,6 +111,7 @@ jjwtGson = { group = "io.jsonwebtoken", name = "jjwt-gson", version.ref = "jjwt"
 junitApi = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
 junitParams = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit" }
 junitEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
+junitLauncher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junitLauncher" }
 
 # general testing
 mockito = { group = "org.mockito", name = "mockito-junit-jupiter", version.ref = "mockito" }
@@ -211,7 +212,6 @@ serverPlatform = ["spigot", "sponge", "nukkitX", "minestom"]
 
 [plugins]
 
-blossom = { id = "net.kyori.blossom", version.ref = "blossom" }
 fabricLoom = { id = "fabric-loom", version.ref = "fabricLoom" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionSha256Sum=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bukkit/BukkitBridgePlugin.java
@@ -30,7 +30,7 @@ import org.bukkit.plugin.PluginManager;
 @PlatformPlugin(
   platform = "bukkit",
   name = "CloudNet-Bridge",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Bridges service software support between all supported versions for easy CloudNet plugin development",
   authors = "CloudNetService"
 )

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/bungeecord/BungeeCordBridgePlugin.java
@@ -35,7 +35,7 @@ import net.md_5.bungee.api.plugin.PluginManager;
 @PlatformPlugin(
   platform = "bungeecord",
   name = "CloudNet-Bridge",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Bridges service software support between all supported versions for easy CloudNet plugin development",
   authors = "CloudNetService")
 public final class BungeeCordBridgePlugin implements PlatformEntrypoint {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
@@ -28,7 +28,7 @@ import lombok.NonNull;
 @PlatformPlugin(
   platform = "fabric",
   name = "CloudNet-Bridge",
-  version = "{project.build.version}",
+  version = "@version@",
   dependencies = {
     @Dependency(name = "fabricloader", version = ">=0.14.22"),
     @Dependency(name = "minecraft", version = "~1.20.2"),

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomBridgeExtension.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/minestom/MinestomBridgeExtension.java
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 @PlatformPlugin(
   platform = "minestom",
   name = "CloudNet-Bridge",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Bridges service software support between all supported versions for easy CloudNet plugin development",
   authors = "CloudNetService",
   externalDependencies = @ExternalDependency(

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/nukkit/NukkitBridgePlugin.java
@@ -32,7 +32,7 @@ import lombok.NonNull;
   platform = "nukkit",
   api = "1.0.5",
   name = "CloudNet-Bridge",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Bridges service software support between all supported versions for easy CloudNet plugin development",
   authors = "CloudNetService")
 public final class NukkitBridgePlugin implements PlatformEntrypoint {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/sponge/SpongeBridgePlugin.java
@@ -31,7 +31,7 @@ import org.spongepowered.plugin.PluginContainer;
 @PlatformPlugin(
   platform = "sponge",
   name = "CloudNet-Bridge",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Bridges service software support between all supported versions for easy CloudNet plugin development",
   authors = "CloudNetService",
   dependencies = @Dependency(name = "spongeapi", version = "8.0.0")

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/velocity/VelocityBridgePlugin.java
@@ -33,7 +33,7 @@ import lombok.NonNull;
 @PlatformPlugin(
   platform = "velocity",
   name = "CloudNet-Bridge",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Bridges service software support between all supported versions for easy CloudNet plugin development",
   authors = "CloudNetService")
 public final class VelocityBridgePlugin implements PlatformEntrypoint {

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgePlugin.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/waterdog/WaterDogPEBridgePlugin.java
@@ -32,7 +32,7 @@ import lombok.NonNull;
 @PlatformPlugin(
   platform = "waterdog",
   name = "CloudNet-Bridge",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Bridges service software support between all supported versions for easy CloudNet plugin development",
   authors = "CloudNetService")
 public final class WaterDogPEBridgePlugin implements PlatformEntrypoint {

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bukkit/BukkitCloudPermissionsPlugin.java
@@ -37,7 +37,7 @@ import org.bukkit.plugin.java.JavaPlugin;
   platform = "bukkit",
   name = "CloudNet-CloudPerms",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Bukkit extension which implement the permission management system from CloudNet into Bukkit"
 )
 public final class BukkitCloudPermissionsPlugin implements PlatformEntrypoint {

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/bungee/BungeeCloudPermissionsPlugin.java
@@ -30,7 +30,7 @@ import net.md_5.bungee.api.plugin.PluginManager;
   platform = "bungeecord",
   name = "CloudNet-CloudPerms",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "BungeeCord extension which implement the permission management system from CloudNet into BungeeCord"
 )
 public final class BungeeCloudPermissionsPlugin implements PlatformEntrypoint {

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/MinestomCloudPermissionsExtension.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/minestom/MinestomCloudPermissionsExtension.java
@@ -39,7 +39,7 @@ import net.minestom.server.network.ConnectionManager;
   platform = "minestom",
   name = "CloudNet-CloudPerms",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   externalDependencies = @ExternalDependency(
     groupId = "com.google.guava",
     artifactId = "guava",

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/nukkit/NukkitCloudPermissionsPlugin.java
@@ -36,7 +36,7 @@ import lombok.NonNull;
   platform = "nukkit",
   name = "CloudNet-CloudPerms",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   api = "1.0.5",
   description = "Nukkit extension which implement the permission management system from CloudNet into Nukkit"
 )

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongeCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/sponge/SpongeCloudPermissionsPlugin.java
@@ -40,7 +40,7 @@ import org.spongepowered.plugin.PluginContainer;
   platform = "sponge",
   name = "CloudNet-CloudPerms",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   homepage = "https://cloudnetservice.eu",
   description = "Sponge extension which implement the permission management system from CloudNet into Sponge",
   dependencies = @Dependency(name = "spongeapi", version = "8.0.0")

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/velocity/VelocityCloudNetCloudPermissionsPlugin.java
@@ -30,7 +30,7 @@ import lombok.NonNull;
 @PlatformPlugin(
   platform = "velocity",
   name = "CloudNet-CloudPerms",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Velocity extension which implement the permission management system from CloudNet into Velocity",
   homepage = "https://cloudnetservice.eu",
   authors = "CloudNetService"

--- a/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/waterdogpe/WaterdogPECloudPermissionsPlugin.java
+++ b/modules/cloudperms/src/main/java/eu/cloudnetservice/modules/cloudperms/waterdogpe/WaterdogPECloudPermissionsPlugin.java
@@ -28,7 +28,7 @@ import lombok.NonNull;
   platform = "waterdog",
   name = "CloudNet-CloudPerms",
   authors = "CloudNetService",
-  version = "{project.build.version}"
+  version = "@version@"
 )
 public class WaterdogPECloudPermissionsPlugin implements PlatformEntrypoint {
 

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/bungeecord/BungeeCordLabyModPlugin.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/bungeecord/BungeeCordLabyModPlugin.java
@@ -33,7 +33,7 @@ import net.md_5.bungee.api.plugin.PluginManager;
   platform = "bungeecord",
   name = "CloudNet-LabyMod",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Displays LabyMod DiscordRPC information when playing on cloudnet a server",
   dependencies = @Dependency(name = "CloudNet-Bridge")
 )

--- a/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModPlugin.java
+++ b/modules/labymod/src/main/java/eu/cloudnetservice/modules/labymod/platform/velocity/VelocityLabyModPlugin.java
@@ -35,7 +35,7 @@ import lombok.NonNull;
   platform = "velocity",
   name = "CloudNet-LabyMod",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Displays LabyMod DiscordRPC information when playing on cloudnet a server",
   dependencies = @Dependency(name = "CloudNet-Bridge")
 )

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
@@ -38,7 +38,7 @@ import org.bukkit.plugin.java.JavaPlugin;
   platform = "bukkit",
   name = "CloudNet-NPCs",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   homepage = "https://cloudnetservice.eu",
   description = "CloudNet extension which adds NPCs for server selection",
   dependencies = {

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignsPlugin.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignsPlugin.java
@@ -35,7 +35,7 @@ import org.bukkit.plugin.java.JavaPlugin;
   api = "1.13",
   platform = "bukkit",
   name = "CloudNet-Signs",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Bukkit extension for the CloudNet runtime which adds sign connector support",
   authors = "CloudNetService",
   dependencies = @Dependency(name = "CloudNet-Bridge"),

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignsExtension.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/minestom/MinestomSignsExtension.java
@@ -32,7 +32,7 @@ import net.minestom.server.command.CommandManager;
 @PlatformPlugin(
   platform = "minestom",
   name = "CloudNet_Signs",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Minestom extension for the CloudNet runtime which adds sign connector support",
   authors = "CloudNetService",
   dependencies = @Dependency(name = "CloudNet-Bridge"))

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignsPlugin.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignsPlugin.java
@@ -35,7 +35,7 @@ import lombok.NonNull;
 @PlatformPlugin(
   platform = "nukkit",
   name = "CloudNet-Signs",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Nukkit extension for the CloudNet runtime which adds sign connector support",
   authors = "CloudNetService",
   dependencies = @Dependency(name = "CloudNet-Bridge"),

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignsPlugin.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/SpongeSignsPlugin.java
@@ -33,7 +33,7 @@ import org.spongepowered.plugin.PluginContainer;
 @PlatformPlugin(
   platform = "sponge",
   name = "CloudNet-Signs",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Sponge extension for the CloudNet runtime which adds sign connector support",
   authors = "CloudNetService",
   dependencies = @Dependency(name = "CloudNet-Bridge")

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyPlugin.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/bungee/BungeeCordSyncProxyPlugin.java
@@ -33,7 +33,7 @@ import net.md_5.bungee.api.plugin.PluginManager;
 @PlatformPlugin(
   platform = "bungeecord",
   name = "CloudNet-SyncProxy",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "CloudNet extension which serves proxy utils with CloudNet support",
   authors = "CloudNetService",
   dependencies = {@Dependency(name = "CloudNet-Bridge"), @Dependency(name = "CloudNet-CloudPerms", optional = true)})

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyPlugin.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/velocity/VelocitySyncProxyPlugin.java
@@ -30,7 +30,7 @@ import lombok.NonNull;
 @PlatformPlugin(
   platform = "velocity",
   name = "CloudNet-SyncProxy",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "CloudNet extension which serves proxy utils with CloudNet support",
   authors = "CloudNetService",
   dependencies = {@Dependency(name = "CloudNet-Bridge"), @Dependency(name = "CloudNet-CloudPerms", optional = true)}

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyPlugin.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/platform/waterdog/WaterDogPESyncProxyPlugin.java
@@ -31,7 +31,7 @@ import lombok.NonNull;
 @PlatformPlugin(
   platform = "waterdog",
   name = "CloudNet-SyncProxy",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "CloudNet extension which serves proxy utils with CloudNet support",
   authors = "CloudNetService",
   dependencies = {@Dependency(name = "CloudNet-Bridge"), @Dependency(name = "CloudNet-CloudPerms", optional = true)})

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -14,24 +14,14 @@
  * limitations under the License.
  */
 
-import net.kyori.blossom.BlossomExtension
-
-plugins {
-  alias(libs.plugins.blossom) apply false
-}
+import org.apache.tools.ant.filters.ReplaceTokens
 
 subprojects {
-  apply(plugin = "net.kyori.blossom")
-
   repositories {
     maven("https://repo.spongepowered.org/maven/")
     maven("https://repo.opencollab.dev/maven-releases/")
     maven("https://repo.opencollab.dev/maven-snapshots/")
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
-  }
-
-  configure<BlossomExtension> {
-    replaceToken("{project.build.version}", project.version)
   }
 
   dependencies {
@@ -40,5 +30,17 @@ subprojects {
     // generation for platform main classes
     "compileOnly"(rootProject.projects.ext.platformInjectSupport.platformInjectApi)
     "annotationProcessor"(rootProject.projects.ext.platformInjectSupport.platformInjectProcessor)
+  }
+
+  tasks.create<Sync>("processSources") {
+    inputs.property("version", project.version)
+    from(sourceSets().getByName("main").java)
+    into(layout.buildDirectory.dir("src"))
+    filter(ReplaceTokens::class, mapOf("tokens" to mapOf("version" to rootProject.version)))
+  }
+
+  tasks.named<JavaCompile>("compileJava") {
+    dependsOn(tasks.getByName("processSources"))
+    source = tasks.getByName("processSources").outputs.files.asFileTree
   }
 }

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/BukkitChatPlugin.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/BukkitChatPlugin.java
@@ -38,7 +38,7 @@ import org.bukkit.plugin.java.JavaPlugin;
   name = "CloudNet-Chat",
   authors = "CloudNetService",
   pluginFileNames = "plugin.yml",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Brings chat prefixes and colored message support to all server platforms",
   dependencies = @Dependency(name = "CloudNet-CloudPerms")
 )

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/MinestomChatExtension.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/MinestomChatExtension.java
@@ -40,7 +40,7 @@ import net.minestom.server.extensions.Extension;
   platform = "minestom",
   name = "CloudNet-Chat",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   dependencies = @Dependency(name = "CloudNet-CloudPerms")
 )
 public class MinestomChatExtension implements PlatformEntrypoint {

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/NukkitChatPlugin.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/NukkitChatPlugin.java
@@ -37,7 +37,7 @@ import lombok.NonNull;
   platform = "nukkit",
   name = "CloudNet-Chat",
   authors = "CloudNetService",
-  version = "{project.build.version}",
+  version = "@version@",
   description = "Brings chat prefixes and colored message support to all server platforms",
   dependencies = @Dependency(name = "CloudNet-CloudPerms")
 )

--- a/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/SpongeChatPlugin.java
+++ b/plugins/chat/src/main/java/eu/cloudnetservice/plugins/chat/SpongeChatPlugin.java
@@ -58,13 +58,13 @@ import org.spongepowered.plugin.ResourceQueryable;
 @PlatformPlugin(
   platform = "sponge",
   name = "CloudNet-Chat",
-  version = "{project.build.version}",
+  version = "@version@",
   authors = "CloudNetService",
   homepage = "https://cloudnetservice.eu",
   description = "Brings chat prefixes and colored message support to all server platforms",
   dependencies = {
     @Dependency(name = "spongeapi", version = "8.0.0"),
-    @Dependency(name = "CloudNet-CloudPerms", version = "{project.build.version}")
+    @Dependency(name = "CloudNet-CloudPerms", version = "@version@")
   }
 )
 public class SpongeChatPlugin implements PlatformEntrypoint {

--- a/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
+++ b/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
@@ -51,7 +51,7 @@ public class CloudNetPapiExpansion extends PlaceholderExpansion {
 
   @Override
   public @NonNull String getVersion() {
-    return "{project.build.version}";
+    return "@version@";
   }
 
   @Override

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/bukkit/BukkitSimpleNameTagsPlugin.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/bukkit/BukkitSimpleNameTagsPlugin.java
@@ -39,7 +39,7 @@ import org.bukkit.scheduler.BukkitScheduler;
   authors = "CloudNetService",
   pluginFileNames = "plugin.yml",
   name = "CloudNet-SimpleNameTags",
-  version = "{project.build.version}",
+  version = "@version@",
   dependencies = @Dependency(name = "CloudNet-CloudPerms"),
   description = "Adds prefix, suffix and display name support to all server platforms"
 )

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/minestom/MinestomSimpleNameTagsExtension.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/minestom/MinestomSimpleNameTagsExtension.java
@@ -37,7 +37,7 @@ import net.minestom.server.scoreboard.TeamManager;
 @PlatformPlugin(
   platform = "minestom",
   name = "CloudNet-SimpleNameTags",
-  version = "{project.build.version}",
+  version = "@version@",
   authors = "CloudNetService",
   dependencies = @Dependency(name = "CloudNet-CloudPerms")
 )

--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/sponge/SpongeSimpleNameTagsPlugin.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/sponge/SpongeSimpleNameTagsPlugin.java
@@ -38,13 +38,13 @@ import org.spongepowered.plugin.PluginContainer;
 @PlatformPlugin(
   platform = "sponge",
   name = "CloudNet-SimpleNameTags",
-  version = "{project.build.version}",
+  version = "@version@",
   authors = "CloudNetService",
   homepage = "https://cloudnetservice.eu",
   description = "Adds prefix, suffix and display name support to all server platforms",
   dependencies = {
     @Dependency(name = "spongeapi", version = "8.0.0"),
-    @Dependency(name = "CloudNet-CloudPerms", version = "{project.build.version}")
+    @Dependency(name = "CloudNet-CloudPerms", version = "@version@")
   }
 )
 public final class SpongeSimpleNameTagsPlugin implements PlatformEntrypoint {


### PR DESCRIPTION
### Motivation
Gradle released a new version (8.4) recently and we should update.

### Modification
Update Gradle to 8.4. There were some other changes that needed to be done as well for this:
1. I had to replace blossom with a custom task due to the missing gradle 8 support in v1 and v2 only using template files
2. The `Project.buildDir` method is deprecated and must be replaced with `Project.layout.buildDirectory`
3. Dynamically loading the junit launcher via gradle is now deprecated, therefore we need to add the junit launcher dependency ourself

### Result
We can now fully use Gradle 8.4 without any deprecations (at least none that we can resolve).

##### Other context
Closes #1267
