### PR TITLE
chore: Increase timeout for process termination

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
+++ b/node/src/main/java/eu/cloudnetservice/node/config/JsonConfiguration.java
@@ -212,7 +212,7 @@ public final class JsonConfiguration implements Configuration {
     if (this.processTerminationTimeoutSeconds <= 0) {
       this.processTerminationTimeoutSeconds = ConfigurationUtil.get(
         "cloudnet.config.processTerminationTimeoutSeconds",
-        5,
+        60,
         Integer::parseInt);
     }
 


### PR DESCRIPTION
### Motivation
Current Java Edition Minecraft servers, especially those that are forks of the vanilla Minecraft server software, take some time to properly stop and save all resources, i.e. worlds, inventories and other state to disk. Prematurely terminating those processes leads to worlds not being saved at all, world corruption due to the interrupted save process and unloadable worlds. In addition this leads to lock files being left that don't belong to any process anymore.

### Modification
Increase the timeout to 60 seconds. This gives servers more time to properly store all files and shutdown whilst still cleaning up servers that may have become stuck whilst shutting down.

### Result
Server processes are now given more time to properly shutdown.

##### Other context
See the discussion in Discord starting from [here](https://discord.com/channels/325362837184577536/818777626663321671/1255228564832260127).
