### PR TITLE
fix: tablist order

### DIFF
--- a/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/SimpleNameTagsManager.java
+++ b/plugins/simplenametags/src/main/java/eu/cloudnetservice/plugins/simplenametags/SimpleNameTagsManager.java
@@ -146,7 +146,7 @@ public abstract class SimpleNameTagsManager<P> {
     var teamName = String.format(
       TEAM_NAME_FORMAT,
       highestSortIdLength == sortIdLength
-        ? sortIdLength
+        ? group.sortId()
         : String.format("%0" + highestSortIdLength + "d", group.sortId()),
       group.name());
     // shorten the name if needed


### PR DESCRIPTION
### Motivation
The Tablist wasn't in the expected order. And i wanted to know why.

### Modification
use the sortID to prefix the teamName and not the length of the sortid

### Result
The Tablist is in the expected order according to the sortId
