### PR TITLE
fix: prevent blocking operations on the netty event loop

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/NettyUtil.java
@@ -32,9 +32,6 @@ import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.ssl.OpenSsl;
 import io.netty5.handler.ssl.SslProvider;
 import io.netty5.util.ResourceLeakDetector;
-import io.netty5.util.concurrent.Future;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -275,29 +272,6 @@ public final class NettyUtil {
       return 3;
     } else {
       return 4;
-    }
-  }
-
-  /**
-   * Waits for the given future to complete, either returning the same future instance as given (but completed) or
-   * rethrowing all exceptions that occurred during completion. This method throws an IllegalThreadStateException if the
-   * current thread was interrupted during the future computation.
-   *
-   * @param future the future to wait for.
-   * @param <T>    the type of data returned by the future.
-   * @return the same future as given to the method, but completed.
-   * @throws NullPointerException        if the given future is null.
-   * @throws CancellationException       if the computation was cancelled
-   * @throws CompletionException         if the computation threw an exception.
-   * @throws IllegalThreadStateException if the current thread was interrupted during computation.
-   */
-  public static @NonNull <T> Future<T> awaitFuture(@NonNull Future<T> future) {
-    try {
-      // await the future and rethrow exceptions if any occur
-      return future.asStage().sync().future();
-    } catch (InterruptedException exception) {
-      Thread.currentThread().interrupt(); // reset the interrupted state of the thread
-      throw new IllegalThreadStateException();
     }
   }
 

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/client/NettyNetworkClient.java
@@ -27,6 +27,7 @@ import eu.cloudnetservice.driver.network.netty.NettyUtil;
 import eu.cloudnetservice.driver.network.protocol.Packet;
 import eu.cloudnetservice.driver.network.protocol.PacketListenerRegistry;
 import eu.cloudnetservice.driver.network.protocol.defaults.DefaultPacketListenerRegistry;
+import eu.cloudnetservice.driver.network.scheduler.NetworkTaskScheduler;
 import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.channel.ChannelOption;
