### PR TITLE
fix: tasks setup does not allow skipping proxy fallback settings

### DIFF
--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/NodeSetupListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/NodeSetupListener.java
@@ -63,7 +63,7 @@ public final class NodeSetupListener {
   public void handleSetupComplete(@NonNull SetupCompleteEvent event, @NonNull BridgeManagement bridgeManagement) {
     String fallbackName = event.setup().result("generateBridgeFallback");
     // check if we want to add a fallback
-    if (fallbackName != null && !fallbackName.isEmpty()) {
+    if (fallbackName != null && !fallbackName.isEmpty() && !fallbackName.equalsIgnoreCase("none")) {
       var config = bridgeManagement.configuration();
       config.fallbackConfigurations().add(ProxyFallbackConfiguration.builder()
         .targetGroup(event.setup().result("taskName"))

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/NodeSetupListener.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/node/listener/NodeSetupListener.java
@@ -30,6 +30,8 @@ import eu.cloudnetservice.node.event.setup.SetupInitiateEvent;
 import eu.cloudnetservice.node.version.ServiceVersionProvider;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.Collection;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 
 @Singleton
@@ -80,21 +82,31 @@ public final class NodeSetupListener {
       .translatedQuestion("module-bridge-tasks-setup-default-fallback")
       .answerType(QuestionAnswerType.<String>builder()
         .parser(input -> {
-          // we allow an empty input or an existing task
-          if (!input.isEmpty() && taskProvider.serviceTask(input) == null) {
-            throw Parsers.ParserException.INSTANCE;
+          // either "none" or an existing task
+          if (input.equalsIgnoreCase("none") || taskProvider.serviceTask(input) != null) {
+            return input;
           }
-          return input;
+
+          throw Parsers.ParserException.INSTANCE;
         })
-        .possibleResults(taskProvider.serviceTasks().stream().filter(
-            task -> {
-              var env = versionProvider.environmentType(task.processConfiguration().environment());
-              // only minecraft servers are allowed to be a fallback
-              return env != null && ServiceEnvironmentType.minecraftServer(env);
-            })
-          .map(Named::name)
-          .toList()))
+        .possibleResults(this.possibleFallbackTasks(taskProvider, versionProvider)))
       .build();
   }
 
+  private @NonNull Collection<String> possibleFallbackTasks(
+    @NonNull ServiceTaskProvider taskProvider,
+    @NonNull ServiceVersionProvider versionProvider
+  ) {
+    return taskProvider.serviceTasks().stream()
+      .filter(task -> {
+        var env = versionProvider.environmentType(task.processConfiguration().environment());
+        // only minecraft servers are allowed to be a fallback
+        return env != null && ServiceEnvironmentType.minecraftServer(env);
+      })
+      .map(Named::name)
+      .collect(Collectors.collectingAndThen(Collectors.toList(), results -> {
+        results.add("none");
+        return results;
+      }));
+  }
 }

--- a/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
+++ b/node/src/main/java/eu/cloudnetservice/node/console/animation/setup/answer/Parsers.java
@@ -57,7 +57,7 @@ public final class Parsers {
 
   public @NonNull QuestionAnswerType.Parser<String> nonEmptyStr() {
     return input -> {
-      if (input.trim().isEmpty()) {
+      if (input.isEmpty()) {
         throw ParserException.INSTANCE;
       }
       return input;

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -353,7 +353,7 @@ command-version-install-wrong-java=The version {0$version$} is not compatible wi
 #
 module-bridge-command-description=Management for the config of the bridge module
 module-bridge-player-command-description=Management for online and offline cloud players
-module-bridge-tasks-setup-default-fallback=Which fallback task should be used for this proxy? (Leave empty if you don't want to configure it now)
+module-bridge-tasks-setup-default-fallback=Which fallback task should be used for this proxy? (Use none if you don't want to configure it now)
 module-bridge-command-create-entry-success=The bridge configuration entry has been created
 module-bridge-command-entry-already-exists=There already is a configuration entry for this group
 module-bridge-command-players-delete-player=The player {0$name$}#{1$uniqueId$} will be deleted from the database


### PR DESCRIPTION
### Motivation
When using the tasks setup to create a new proxy task the setup asks to provide a default fallback task for the proxy.
Due to a change to our jline handling the question does not allow empty answers anymore.

### Modification
The setup now allows "none" as answer instead of an empty string.

### Result
The setup is working correctly again
