### PR TITLE
fix: start service when exactly the max memory is used

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/service/defaults/AbstractService.java
@@ -662,7 +662,7 @@ public abstract class AbstractService implements CloudService {
     // check jvm heap size
     if (this.cloudServiceManager.currentUsedHeapMemory()
       + this.serviceConfiguration().processConfig().maxHeapMemorySize()
-      >= this.configuration.maxMemory()) {
+      > this.configuration.maxMemory()) {
       // schedule a retry
       if (this.configuration.runBlockedServiceStartTryLaterAutomatic()) {
         this.mainThread.runTask(this::start);


### PR DESCRIPTION
### Motivation
When having two services that require `1024`mb each and a node with a memory limit of `2048`mb the node would start only one of the two services.

### Modification
Modified the memory check in that way that using 100% of the memory is still okay.

### Result
In the example from above both services are started (how they are supposed to)