### PR TITLE
WorldEdit transformers for 1.8.8 + give more control to transformers (wrapper)

### DIFF
--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEConfigTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEConfigTransformer.java
@@ -27,6 +27,13 @@ public class FAWEConfigTransformer implements ClassTransformer {
   private static final String MN_SET_ACCESSIBLE = "setAccessible";
 
   /**
+   * Constructs a new instance of this transformer, usually done via SPI.
+   */
+  public FAWEConfigTransformer() {
+    // used by SPI
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEConfigTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEConfigTransformer.java
@@ -20,8 +20,15 @@ import eu.cloudnetservice.wrapper.transform.ClassTransformer;
 import java.lang.classfile.ClassTransform;
 import java.lang.classfile.CodeTransform;
 import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
 
-public class FAWEConfigTransformer implements ClassTransformer {
+/**
+ * A transformer implementation that disables the {@code setAccessible} method in the FAWE Config on old FAWE versions.
+ * This is due to the fact that the method uses illegal reflection in the attempt to set a final field which is not
+ * possible anymore on newer java versions.
+ */
+@ApiStatus.Internal
+public final class FAWEConfigTransformer implements ClassTransformer {
 
   private static final String CNI_CONFIG = "com/boydti/fawe/config/Config";
   private static final String MN_SET_ACCESSIBLE = "setAccessible";

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEConfigTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEConfigTransformer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.transform.bukkit;
+
+import eu.cloudnetservice.wrapper.transform.ClassTransformer;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.CodeTransform;
+import lombok.NonNull;
+
+public class FAWEConfigTransformer implements ClassTransformer {
+
+  private static final String CNI_CONFIG = "com/boydti/fawe/config/Config";
+  private static final String MN_SET_ACCESSIBLE = "setAccessible";
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull ClassTransform provideClassTransform() {
+    CodeTransform codeTransform = (builder, _) -> builder.return_();
+    return ClassTransform.transformingMethodBodies(
+      mm -> mm.methodName().equalsString(MN_SET_ACCESSIBLE),
+      codeTransform);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull TransformWillingness classTransformWillingness(@NonNull String internalClassName) {
+    var isFaweConfig = CNI_CONFIG.equals(internalClassName);
+    return isFaweConfig ? TransformWillingness.ACCEPT_ONCE : TransformWillingness.REJECT;
+  }
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEReflectionUtilsTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEReflectionUtilsTransformer.java
@@ -24,8 +24,15 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.reflect.Field;
 import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
 
-public class FAWEReflectionUtilsTransformer implements ClassTransformer {
+/**
+ * A transformer implementation that rewrites the {@code setFailsafeFieldValue} method in the {@code ReflectionUtils}
+ * class on old FAWE versions. This is due to the fact that the method uses illegal reflection in the attempt to set a final field which is
+ * not possible anymore on newer java versions.
+ */
+@ApiStatus.Internal
+public final class FAWEReflectionUtilsTransformer implements ClassTransformer {
 
   private static final String CNI_REFLECTION_UTILS = "com/boydti/fawe/util/ReflectionUtils";
   private static final String MN_SET_FAILSAFE_FIELD_VALUE = "setFailsafeFieldValue";
@@ -44,10 +51,12 @@ public class FAWEReflectionUtilsTransformer implements ClassTransformer {
     // used by SPI
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public @NonNull ClassTransform provideClassTransform() {
-    CodeTransform codeTransform = (builder, e) -> {
-
+    CodeTransform codeTransform = (builder, _) -> {
       // field.setAccessible(true);
       builder.aload(0).iconst_1();
       builder.invokevirtual(CD_FIELD, MN_FIELD_SET_ACCESSIBLE, MTD_SET_ACCESSIBLE);
@@ -64,6 +73,9 @@ public class FAWEReflectionUtilsTransformer implements ClassTransformer {
       codeTransform);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public @NonNull TransformWillingness classTransformWillingness(@NonNull String internalClassName) {
     var isFaweReflectionUtils = internalClassName.equals(CNI_REFLECTION_UTILS);

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEReflectionUtilsTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEReflectionUtilsTransformer.java
@@ -37,6 +37,13 @@ public class FAWEReflectionUtilsTransformer implements ClassTransformer {
   private static final MethodTypeDesc MTD_SET = MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_Object,
     ConstantDescs.CD_Object);
 
+  /**
+   * Constructs a new instance of this transformer, usually done via SPI.
+   */
+  public FAWEReflectionUtilsTransformer() {
+    // used by SPI
+  }
+
   @Override
   public @NonNull ClassTransform provideClassTransform() {
     CodeTransform codeTransform = (builder, e) -> {

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEReflectionUtilsTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEReflectionUtilsTransformer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.transform.bukkit;
+
+import eu.cloudnetservice.wrapper.transform.ClassTransformer;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.CodeTransform;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.reflect.Field;
+import lombok.NonNull;
+
+public class FAWEReflectionUtilsTransformer implements ClassTransformer {
+
+  private static final String CNI_REFLECTION_UTILS = "com/boydti/fawe/util/ReflectionUtils";
+  private static final String MN_SET_FAILSAFE_FIELD_VALUE = "setFailsafeFieldValue";
+  private static final ClassDesc CD_FIELD = ClassDesc.of(Field.class.getName());
+  private static final String MN_FIELD_SET_ACCESSIBLE = "setAccessible";
+  private static final MethodTypeDesc MTD_SET_ACCESSIBLE = MethodTypeDesc.of(ConstantDescs.CD_void,
+    ConstantDescs.CD_boolean);
+  private static final String MN_FIELD_SET = "set";
+  private static final MethodTypeDesc MTD_SET = MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_Object,
+    ConstantDescs.CD_Object);
+
+  @Override
+  public @NonNull ClassTransform provideClassTransform() {
+    CodeTransform codeTransform = (builder, e) -> {
+
+      // field.setAccessible(true);
+      builder.aload(0).iconst_1();
+      builder.invokevirtual(CD_FIELD, MN_FIELD_SET_ACCESSIBLE, MTD_SET_ACCESSIBLE);
+
+      // field.set(instance, value);
+      builder.aload(0).aload(1).aload(2);
+      builder.invokevirtual(CD_FIELD, MN_FIELD_SET, MTD_SET);
+
+      // return;
+      builder.return_();
+    };
+    return ClassTransform.transformingMethodBodies(
+      mm -> mm.methodName().equalsString(MN_SET_FAILSAFE_FIELD_VALUE),
+      codeTransform);
+  }
+
+  @Override
+  public @NonNull TransformWillingness classTransformWillingness(@NonNull String internalClassName) {
+    var isFaweReflectionUtils = internalClassName.equals(CNI_REFLECTION_UTILS);
+    return isFaweReflectionUtils ? TransformWillingness.ACCEPT_ONCE : TransformWillingness.REJECT;
+  }
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEWorldEditDownloadURLTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEWorldEditDownloadURLTransformer.java
@@ -30,6 +30,13 @@ public class FAWEWorldEditDownloadURLTransformer implements ClassTransformer {
   private static final String NEW_DOWNLOAD_URL = "https://mediafilez.forgecdn.net/files/2431/372/worldedit-bukkit-6.1.7.2.jar";
   private static final String CNI_JARS = "com/boydti/fawe/util/Jars";
 
+  /**
+   * Constructs a new instance of this transformer, usually done via SPI.
+   */
+  public FAWEWorldEditDownloadURLTransformer() {
+    // used by SPI
+  }
+
   @Override
   public @NonNull ClassTransform provideClassTransform() {
     CodeTransform codeTransform = (builder, element) -> {

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEWorldEditDownloadURLTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEWorldEditDownloadURLTransformer.java
@@ -19,12 +19,17 @@ package eu.cloudnetservice.wrapper.transform.bukkit;
 import eu.cloudnetservice.wrapper.transform.ClassTransformer;
 import java.lang.classfile.ClassTransform;
 import java.lang.classfile.CodeTransform;
-import java.lang.classfile.Opcode;
 import java.lang.classfile.instruction.ConstantInstruction;
 import java.lang.constant.ConstantDescs;
 import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
 
-public class FAWEWorldEditDownloadURLTransformer implements ClassTransformer {
+/**
+ * A transformer implementation that allows FAWEs automatic downloading of WorldEdit on older versions. The URL has
+ * changed a while ago, this updates the download URL to work again.
+ */
+@ApiStatus.Internal
+public final class FAWEWorldEditDownloadURLTransformer implements ClassTransformer {
 
   private static final String OLD_DOWNLOAD_URL = "https://addons.cursecdn.com/files/2431/372/worldedit-bukkit-6.1.7.2.jar";
   private static final String NEW_DOWNLOAD_URL = "https://mediafilez.forgecdn.net/files/2431/372/worldedit-bukkit-6.1.7.2.jar";
@@ -37,16 +42,17 @@ public class FAWEWorldEditDownloadURLTransformer implements ClassTransformer {
     // used by SPI
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public @NonNull ClassTransform provideClassTransform() {
     CodeTransform codeTransform = (builder, element) -> {
-      if (element instanceof ConstantInstruction.LoadConstantInstruction loadConstant) {
-        if (loadConstant.opcode() == Opcode.LDC) {
-          if (loadConstant.constantValue().equals(OLD_DOWNLOAD_URL)) {
-            builder.ldc(NEW_DOWNLOAD_URL);
-            return;
-          }
-        }
+      if (element instanceof ConstantInstruction.LoadConstantInstruction inst
+        && inst.constantValue() instanceof String string
+        && string.equals(OLD_DOWNLOAD_URL)) {
+        builder.ldc(NEW_DOWNLOAD_URL);
+        return;
       }
       builder.with(element);
     };
@@ -55,6 +61,9 @@ public class FAWEWorldEditDownloadURLTransformer implements ClassTransformer {
       codeTransform);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public @NonNull TransformWillingness classTransformWillingness(@NonNull String internalClassName) {
     var isJars = internalClassName.equals(CNI_JARS);

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEWorldEditDownloadURLTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/FAWEWorldEditDownloadURLTransformer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.transform.bukkit;
+
+import eu.cloudnetservice.wrapper.transform.ClassTransformer;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.CodeTransform;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.instruction.ConstantInstruction;
+import java.lang.constant.ConstantDescs;
+import lombok.NonNull;
+
+public class FAWEWorldEditDownloadURLTransformer implements ClassTransformer {
+
+  private static final String OLD_DOWNLOAD_URL = "https://addons.cursecdn.com/files/2431/372/worldedit-bukkit-6.1.7.2.jar";
+  private static final String NEW_DOWNLOAD_URL = "https://mediafilez.forgecdn.net/files/2431/372/worldedit-bukkit-6.1.7.2.jar";
+  private static final String CNI_JARS = "com/boydti/fawe/util/Jars";
+
+  @Override
+  public @NonNull ClassTransform provideClassTransform() {
+    CodeTransform codeTransform = (builder, element) -> {
+      if (element instanceof ConstantInstruction.LoadConstantInstruction loadConstant) {
+        if (loadConstant.opcode() == Opcode.LDC) {
+          if (loadConstant.constantValue().equals(OLD_DOWNLOAD_URL)) {
+            builder.ldc(NEW_DOWNLOAD_URL);
+            return;
+          }
+        }
+      }
+      builder.with(element);
+    };
+    return ClassTransform.transformingMethodBodies(
+      mm -> mm.methodName().equalsString(ConstantDescs.CLASS_INIT_NAME),
+      codeTransform);
+  }
+
+  @Override
+  public @NonNull TransformWillingness classTransformWillingness(@NonNull String internalClassName) {
+    var isJars = internalClassName.equals(CNI_JARS);
+    return isJars ? TransformWillingness.ACCEPT_ONCE : TransformWillingness.REJECT;
+  }
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/WorldEditJava8DetectorTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/WorldEditJava8DetectorTransformer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.transform.bukkit;
+
+import eu.cloudnetservice.wrapper.transform.ClassTransformer;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.CodeTransform;
+import lombok.NonNull;
+
+public class WorldEditJava8DetectorTransformer implements ClassTransformer {
+
+  private static final String CN_JAVA_8_DETECTOR = "com/sk89q/worldedit/util/Java8Detector";
+  private static final String MN_NOTIFY_IF_NOT_8 = "notifyIfNot8";
+
+  @Override
+  public @NonNull ClassTransform provideClassTransform() {
+    CodeTransform codeTransform = (builder, _) -> builder.return_();
+    return ClassTransform.transformingMethodBodies(
+      mm -> mm.methodName().equalsString(MN_NOTIFY_IF_NOT_8),
+      codeTransform);
+  }
+
+  @Override
+  public @NonNull TransformWillingness classTransformWillingness(@NonNull String internalClassName) {
+    var isJava8Detector = internalClassName.equals(CN_JAVA_8_DETECTOR);
+    return isJava8Detector ? TransformWillingness.ACCEPT_ONCE : TransformWillingness.REJECT;
+  }
+}

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/WorldEditJava8DetectorTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/WorldEditJava8DetectorTransformer.java
@@ -26,6 +26,13 @@ public class WorldEditJava8DetectorTransformer implements ClassTransformer {
   private static final String CN_JAVA_8_DETECTOR = "com/sk89q/worldedit/util/Java8Detector";
   private static final String MN_NOTIFY_IF_NOT_8 = "notifyIfNot8";
 
+  /**
+   * Constructs a new instance of this transformer, usually done via SPI.
+   */
+  public WorldEditJava8DetectorTransformer() {
+    // used by SPI
+  }
+
   @Override
   public @NonNull ClassTransform provideClassTransform() {
     CodeTransform codeTransform = (builder, _) -> builder.return_();

--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/WorldEditJava8DetectorTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/WorldEditJava8DetectorTransformer.java
@@ -20,8 +20,14 @@ import eu.cloudnetservice.wrapper.transform.ClassTransformer;
 import java.lang.classfile.ClassTransform;
 import java.lang.classfile.CodeTransform;
 import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
 
-public class WorldEditJava8DetectorTransformer implements ClassTransformer {
+/**
+ * A transformer implementation that disables warnings produced by WorldEdit on older versions if the java version is
+ * not Java 8.
+ */
+@ApiStatus.Internal
+public final class WorldEditJava8DetectorTransformer implements ClassTransformer {
 
   private static final String CN_JAVA_8_DETECTOR = "com/sk89q/worldedit/util/Java8Detector";
   private static final String MN_NOTIFY_IF_NOT_8 = "notifyIfNot8";
@@ -33,6 +39,9 @@ public class WorldEditJava8DetectorTransformer implements ClassTransformer {
     // used by SPI
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public @NonNull ClassTransform provideClassTransform() {
     CodeTransform codeTransform = (builder, _) -> builder.return_();
@@ -41,6 +50,9 @@ public class WorldEditJava8DetectorTransformer implements ClassTransformer {
       codeTransform);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public @NonNull TransformWillingness classTransformWillingness(@NonNull String internalClassName) {
     var isJava8Detector = internalClassName.equals(CN_JAVA_8_DETECTOR);

--- a/wrapper-jvm/src/main/resources/META-INF/services/eu.cloudnetservice.wrapper.transform.ClassTransformer
+++ b/wrapper-jvm/src/main/resources/META-INF/services/eu.cloudnetservice.wrapper.transform.ClassTransformer
@@ -17,5 +17,9 @@
 eu.cloudnetservice.wrapper.transform.bukkit.BukkitCommodoreTransformer
 eu.cloudnetservice.wrapper.transform.bukkit.BukkitJavaVersionCheckTransformer
 eu.cloudnetservice.wrapper.transform.bukkit.PaperConfigTransformer
+eu.cloudnetservice.wrapper.transform.bukkit.FAWEConfigTransformer
+eu.cloudnetservice.wrapper.transform.bukkit.FAWEReflectionUtilsTransformer
+eu.cloudnetservice.wrapper.transform.bukkit.WorldEditJava8DetectorTransformer
+eu.cloudnetservice.wrapper.transform.bukkit.FAWEWorldEditDownloadURLTransformer
 eu.cloudnetservice.wrapper.transform.minestom.MinestomStopCleanlyTransformer
 eu.cloudnetservice.wrapper.transform.netty.OldEpollDisableTransformer


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
A few servers running bukkit 1.8.8 still use worldedit. Only since the change to modern java on those old versions, worldedit stopped to work. This PR fixes worldedit and FAWE on 1.8.8.
The necessary class transformers also uncovered a problem in the class transformer api. Converting a `ClassNode` back to a `byte[]` was not possible (in some cases), because of `COMPUTE_FRAMES|COMPUTE_MAXS`.

Some might also want to make use of the wrapper transformer API in wrapper modules, so the custom `byte[]` creation might come in handy.
As an example, I have another project that needs transforming of classes, but uses a `byte[]` instead of asm.
The new API allows something like this:
```
@Override
public byte[] toByteArray(ClassNode classNode) {
    var bytes = Transformer.super.toByteArray(classNode);
    return CustomTransformer.transform(bytes);
}
```

### Modification
<!-- Describe the modification you've done to the codebase -->
Added transformers for WorldEdit / FAWE
Added a custom opt-in serializer option for transformers.
Added better logging for transformer failures.

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
FAWE / WorldEdit supported.
Proper handling of transformer errors / soft failure - not doing this causes the JVM to freeze on errors iirc.
Give more control to transformers, without changing their default behaviour.

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
This is something I concocted some ago and kept in my fork, thought this might be of interest.
I did also test worldedit/fawe on 1.20 to make sure this doesn't cause any problems. Didn't notice anything, but as always with transformers, future changes on worldedit (they'd have to do something odd, but still) could cause the transformer to break worldedit functionality.

If the worldedit transformers aren't merged, I'd still love to see the API to give more control to transformers merged, because I use the API changes privately. WorldEdit transformers could be re-added by a wrapper module, but only with the more powerful api.
