### PR TITLE
fix: npc command does not set showfullservices correctly

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/command/NPCCommand.java
@@ -338,7 +338,7 @@ public final class NPCCommand extends BaseTabExecutor {
 
         // if the npc should full services in the inventory
         case "sfs", "showfullservices" ->
-          updatedNpc = NPC.builder(npc).showIngameServices(this.parseBoolean(args[2])).build();
+          updatedNpc = NPC.builder(npc).showFullServices(this.parseBoolean(args[2])).build();
 
         // sets the glowing color
         case "gc", "glowingcolor" -> {


### PR DESCRIPTION
### Motivation
The npc command on the bukkit platform does not set the showfullservices property correctly.

### Modification
Used the correct setter in the npc builder to set showfullservices.

### Result
The property showfullservices is set correctly.