### PR TITLE
fix: remove explicit opcode checking for LDC instruction

### DIFF
--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/BukkitJavaVersionCheckTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/bukkit/BukkitJavaVersionCheckTransformer.java
@@ -92,7 +92,6 @@ public final class BukkitJavaVersionCheckTransformer implements ClassTransformer
     @Override
     public void accept(@NonNull CodeBuilder builder, @NonNull CodeElement element) {
       if (element instanceof ConstantInstruction.LoadConstantInstruction inst
-        && inst.opcode() == Opcode.LDC
         && inst.constantValue() instanceof String value) {
         if (value.equals("java.class.version") && this.dropState == DROP_STATE_IDLE) {
           // encountered the call get the java class version for the version check, start dropping all returns


### PR DESCRIPTION
### Motivation
The new class transformer to remove the bukkit java version check contains an explicit opcode checking for a constant load instruction to use LDC. However, sometimes the opcode can be LDC_W which breaks the check and causes the last return statement of the method to removed as well.

### Modification
Remove the explicit opcode checking and only rely on the constant value type that is being loaded to the stack instead.

### Result
The last return statement of the main method is no longer dropped due to a bad opcode instruction check.

##### Other context
Fixes #1449
