### PR TITLE
fix: make the player kick command reason quoted to allow flags

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/command/PlayersCommand.java
@@ -22,6 +22,7 @@ import cloud.commandframework.annotations.CommandPermission;
 import cloud.commandframework.annotations.Flag;
 import cloud.commandframework.annotations.parsers.Parser;
 import cloud.commandframework.annotations.specifier.Greedy;
+import cloud.commandframework.annotations.specifier.Quoted;
 import cloud.commandframework.annotations.suggestions.Suggestions;
 import cloud.commandframework.context.CommandContext;
 import eu.cloudnetservice.common.Named;
@@ -217,7 +218,7 @@ public class PlayersCommand {
   public void kickPlayer(
     @NonNull CommandSource source,
     @NonNull @Argument("player") CloudPlayer player,
-    @Nullable @Greedy @Argument("reason") String reason,
+    @Nullable @Quoted @Argument("reason") String reason,
     @Flag("force") boolean force
   ) {
     var reasonComponent = reason == null


### PR DESCRIPTION
### Motivation
Cloud does not parse flags provided after a greedy string argument. This results in the --force flag of the players kick command being useless.

### Modification
The reason for the kick is now provided as quoted string and the flag is parsed correctly.

### Result
The force kick flag is usable.
