### PR TITLE
[ci skip] fix: remove wrong colon on docker image update deactivation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,7 +77,7 @@
     {
       "description": "Disabled because we don't want to pin our versions",
       "matchPackagePrefixes": [
-        "azul/zulu-openjdk:"
+        "azul/zulu-openjdk"
       ],
       "enabled": false
     },


### PR DESCRIPTION
### Motivation
#1427 introduced a new setting to deactivate renovate updates for the zulu docker image, but it included a wrong colon at the end which means that the rule doesn't match.

### Modification
Remove wrong colon to fix the rule.

### Result
The renovate azul docker image deactivation actually works.
