### PR TITLE
feat: support the adventure format in npc armorstand names

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -19,6 +19,7 @@ package eu.cloudnetservice.modules.npc.platform.bukkit.entity;
 import dev.derklaro.reflexion.MethodAccessor;
 import dev.derklaro.reflexion.Reflexion;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
+import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.BridgeDocProperties;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
 import eu.cloudnetservice.modules.bridge.player.PlayerManager;
@@ -556,7 +557,7 @@ public abstract class BukkitPlatformSelectorEntity
         .replace("%max_players%", maxPlayers).replace("%m_p%", maxPlayers)
         .replace("%online_servers%", onlineServers).replace("%o_s%", onlineServers);
       // set the custom name of the armor stand
-      this.armorStand.setCustomName(newInfoLine);
+      this.armorStand.setCustomName(ComponentFormats.ADVENTURE_TO_BUNGEE.convertText(newInfoLine));
     }
   }
 }


### PR DESCRIPTION
### Motivation
We are supporting adventure and bungeecord color formatting at most places. Do the same for the armorstands of npcs.

### Modification
Translated the adventure color format back to bungeecord to support the format in the name of armorstands.

### Result
Adventure is supported for armorstands of npcs.

##### Other context
Fixes #1311
