### PR TITLE
feat: ignore non-existent worlds when choosing a free sign

### DIFF
--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import lombok.NonNull;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -190,10 +191,18 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
       .target(ChannelMessageTarget.Type.NODE, this.wrapperConfig.serviceConfiguration().serviceId().nodeUniqueId());
   }
 
-  public int removeMissingSigns() {
+  public int removeAllMissingSigns() {
+    return this.removeMissingSigns(sign -> true);
+  }
+
+  public int removeMissingSigns(@NonNull String world) {
+    return this.removeMissingSigns(sign -> sign.base().location().world().equalsIgnoreCase(world));
+  }
+
+  public int removeMissingSigns(@NonNull Function<PlatformSign<P, C>, Boolean> filter) {
     var removed = 0;
     for (var sign : this.platformSigns.values()) {
-      if (!sign.exists()) {
+      if (filter.apply(sign) && !sign.exists()) {
         this.deleteSign(sign.base());
         removed++;
       }
@@ -381,6 +390,10 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
     try {
       PlatformSign<P, C> bestChoice = null;
       for (var platformSign : this.platformSigns.values()) {
+        if (!platformSign.exists()) {
+          continue;
+        }
+
         var sign = platformSign.base();
         if (snapshot.configuration().groups().contains(sign.targetGroup())
           && (sign.templatePath() == null || this.checkTemplatePath(snapshot, sign))) {

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
@@ -50,7 +50,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Function;
+import java.util.function.Predicate;
 import lombok.NonNull;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -199,10 +199,10 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
     return this.removeMissingSigns(sign -> sign.base().location().world().equalsIgnoreCase(world));
   }
 
-  public int removeMissingSigns(@NonNull Function<PlatformSign<P, C>, Boolean> filter) {
+  public int removeMissingSigns(@NonNull Predicate<PlatformSign<P, C>> filter) {
     var removed = 0;
     for (var sign : this.platformSigns.values()) {
-      if (filter.apply(sign) && !sign.exists()) {
+      if (filter.test(sign) && !sign.exists()) {
         this.deleteSign(sign.base());
         removed++;
       }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/functionality/SignsCommand.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/functionality/SignsCommand.java
@@ -89,9 +89,18 @@ public class SignsCommand extends BaseTabExecutor {
       }
 
       return true;
-    } else if (args.length == 1 && args[0].equalsIgnoreCase("cleanup")) {
+    } else if (args.length == 1 && args[0].equalsIgnoreCase("cleanupall")) {
       // removes all signs on which location is not a sign anymore
-      var removed = this.signManagement.removeMissingSigns();
+      var removed = this.signManagement.removeAllMissingSigns();
+      SignsConfiguration.sendMessage(
+        "command-cloudsign-cleanup-success",
+        player::sendMessage,
+        m -> m.replace("%amount%", Integer.toString(removed)));
+      return true;
+    } else if ((args.length == 1 || args.length == 2) && args[0].equalsIgnoreCase("cleanup")) {
+      var world = args.length == 2 ? args[1] : player.getWorld().getName();
+      // removes all signs on which location is not a sign anymore
+      var removed = this.signManagement.removeMissingSigns(world);
       SignsConfiguration.sendMessage(
         "command-cloudsign-cleanup-success",
         player::sendMessage,
@@ -134,7 +143,8 @@ public class SignsCommand extends BaseTabExecutor {
     sender.sendMessage("§7/cloudsigns create <targetGroup> [templatePath]");
     sender.sendMessage("§7/cloudsigns remove");
     sender.sendMessage("§7/cloudsigns removeAll");
-    sender.sendMessage("§7/cloudsigns cleanup");
+    sender.sendMessage("§7/cloudsigns cleanup [world]");
+    sender.sendMessage("§7/cloudsigns cleanupAll");
     return true;
   }
 

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/functionality/SignsCommand.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/functionality/SignsCommand.java
@@ -77,8 +77,14 @@ public class SignsCommand implements CommandExecutor {
       }
 
       return true;
-    } else if (args.length == 1 && args[0].equalsIgnoreCase("cleanup")) {
-      var removed = this.signManagement.removeMissingSigns();
+    } else if (args.length == 1 && args[0].equalsIgnoreCase("cleanupall")) {
+      var removed = this.signManagement.removeAllMissingSigns();
+      SignsConfiguration.sendMessage("command-cloudsign-cleanup-success", player::sendMessage,
+        m -> m.replace("%amount%", Integer.toString(removed)));
+      return true;
+    } else if ((args.length == 1 || args.length == 2) && args[0].equalsIgnoreCase("cleanup")) {
+      var world = args.length == 2 ? args[1] : player.getLocation().getLevel().getName();
+      var removed = this.signManagement.removeMissingSigns(world);
       SignsConfiguration.sendMessage("command-cloudsign-cleanup-success", player::sendMessage,
         m -> m.replace("%amount%", Integer.toString(removed)));
       return true;
@@ -109,7 +115,8 @@ public class SignsCommand implements CommandExecutor {
     sender.sendMessage("§7/cloudsigns create <targetGroup> [templatePath]");
     sender.sendMessage("§7/cloudsigns remove");
     sender.sendMessage("§7/cloudsigns removeAll");
-    sender.sendMessage("§7/cloudsigns cleanup");
+    sender.sendMessage("§7/cloudsigns cleanup [world]");
+    sender.sendMessage("§7/cloudsigns cleanupAll");
 
     return true;
   }

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/functionality/SignsCommand.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/sponge/functionality/SignsCommand.java
@@ -40,6 +40,7 @@ public class SignsCommand implements CommandExecutor {
   public static final Parameter.Key<String> ACTION = Parameter.key("action", String.class);
   public static final Parameter.Key<String> TARGET_GROUP = Parameter.key("target_group", String.class);
   public static final Parameter.Key<String> TARGET_TEMPLATE = Parameter.key("target_template_path", String.class);
+  public static final Parameter.Key<String> WORLD = Parameter.key("world", String.class);
 
   protected final Supplier<SpongeSignManagement> signManagement;
 
@@ -66,6 +67,7 @@ public class SignsCommand implements CommandExecutor {
     var type = context.one(ACTION).orElse(null);
     var targetGroup = context.one(TARGET_GROUP).orElse(null);
     var targetTemplatePath = context.one(TARGET_TEMPLATE).orElse(null);
+    var world = context.one(WORLD).orElse(player.world().properties().name());
 
     if (type != null) {
       if (type.equalsIgnoreCase("create") && targetGroup != null) {
@@ -93,8 +95,15 @@ public class SignsCommand implements CommandExecutor {
         }
 
         return CommandResult.success();
+      } else if (type.equalsIgnoreCase("cleanupall")) {
+        var removed = this.signManagement.get().removeAllMissingSigns();
+        SignsConfiguration.sendMessage(
+          "command-cloudsign-cleanup-success",
+          m -> player.sendMessage(Component.text(m)),
+          m -> m.replace("%amount%", Integer.toString(removed)));
+        return CommandResult.success();
       } else if (type.equalsIgnoreCase("cleanup")) {
-        var removed = this.signManagement.get().removeMissingSigns();
+        var removed = this.signManagement.get().removeMissingSigns(world);
         SignsConfiguration.sendMessage(
           "command-cloudsign-cleanup-success",
           m -> player.sendMessage(Component.text(m)),
@@ -133,7 +142,8 @@ public class SignsCommand implements CommandExecutor {
     context.sendMessage(Identity.nil(), Component.text("§7/cloudsigns create <targetGroup> [templatePath]"));
     context.sendMessage(Identity.nil(), Component.text("§7/cloudsigns remove"));
     context.sendMessage(Identity.nil(), Component.text("§7/cloudsigns removeAll"));
-    context.sendMessage(Identity.nil(), Component.text("§7/cloudsigns cleanup"));
+    context.sendMessage(Identity.nil(), Component.text("§7/cloudsigns cleanup [world]"));
+    context.sendMessage(Identity.nil(), Component.text("§7/cloudsigns cleanupAll"));
 
     return CommandResult.success();
   }


### PR DESCRIPTION
### Motivation
If multiple tasks are in the same group and the tasks use different world names, it is possible that the CloudSigns module selects signs that do not exist, therefore the services are never displayed. This PR ignores all signs that do not exist on the server.

### Modification
Signs in unknown worlds are skipped.
Another "cleanupall" option has been added to the cloud signs command, which behaves like the old "cleanup".
The old "cleanup" option has been extended by an additional optional argument "world", which specifies the world in which the cleanup should take place.

### Result
Only characters in existing worlds are considered.

##### Other context
https://discord.com/channels/325362837184577536/818777626663321671/1215677639709425756