### PR TITLE
feat: implement Externalizable for Document

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/document/Document.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/document/Document.java
@@ -22,8 +22,8 @@ import eu.cloudnetservice.driver.document.send.DocumentSend;
 import eu.cloudnetservice.driver.document.send.element.Element;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import io.leangen.geantyref.TypeToken;
+import java.io.Externalizable;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -88,7 +88,7 @@ import org.jetbrains.annotations.Unmodifiable;
  *
  * @since 4.0
  */
-public interface Document extends DocPropertyHolder, Serializable {
+public interface Document extends DocPropertyHolder, Externalizable {
 
   /**
    * Get the jvm static implementation of an empty document. The returned document does not take any writes into account

--- a/driver/src/main/java/eu/cloudnetservice/driver/document/empty/EmptyDocument.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/document/empty/EmptyDocument.java
@@ -23,12 +23,15 @@ import eu.cloudnetservice.driver.document.send.DocumentSend;
 import eu.cloudnetservice.driver.document.send.element.Element;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import io.leangen.geantyref.TypeToken;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.io.OutputStream;
 import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Set;
 import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 import org.jetbrains.annotations.Unmodifiable;
@@ -49,10 +52,11 @@ public final class EmptyDocument implements Document.Mutable, DefaultedDocProper
   public static final Document.Mutable INSTANCE = new EmptyDocument();
 
   /**
-   * Constructs an empty document instance. This constructor is sealed to prevent accidental instantiations. Obtain the
-   * singleton instance of this implementation via {@link Document#emptyDocument()}.
+   * Constructs an empty document instance. This constructor is public to all serialization of this document and should
+   * not be called. Obtain the singleton instance of this implementation via {@link Document#emptyDocument()}.
    */
-  private EmptyDocument() {
+  @ApiStatus.Internal
+  public EmptyDocument() {
   }
 
   /**
@@ -401,5 +405,19 @@ public final class EmptyDocument implements Document.Mutable, DefaultedDocProper
   @Override
   public @NonNull String toString() {
     return "[empty]";
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void writeExternal(@NonNull ObjectOutput out) {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void readExternal(@NonNull ObjectInput in) {
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/document/gson/ImmutableGsonDocument.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/document/gson/ImmutableGsonDocument.java
@@ -36,8 +36,8 @@ import eu.cloudnetservice.driver.document.send.element.Element;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import io.leangen.geantyref.TypeToken;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Serial;
@@ -459,29 +459,18 @@ class ImmutableGsonDocument implements Document, DefaultedDocPropertyHolder {
   }
 
   /**
-   * Writes this document in a compact way to the given output stream. This method is part of the java serialisation
-   * api.
-   *
-   * @param out the target stream to write the content of this document to.
-   * @throws IOException                    if an i/o error occurs while writing the content.
-   * @throws DocumentSerialisationException if an exception occurs serialising the document.
+   * {@inheritDoc}
    */
-  @Serial
-  private void writeObject(@NonNull ObjectOutputStream out) throws IOException {
+  @Override
+  public void writeExternal(@NonNull ObjectOutput out) throws IOException {
     out.writeUTF(this.serializeToString(StandardSerialisationStyle.COMPACT));
   }
 
   /**
-   * Reads a json object from the given stream and copies all it's members into this document. This method does not take
-   * into account whether a key of the deserialized object is already present in this document. This method is part of
-   * the java serialisation api.
-   *
-   * @param in the stream to read the json content from.
-   * @throws IOException              if an i/o error occurs while reading the document content.
-   * @throws IllegalArgumentException if the decoded json element from the stream is not a json object.
+   * {@inheritDoc}
    */
-  @Serial
-  private void readObject(@NonNull ObjectInputStream in) throws IOException {
+  @Override
+  public void readExternal(@NonNull ObjectInput in) throws IOException {
     var parsedDocument = JsonParser.parseString(in.readUTF());
     Preconditions.checkArgument(parsedDocument.isJsonObject(), "Input is not a json object");
 

--- a/driver/src/main/java/eu/cloudnetservice/driver/document/gson/MutableGsonDocument.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/document/gson/MutableGsonDocument.java
@@ -16,20 +16,12 @@
 
 package eu.cloudnetservice.driver.document.gson;
 
-import com.google.common.base.Preconditions;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import eu.cloudnetservice.driver.document.Document;
-import eu.cloudnetservice.driver.document.DocumentSerialisationException;
-import eu.cloudnetservice.driver.document.StandardSerialisationStyle;
 import eu.cloudnetservice.driver.document.gson.send.GsonRootObjectVisitor;
 import eu.cloudnetservice.driver.document.property.DefaultedDocPropertyHolder;
 import eu.cloudnetservice.driver.document.send.DocumentSend;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serial;
 import java.util.Set;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,9 +34,6 @@ import org.jetbrains.annotations.Nullable;
 final class MutableGsonDocument
   extends ImmutableGsonDocument
   implements Document.Mutable, DefaultedDocPropertyHolder.Mutable<Document.Mutable> {
-
-  @Serial
-  private static final long serialVersionUID = 4248891600084741117L;
 
   /**
    * Constructs a new, empty gson document instance.
@@ -195,39 +184,5 @@ final class MutableGsonDocument
   @Override
   public @NonNull Document.Mutable propertyHolder() {
     return this;
-  }
-
-  /**
-   * Writes this document in a compact way to the given output stream. This method is part of the java serialisation
-   * api.
-   *
-   * @param out the target stream to write the content of this document to.
-   * @throws IOException                    if an i/o error occurs while writing the content.
-   * @throws DocumentSerialisationException if an exception occurs serialising the document.
-   */
-  @Serial
-  private void writeObject(@NonNull ObjectOutputStream out) throws IOException {
-    out.writeUTF(this.serializeToString(StandardSerialisationStyle.COMPACT));
-  }
-
-  /**
-   * Reads a json object from the given stream and copies all it's members into this document. This method does not take
-   * into account whether a key of the deserialized object is already present in this document. This method is part of
-   * the java serialisation api.
-   *
-   * @param in the stream to read the json content from.
-   * @throws IOException              if an i/o error occurs while reading the document content.
-   * @throws IllegalArgumentException if the decoded json element from the stream is not a json object.
-   */
-  @Serial
-  private void readObject(@NonNull ObjectInputStream in) throws IOException {
-    var parsedDocument = JsonParser.parseString(in.readUTF());
-    Preconditions.checkArgument(parsedDocument.isJsonObject(), "Input is not a json object");
-
-    // put all elements of the parsed object into the internal object
-    var object = parsedDocument.getAsJsonObject();
-    for (var entry : object.entrySet()) {
-      this.internalObject.add(entry.getKey(), entry.getValue());
-    }
   }
 }


### PR DESCRIPTION
### Motivation
Externalizable provides a clear api that has to be implemented in order to make an implementation of Document serializable and reduces the risk to fall back to the default jvm behaviour to serialize a document instance.

### Modification
Implement Externalizable (which implements Serializable) and implement its api methods. The old serial methods to read and write the object were removed in favor of the new api. A test was also added to ensure the correctness of the implementation.

### Result
The document api is less error-prone to serialization issues for future (or user custom) implementations.
