### PR TITLE
build: ensure :processResources runs before :compileJava

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,6 +148,10 @@ subprojects {
     applyDefaultJavadocOptions(options)
   }
 
+  tasks.withType<JavaCompile> {
+    dependsOn(tasks.withType<ProcessResources>())
+  }
+
   // all these projects are publishing their java artifacts
   configurePublishing("java", true)
 }


### PR DESCRIPTION
### Motivation
There are some build steps that require resources to be present at compile time. Due to some Gradle magic, the `processResources` task is not always executed before `compileJava`, which leads to failures when f. ex. generating plugin manifests with our annotation processing.

### Modification
Require the `processResources` task to run before `compileJava` by adding a dependency.

### Result
`processResources` now runs before `compileJava` again, fixing all issues with plugin manifest generation during compile.
