### PR TITLE
Add missing @RPCInvocationTarget to WrapperDatabase.java

### DIFF
--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/database/WrapperDatabase.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/database/WrapperDatabase.java
@@ -17,12 +17,14 @@
 package eu.cloudnetservice.wrapper.database;
 
 import eu.cloudnetservice.driver.database.Database;
+import eu.cloudnetservice.driver.network.rpc.annotation.RPCInvocationTarget;
 import lombok.NonNull;
 
 public abstract class WrapperDatabase implements Database {
 
   private final String name;
 
+  @RPCInvocationTarget
   public WrapperDatabase(@NonNull String name) {
     this.name = name;
   }


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
Trying to get an instance of DatabaseProvider on the wrapper causes an error.
```
injectionLayer.instance(DatabaseProvider.class)
...
Caused by: java.lang.IllegalStateException: no target constructor for rpc found in eu.cloudnetservice.wrapper.database.WrapperDatabase
	at eu.cloudnetservice.driver.network.rpc.defaults.generation.RPCImplementationGenerator.resolveBaseConstructorInformation(RPCImplementationGenerator.java:227) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	at eu.cloudnetservice.driver.network.rpc.defaults.generation.RPCImplementationGenerator.generateImplementation(RPCImplementationGenerator.java:119) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	at eu.cloudnetservice.driver.network.rpc.defaults.generation.RPCGenerationCache.getOrGenerateImplementation(RPCGenerationCache.java:108) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	at eu.cloudnetservice.driver.network.rpc.defaults.generation.DefaultRPCImplementationBuilder.generateImplementation(DefaultRPCImplementationBuilder.java:172) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	at eu.cloudnetservice.wrapper.database.WrapperDatabaseProvider.<init>(WrapperDatabaseProvider.java:41) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	at eu.cloudnetservice.driver.network.rpc.defaults.generation.RPCInternalInstanceFactory.constructInstance(RPCInternalInstanceFactory.java:207) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	at eu.cloudnetservice.driver.network.rpc.defaults.generation.DefaultRPCImplementationBuilder$DefaultInstanceAllocator.allocate(DefaultRPCImplementationBuilder.java:313) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	at eu.cloudnetservice.wrapper.inject.RPCFactories.provideDatabaseProvider(RPCFactories.java:140) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	at dev.derklaro.aerogel.internal.util.MethodHandleUtil.invokeMethod(MethodHandleUtil.java:71) ~[aerogel-2.1.0.jar:?]
	at dev.derklaro.aerogel.internal.binding.constructors.FactoryMethodBindingConstructor.lambda$constructProvider$0(FactoryMethodBindingConstructor.java:96) ~[aerogel-2.1.0.jar:?]
	at dev.derklaro.aerogel.internal.provider.FunctionalContextualProvider.get(FunctionalContextualProvider.java:74) ~[aerogel-2.1.0.jar:?]
	at dev.derklaro.aerogel.util.Scopes$SingletonContextualProvider.get(Scopes.java:96) ~[aerogel-2.1.0.jar:?]
	at dev.derklaro.aerogel.internal.context.DefaultInjectionContext.resolveInstance(DefaultInjectionContext.java:388) ~[aerogel-2.1.0.jar:?]
	at dev.derklaro.aerogel.internal.context.util.ContextInstanceResolveHelper.resolveInstanceAndRemoveContext(ContextInstanceResolveHelper.java:95) ~[aerogel-2.1.0.jar:?]
	at dev.derklaro.aerogel.internal.context.util.ContextInstanceResolveHelper.resolveInstance(ContextInstanceResolveHelper.java:79) ~[aerogel-2.1.0.jar:?]
	at dev.derklaro.aerogel.internal.context.util.ContextInstanceResolveHelper.resolveInstance(ContextInstanceResolveHelper.java:63) ~[aerogel-2.1.0.jar:?]
	at dev.derklaro.aerogel.internal.DefaultInjector.instance(DefaultInjector.java:139) ~[aerogel-2.1.0.jar:?]
	at dev.derklaro.aerogel.internal.DefaultInjector.instance(DefaultInjector.java:121) ~[aerogel-2.1.0.jar:?]
	at eu.cloudnetservice.driver.inject.DefaultInjectionLayer.instance(DefaultInjectionLayer.java:58) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	at eu.cloudnetservice.driver.inject.UncloseableInjectionLayer.instance(UncloseableInjectionLayer.java:58) ~[wrapper.jar:4.0.0-RC11-SNAPSHOT-f61834ff]
	... 12 more
```

### Modification
<!-- Describe the modification you've done to the codebase -->
Add @RPCInvocationTarget to WrapperDatabase

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
DatabaseProvider works on wrapper
