### PR TITLE
fix: ensure that npcs are removed correctly

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 CloudNetService team & contributors
+ * Copyright 2019-2024 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,6 +201,10 @@ public abstract class PlatformNPCManagement<L, P, M, I, S> extends AbstractNPCMa
         }
       }
     });
+  }
+
+  public void close() {
+    this.trackedEntities.values().forEach(PlatformSelectorEntity::remove);
   }
 
   public @Nullable NPCConfigurationEntry applicableNPCConfigurationEntry() {

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
@@ -203,7 +203,7 @@ public abstract class PlatformNPCManagement<L, P, M, I, S> extends AbstractNPCMa
     });
   }
 
-  public void close() {
+  public void removeSpawnedEntities() {
     this.trackedEntities.values().forEach(PlatformSelectorEntity::remove);
   }
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
@@ -94,7 +94,7 @@ public final class BukkitNPCPlugin implements PlatformEntrypoint {
 
   @Override
   public void onDisable() {
-    this.npcManagement.close();
+    this.npcManagement.removeSpawnedEntities();
     this.moduleHelper.unregisterAll(this.getClass().getClassLoader());
   }
 }

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-2023 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/BukkitNPCPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 CloudNetService team & contributors
+ * Copyright 2019-2024 CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,19 +55,18 @@ import org.bukkit.plugin.java.JavaPlugin;
 public final class BukkitNPCPlugin implements PlatformEntrypoint {
 
   private final ModuleHelper moduleHelper;
+  private final BukkitPlatformNPCManagement npcManagement;
 
   @Inject
-  public BukkitNPCPlugin(@NonNull ModuleHelper moduleHelper) {
+  public BukkitNPCPlugin(@NonNull ModuleHelper moduleHelper, @NonNull BukkitPlatformNPCManagement npcManagement) {
     this.moduleHelper = moduleHelper;
+    this.npcManagement = npcManagement;
   }
 
   @Inject
-  private void registerNPCManagement(
-    @NonNull ServiceRegistry serviceRegistry,
-    @NonNull BukkitPlatformNPCManagement npcManagement
-  ) {
-    npcManagement.registerToServiceRegistry(serviceRegistry);
-    npcManagement.initialize();
+  private void registerNPCManagement(@NonNull ServiceRegistry serviceRegistry) {
+    this.npcManagement.registerToServiceRegistry(serviceRegistry);
+    this.npcManagement.initialize();
   }
 
   @Inject
@@ -95,6 +94,7 @@ public final class BukkitNPCPlugin implements PlatformEntrypoint {
 
   @Override
   public void onDisable() {
+    this.npcManagement.close();
     this.moduleHelper.unregisterAll(this.getClass().getClassLoader());
   }
 }


### PR DESCRIPTION
### Motivation
When creating a npc on a service created from a static task, the infolines (and for entity npcs even the entity itself) are saved to the disk. After restarting the service the entity and info lines are duplicated because the plugin respawns them (as it should) but there are still the old ones from the disk.

### Modification
Added a new close method to the PlatformNPCManagement. By default it removes all tracked entities (thus all info lines are removed too). The new method is called on plugin disable.

### Result
No duplicates.

##### Other context
Fixes #1348