@@ -67,7 +68,7 @@ public class NettyNetworkClient implements NetworkClient {
   protected final PacketListenerRegistry packetRegistry = new DefaultPacketListenerRegistry();
 
   protected final EventManager eventManager;
-  protected final Executor packetDispatcher;
+  protected final NetworkTaskScheduler packetDispatcher;
   protected final Callable<NetworkChannelHandler> handlerFactory;
 
   /**
@@ -202,6 +203,7 @@ public class NettyNetworkClient implements NetworkClient {
   @Override
   public void close() {
     this.closeChannels();
+    this.packetDispatcher.shutdown();
     this.eventLoopGroup.shutdownGracefully();
   }
 

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
@@ -28,6 +28,7 @@ import eu.cloudnetservice.driver.network.netty.NettyUtil;
 import eu.cloudnetservice.driver.network.protocol.Packet;
 import eu.cloudnetservice.driver.network.protocol.PacketListenerRegistry;
 import eu.cloudnetservice.driver.network.protocol.defaults.DefaultPacketListenerRegistry;
+import eu.cloudnetservice.driver.network.scheduler.NetworkTaskScheduler;
 import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.channel.ChannelOption;
@@ -75,7 +76,7 @@ public class NettyNetworkServer implements NetworkServer {
   protected final PacketListenerRegistry packetRegistry = new DefaultPacketListenerRegistry();
 
   protected final EventManager eventManager;
-  protected final Executor packetDispatcher;
+  protected final NetworkTaskScheduler packetDispatcher;
   protected final Callable<NetworkChannelHandler> handlerFactory;
 
   /**
@@ -236,11 +237,11 @@ public class NettyNetworkServer implements NetworkServer {
   @Override
   public void close() {
     this.closeChannels();
-
     for (var entry : this.channelFutures.values()) {
       entry.cancel();
     }
 
+    this.packetDispatcher.shutdown();
     this.bossEventLoopGroup.shutdownGracefully();
     this.workerEventLoopGroup.shutdownGracefully();
   }

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/netty/server/NettyNetworkServer.java
@@ -293,16 +293,6 @@ public class NettyNetworkServer implements NetworkServer {
    * {@inheritDoc}
    */
   @Override
-  public void sendPacketSync(@NonNull Packet... packets) {
-    for (var channel : this.channels) {
-      channel.sendPacketSync(packets);
-    }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public void closeChannels() {
     var iterator = this.channels.iterator();
     while (iterator.hasNext()) {

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketSender.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketSender.java
@@ -53,17 +53,4 @@ public interface PacketSender {
       this.sendPacket(packet);
     }
   }
-
-  /**
-   * Sends all the given packets to the associated target, waiting for the packet writes to the channel to complete
-   * before resuming the current thread.
-   *
-   * @param packets the packets to send.
-   * @throws NullPointerException if the packets are null.
-   */
-  default void sendPacketSync(@NonNull Packet... packets) {
-    for (var packet : packets) {
-      this.sendPacketSync(packet);
-    }
-  }
 }

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/FallbackRejectionHandler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/FallbackRejectionHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.scheduler;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import lombok.NonNull;
+
+/**
+ * A rejected execution handler that starts the rejected task in the provided fallback executor.
+ *
+ * @param fallbackExecutor the fallback executor to start rejected starts in.
+ * @since 4.0
+ */
+record FallbackRejectionHandler(@NonNull ThreadPoolExecutor fallbackExecutor) implements RejectedExecutionHandler {
+
+  /**
+   * Schedules the given rejected task in the fallback executor.
+   *
+   * @param task              the task requested to be executed.
+   * @param rejectingExecutor the executor that failed to schedule the task.
+   * @throws NullPointerException if the given task or rejecting executor is null.
+   */
+  @Override
+  public void rejectedExecution(@NonNull Runnable task, @NonNull ThreadPoolExecutor rejectingExecutor) {
+    if (!rejectingExecutor.isShutdown() && !this.fallbackExecutor.isShutdown()) {
+      try {
+        this.fallbackExecutor.execute(task);
+      } catch (RejectedExecutionException _) {
+        // ignore this, must be due to a concurrent shutdown call
+      }
+    }
+  }
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/NetworkTaskScheduler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/NetworkTaskScheduler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.scheduler;
+
+import java.util.concurrent.Executor;
+
+/**
+ * A scheduler for tasks that are triggered by incoming network calls and should be handled non-blocking (for execute
+ * invocations) with the lowest latency possible.
+ *
+ * @since 4.0
+ */
+public interface NetworkTaskScheduler extends Executor {
+
+  /**
+   * Triggers a shutdown operation on this scheduler, interrupting all currently running tasks and preventing new tasks
+   * from being scheduled.
+   */
+  void shutdown();
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/ScalingNetworkTaskScheduler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/ScalingNetworkTaskScheduler.java
@@ -37,9 +37,9 @@ import lombok.NonNull;
  */
 public final class ScalingNetworkTaskScheduler implements NetworkTaskScheduler {
 
-  private static final int BASE_QUEUE_TIMEOUT = 500;
-  private static final int MINIMUM_QUEUE_TIMEOUT = 100;
-  private static final double QUEUE_TIMOUT_DECAY_FACTOR = 0.99;
+  private static final int BASE_QUEUE_TIMEOUT = 150;
+  private static final int MINIMUM_QUEUE_TIMEOUT = 50;
+  private static final double QUEUE_TIMOUT_DECAY_FACTOR = 0.95;
 
   private final AtomicBoolean active;
   private final ThreadPoolExecutor coreExecutor;

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/ScalingNetworkTaskScheduler.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/ScalingNetworkTaskScheduler.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.scheduler;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongSupplier;
+import lombok.NonNull;
+
+/**
+ * An implementation of a network task scheduler that slowly starts more threads depending on the count of tasks that
+ * couldn't be scheduled into the core executor service. If more and more tasks are starting to come in and the core
+ * thread pool is not able to keep up, the pace of starting new threads increases. Initially the time between thread
+ * starts is 2.5 seconds, and it can go all the way down to 100ms if needed (starting at around 160 tasks waiting to be
+ * scheduled).
+ *
+ * @since 4.0
+ */
+public final class ScalingNetworkTaskScheduler implements NetworkTaskScheduler {
+
+  private static final int BASE_QUEUE_TIMEOUT = 500;
+  private static final int MINIMUM_QUEUE_TIMEOUT = 100;
+  private static final double QUEUE_TIMOUT_DECAY_FACTOR = 0.99;
+
+  private final AtomicBoolean active;
+  private final ThreadPoolExecutor coreExecutor;
+  private final ThreadPoolExecutor fallbackExecutor;
+  private final TaskSchedulingAction taskScheduler;
+
+  /**
+   * Constructs a new scaling task executor.
+   *
+   * @param threadFactory       the thread factory to use when the underlying executors create new threads.
+   * @param maximumCorePoolSize the maximum threads that the core executor can use.
+   * @throws NullPointerException     if the given thread factory is null.
+   * @throws IllegalArgumentException if the given maximum pool size is smaller than 0.
+   */
+  public ScalingNetworkTaskScheduler(@NonNull ThreadFactory threadFactory, int maximumCorePoolSize) {
+    this.active = new AtomicBoolean(true);
+
+    // use a thread pool with an infinite possible amount of threads as a fallback, but only
+    // keep these threads alive for a few seconds. this only the last-resort executor and shouldn't
+    // have a lot of resources allocated for no reason. note that there is no rejection handler
+    // set, this executor can technically not reject tasks because it can spawn an infinite
+    // amount of threads
+    this.fallbackExecutor = new ThreadPoolExecutor(
+      0,
+      Integer.MAX_VALUE,
+      5L,
+      TimeUnit.SECONDS,
+      new SynchronousQueue<>(),
+      threadFactory);
+
+    // construct the calculator for timeouts when adding tasks into the core executor,
+    // which depends on the count of unscheduled (more unscheduled tasks = smaller timeout)
+    LinkedBlockingQueue<Runnable> unscheduledTaskQueue = new LinkedBlockingQueue<>();
+    LongSupplier timeoutSupplier = () -> {
+      var scheduledTasks = unscheduledTaskQueue.size();
+      var timeout = BASE_QUEUE_TIMEOUT * Math.pow(QUEUE_TIMOUT_DECAY_FACTOR, scheduledTasks);
+      return (long) Math.clamp(timeout, MINIMUM_QUEUE_TIMEOUT, BASE_QUEUE_TIMEOUT);
+    };
+
+    // construct the core executor for incoming packets, which should be used primarily
+    // for scheduling actions. if this scheduler runs out of available threads (for example
+    // if they are all blocked) after a short timeout the tasks are scheduled into a fallback
+    // scheduler which has no size limits and takes over the work to not possibly run into
+    // an issue with too many blocked threads
+    TimedSynchronousQueue<Runnable> workQueue = new TimedSynchronousQueue<>(timeoutSupplier);
+    var fallbackDelegatingRejectionHandler = new FallbackRejectionHandler(this.fallbackExecutor);
+    this.coreExecutor = new ThreadPoolExecutor(
+      maximumCorePoolSize / 2,
+      maximumCorePoolSize,
+      30L,
+      TimeUnit.SECONDS,
+      workQueue,
+      threadFactory,
+      fallbackDelegatingRejectionHandler);
+    workQueue.parentExecutor(this.coreExecutor); // allows the queue to make some optimizations
+
+    // construct and start the actual task scheduling action, uses a virtual
+    // thread here as the action blocks most of the time waiting for tasks
+    // to be executed
+    this.taskScheduler = new TaskSchedulingAction(this.coreExecutor, unscheduledTaskQueue);
+    Thread.ofVirtual().name("NetworkTaskScheduler").start(this.taskScheduler);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void shutdown() {
+    if (this.active.compareAndSet(true, false)) {
+      this.coreExecutor.shutdownNow();
+      this.fallbackExecutor.shutdownNow();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void execute(@NonNull Runnable command) {
+    if (!this.active.get()) {
+      // the underlying scheduler were also shut down, there is no point
+      // in even trying to schedule a new task in them
+      throw new RejectedExecutionException("scheduler was shut down");
+    }
+
+    // scheduling directly into the core executor would be a blocking operation
+    // so we use this "man-in-the-middle" action that does the scheduling into
+    // the core executor without blocking the caller of this method
+    this.taskScheduler.scheduleTask(command);
+  }
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/TaskSchedulingAction.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/TaskSchedulingAction.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.scheduler;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import lombok.NonNull;
+
+/**
+ * The task scheduler runnable that is responsible for scheduling incoming tasks into the target executor service. Due
+ * to the fact that the scheduling action could be blocking, this action should be scheduled in a separate thread.
+ *
+ * @since 4.0
+ */
+final class TaskSchedulingAction implements Runnable {
+
+  private final ThreadPoolExecutor targetExecutor;
+  private final LinkedBlockingQueue<Runnable> unscheduledTasks;
+
+  /**
+   * Constructs a new task scheduling action.
+   *
+   * @param targetExecutor       the executor to execute unscheduled tasks.
+   * @param unscheduledTaskQueue the queue for unscheduled tasks.
+   * @throws NullPointerException if the given target executor or unscheduled task queue is null.
+   */
+  public TaskSchedulingAction(
+    @NonNull ThreadPoolExecutor targetExecutor,
+    @NonNull LinkedBlockingQueue<Runnable> unscheduledTaskQueue
+  ) {
+    this.targetExecutor = targetExecutor;
+    this.unscheduledTasks = unscheduledTaskQueue;
+  }
+
+  /**
+   * Schedules tasks that were added to the unscheduled tasks queue into the target executor. This operation blocks
+   * until a task is available in the tasks queue.
+   */
+  @Override
+  public void run() {
+    while (true) {
+      try {
+        var nextTask = this.unscheduledTasks.take();
+        if (this.targetExecutor.isShutdown()) {
+          // the shutdown call on the target executor might happen
+          // while we're waiting for an unscheduled task to become
+          // available, therefore we need to check after to prevent
+          // scheduling in an executor that was shut down already
+          break;
+        }
+
+        // this call might block for a bit, depending on the queue used by the
+        // target executor (therefore we cannot call it directly on the caller)
+        this.targetExecutor.execute(nextTask);
+      } catch (InterruptedException _) {
+        Thread.currentThread().interrupt(); // reset interrupted state
+        break;
+      } catch (RejectedExecutionException _) {
+        // the executor rejected the execution, this should
+        // usually be handled otherwise... but just to be sure
+        // that this occurrence wouldn't blow up this scheduler
+      }
+    }
+  }
+
+  /**
+   * Schedules the given task for execution.
+   *
+   * @param task the task to execute.
+   * @throws NullPointerException if the given task is null.
+   */
+  public void scheduleTask(@NonNull Runnable task) {
+    this.unscheduledTasks.offer(task);
+  }
+}

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/TimedSynchronousQueue.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/scheduler/TimedSynchronousQueue.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.scheduler;
+
+import com.google.common.base.Preconditions;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import lombok.NonNull;
+
+/**
+ * An implementation of a synchronous queue that always offers tasks to itself with a timeout instead of returning
+ * instantly if that is not possible. The queue also makes some more assumptions when the parent executor service is
+ * provided to achieve the maximum scaling of the parent thread pool.
+ *
+ * @param <E> the type of elements held in this queue
+ * @since 4.0
+ */
+final class TimedSynchronousQueue<E> extends SynchronousQueue<E> {
+
+  private final LongSupplier timeoutSupplier;
+  private ThreadPoolExecutor parentExecutor;
+
+  /**
+   * Constructs a new instance of this queue using the given timeout supplier.
+   *
+   * @param timeoutSupplier the supplier for timeouts used when actually needing to queue elements.
+   * @throws NullPointerException if the given timeout supplier is null.
+   */
+  public TimedSynchronousQueue(@NonNull LongSupplier timeoutSupplier) {
+    super(true); // let waiting threads contend in FIFO order
+    this.timeoutSupplier = timeoutSupplier;
+  }
+
+  /**
+   * Sets the parent thread pool executor that is associated with the queue unless another thread pool executor is
+   * already associated with it.
+   *
+   * @param parentExecutor the parent executor to use for this queue.
+   * @throws NullPointerException  if the given parent executor is null.
+   * @throws IllegalStateException if a parent executor was already set.
+   */
+  public void parentExecutor(@NonNull ThreadPoolExecutor parentExecutor) {
+    Preconditions.checkState(this.parentExecutor == null, "parent executor already set");
+    this.parentExecutor = parentExecutor;
+  }
+
+  /**
+   * Tries to offer the given element into this queue with a timeout provided by the owner of this queue. If the queue
+   * has information about the associated thread pool this method makes some additional considerations to ensure scaling
+   * the thread pool to its maximum capacity first.
+   *
+   * @param element the element to add into this queue.
+   * @return true if the element was added into this queue, false otherwise.
+   * @throws NullPointerException if the given element is null.
+   */
+  @Override
+  public boolean offer(@NonNull E element) {
+    var executor = this.parentExecutor;
+    if (executor != null) {
+      // reject immediately if the parent executor is already shut down, no need to try
+      // to queue it as there won't be any thread to pick up the given task anyway
+      if (executor.isShutdown()) {
+        return false;
+      }
+
+      // check if there are idling threads in the thread pool at the moment. if that is the case
+      // try to enqueue the element for 50ms, which should be more than enough for one of the idling
+      // workers to wake up and poll the task from this queue.
+      // note that the returned active count is an approximation, therefore it could be that there are
+      // no free threads anymore when the actual offer call happens, hence the timeout
+      if (executor.getActiveCount() < executor.getPoolSize()) {
+        var polledByExecutor = this.offerSafe(element, 50);
+        if (polledByExecutor) {
+          return true;
+        }
+      }
+
+      // check if the threads of the executor are already maxed out. TPE prefers to queue
+      // tasks instead of spawning a new thread for them, this basically forces the executor
+      // to go ahead and spawn a new one as we aren't at the maximum pool size yet
+      if (executor.getPoolSize() < executor.getMaximumPoolSize()) {
+        return false;
+      }
+    }
+
+    // either no information is available about the thread pool or the thread pool is completely
+    // busy at the moment. try to queue the task with a timeout, if this doesn't work the task
+    // will be rejected which we can handle somewhere else
+    var offerTimeout = this.timeoutSupplier.getAsLong();
+    return this.offerSafe(element, offerTimeout);
+  }
+
+  /**
+   * Tries to offer the given element into this queue with the given timeout millis.
+   *
+   * @param element       the element to offer into this queue.
+   * @param timeoutMillis the timeout in milliseconds of the offer operation.
+   * @return true if some other thread polled the element within the timeout millis, false otherwise.
+   * @throws NullPointerException if the given element is null.
+   */
+  private boolean offerSafe(@NonNull E element, long timeoutMillis) {
+    try {
+      return super.offer(element, timeoutMillis, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException _) {
+      Thread.currentThread().interrupt(); // reset interrupted state
+      return false;
+    }
+  }
+}

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/netty/NettyUtilTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/netty/NettyUtilTest.java
@@ -21,44 +21,10 @@ import io.netty5.buffer.BufferAllocator;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.handler.ssl.OpenSsl;
 import io.netty5.handler.ssl.SslProvider;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class NettyUtilTest {
-
-  @Test
-  void testPacketDispatcherThreadCount() {
-    {
-      // test node dispatcher
-      var packetDispatcher = NettyUtil.createPacketDispatcher(DriverEnvironment.NODE);
-      var tpe = Assertions.assertInstanceOf(ThreadPoolExecutor.class, packetDispatcher);
-      Assertions.assertEquals(12, tpe.getMaximumPoolSize());
-      Assertions.assertEquals(6, tpe.getCorePoolSize());
-      Assertions.assertEquals(30, tpe.getKeepAliveTime(TimeUnit.SECONDS));
-      Assertions.assertDoesNotThrow(() -> tpe.getRejectedExecutionHandler().rejectedExecution(() -> {
-      }, tpe));
-
-      var dispatchQueue = Assertions.assertInstanceOf(LinkedBlockingQueue.class, tpe.getQueue());
-      Assertions.assertEquals(150, dispatchQueue.remainingCapacity());
-    }
-
-    {
-      // test wrapper dispatcher
-      var packetDispatcher = NettyUtil.createPacketDispatcher(DriverEnvironment.WRAPPER);
-      var tpe = Assertions.assertInstanceOf(ThreadPoolExecutor.class, packetDispatcher);
-      Assertions.assertEquals(4, tpe.getMaximumPoolSize());
-      Assertions.assertEquals(2, tpe.getCorePoolSize());
-      Assertions.assertEquals(30, tpe.getKeepAliveTime(TimeUnit.SECONDS));
-      Assertions.assertDoesNotThrow(() -> tpe.getRejectedExecutionHandler().rejectedExecution(() -> {
-      }, tpe));
-
-      var dispatchQueue = Assertions.assertInstanceOf(LinkedBlockingQueue.class, tpe.getQueue());
-      Assertions.assertEquals(150, dispatchQueue.remainingCapacity());
-    }
-  }
 
   @Test
   void testBossEventLoopGroupCreation() {

--- a/driver/src/test/java/eu/cloudnetservice/driver/network/scheduler/ScalingNetworkTaskSchedulerTest.java
+++ b/driver/src/test/java/eu/cloudnetservice/driver/network/scheduler/ScalingNetworkTaskSchedulerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.network.scheduler;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ScalingNetworkTaskSchedulerTest {
+
+  @Test
+  void testScalingOfSchedulerIfCoreThreadsAreBlocked() throws InterruptedException {
+    var executedTasks = new CountDownLatch(5);
+    var scheduler = new ScalingNetworkTaskScheduler(Executors.defaultThreadFactory(), 2);
+
+    // block the two core threads of the scheduler for an infinite amount of time
+    Runnable blockingAction = () -> {
+      try {
+        Thread.sleep(Long.MAX_VALUE);
+      } catch (InterruptedException _) {
+      }
+    };
+    scheduler.execute(blockingAction);
+    scheduler.execute(blockingAction);
+
+    // schedule more tasks into the thread pool than the wrapped core thread pool
+    // can handle, this triggers the tasks to be put into the fallback scheduler
+    for (var taskId = 0; taskId < 5; taskId++) {
+      scheduler.execute(executedTasks::countDown);
+    }
+
+    var countReachedZero = executedTasks.await(30, TimeUnit.SECONDS);
+    Assertions.assertTrue(countReachedZero);
+  }
+}


### PR DESCRIPTION
### Motivation
Currently it's possible to deadlock the netty event loop, This is caused by the fact that the network task scheduler will now execute packets that cannot be queued (when the queue is full) on the event loop. The user might however call another blocking network operation on the event loop (like sending a query packet) which means that the incoming packets (like a response to the query) cannot be processed and therefore the event loop is deadlocked.

### Modification
The event loop is never used as a fallback to call network operations anymore. Instead, a new second thread pool was added that can add infinite threads in case the network task queue gets fuller and fuller. The threads are started with an initial delay of 150ms which is stadely decreased to 50ms in case the network task queue gets even fuller over time. This is to prevent starting useless threads when just waiting a tiny bit for another thread to finish work would've been suffiecent. Idle threads in the fallback thread pool are removed after 15 seconds of idling.

### Result
The netty event loop doesn't execute blocking operations anymore (which prevents all incoming packets from being handled)

##### Other context
Fixes #1457