### PR TITLE
chore: use human readable name for dockerized services

### DIFF
--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedService.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedService.java
@@ -208,7 +208,7 @@ public class DockerizedService extends JVMService {
         .withEntrypoint(arguments)
         .withStopSignal("SIGTERM")
         .withExposedPorts(exposedPorts)
-        .withName(this.serviceId().uniqueId().toString())
+        .withName(this.serviceId().name() + "_" + this.serviceId().uniqueId())
         .withWorkingDir(this.serviceDirectory.toAbsolutePath().toString())
         .withHostConfig(HostConfig.newHostConfig()
           .withBinds(binds)


### PR DESCRIPTION
### Motivation
Current docker container names are barely legible on graphical and command line interfaces
![image](https://github.com/CloudNetService/CloudNet/assets/36107150/41f6eaf1-c1e6-412d-98e6-ed4d62bdf4ff)

### Modification
Make the name start with service name, then uuid, e.g. `Lobby-1_9fda2d26-f201-4505-a041-15e73937bc57`

### Result
A easier to manage docker name
