### PR TITLE
chore: replace deprecated wrapper validation action

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Setup java
         uses: actions/setup-java@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Setup java
         uses: actions/setup-java@v4


### PR DESCRIPTION
### Motivation
The `gradle/wrapper-validation-action` is deprecated and replaced by the new `gradle/actions/wrapper-validation` action.

### Modification
Replaces the old validation action with the new one & bump the version from v2 to v3.

### Result
Using a supported version of the gradle wrapper validation action.

##### Other context
Closes #1393
