### PR TITLE
chore: add java version constants for java 22-24

### DIFF
--- a/common/src/main/java/eu/cloudnetservice/common/jvm/JavaVersion.java
+++ b/common/src/main/java/eu/cloudnetservice/common/jvm/JavaVersion.java
@@ -92,7 +92,19 @@ public enum JavaVersion {
   /**
    * Java version 21 (LTS).
    */
-  JAVA_21(21, 65D, "Java 21");
+  JAVA_21(21, 65D, "Java 21"),
+  /**
+   * Java version 22.
+   */
+  JAVA_22(22, 66D, "Java 22"),
+  /**
+   * Java version 23.
+   */
+  JAVA_23(23, 67D, "Java 23"),
+  /**
+   * Java version 24.
+   */
+  JAVA_24(24, 68D, "Java 24");
 
   private static final JavaVersion[] JAVA_VERSIONS = resolveActualJavaVersions();
   private static final JavaVersion LATEST_VERSION = JAVA_VERSIONS[JAVA_VERSIONS.length - 1];


### PR DESCRIPTION
### Motivation
New upcoming java versions need new constants in our JavaVersion enum.

### Modification
Add enum constants for Java version 22-24.

### Result
Java version 22-24 have enum constants in our java version enum.
