### PR TITLE
feat: ignore unloaded chunks when choosing a free sign

### DIFF
--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
@@ -390,7 +390,7 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
     try {
       PlatformSign<P, C> bestChoice = null;
       for (var platformSign : this.platformSigns.values()) {
-        if (!platformSign.exists()) {
+        if (!platformSign.needsUpdates() || !platformSign.exists()) {
           continue;
         }
 


### PR DESCRIPTION
### Motivation
On some server implementations it may cause issues when accessing a sign asynchronously when the chunk is currently unloaded.

### Modification
Added a check to exclude signs that are in chunks that are not currently loaded.

### Result
Signs in unloaded chunks are skipped until they are loaded.

##### Other context
https://discord.com/channels/325362837184577536/1247920729756799079/1249063736459792395
