### PR TITLE
chore: add missing nullability annotations for toString and equals

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/CloudNetVersion.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/CloudNetVersion.java
@@ -105,7 +105,7 @@ public record CloudNetVersion(
    * @return the stringified, human-readable representation of this version.
    */
   @Override
-  public String toString() {
+  public @NonNull String toString() {
     // CloudNet Blizzard 3.5.0-SNAPSHOT
     var toString =
       "CloudNet " + this.versionTitle + ' ' + this.major + '.' + this.minor + '.' + this.patch + '-' + this.versionType;

--- a/driver/src/main/java/eu/cloudnetservice/driver/command/CommandInfo.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/command/CommandInfo.java
@@ -69,7 +69,7 @@ public record CommandInfo(
    * {@inheritDoc}
    */
   @Override
-  public boolean equals(Object other) {
+  public boolean equals(@Nullable Object other) {
     if (this == other) {
       return true;
     }

--- a/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependency.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/module/ModuleDependency.java
@@ -172,7 +172,7 @@ public class ModuleDependency {
    * {@inheritDoc}
    */
   @Override
-  public String toString() {
+  public @NonNull String toString() {
     return this.group + ':' + this.name + ':' + this.version;
   }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceId.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ServiceId.java
@@ -215,7 +215,7 @@ public class ServiceId implements Named {
    * @return a stringified, non-cached version of this service id.
    */
   @Override
-  public String toString() {
+  public @NonNull String toString() {
     return this.name() + ':' + this.uniqueId;
   }
 

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/dependency/Dependency.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/dependency/Dependency.java
@@ -39,7 +39,7 @@ public record Dependency(
   }
 
   @Override
-  public String toString() {
+  public @NonNull String toString() {
     return String.format("%s %s %s%s", this.group, this.name, this.originalVersion, this.classifier());
   }
 }

--- a/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyLoginConfiguration.java
+++ b/modules/syncproxy/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyLoginConfiguration.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 public record SyncProxyLoginConfiguration(
@@ -73,7 +74,7 @@ public record SyncProxyLoginConfiguration(
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }

--- a/node/src/main/java/eu/cloudnetservice/node/command/source/DriverCommandSource.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/source/DriverCommandSource.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * The driver command source represents a message receiving object for the driver api. All messages regarding command
@@ -96,7 +97,7 @@ public class DriverCommandSource implements CommandSource {
    * {@inheritDoc}
    */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }


### PR DESCRIPTION
### Motivation
Consistency with our nullability annotations in the code base.

### Modification
Added `@NonNull` annotations for toString methods and `@Nullable` for equals.

### Result
Consistency with our nullability annotations in the code base.
