### PR TITLE
feat: run bridge post-initialization method at the first server tick

### DIFF
--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitBridgePlugin.java
@@ -64,7 +64,8 @@ public final class BukkitBridgePlugin implements PlatformEntrypoint {
   public void onLoad() {
     // init the bridge management
     this.bridgeManagement.registerServices(this.serviceRegistry);
-    this.bridgeManagement.postInit();
+
+    this.plugin.getServer().getScheduler().runTask(this.plugin, this.bridgeManagement::postInit);
     // register the bukkit listener
     this.pluginManager.registerEvents(this.playerListener, this.plugin);
   }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/mixin/handling/MinecraftServerMixin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/mixin/handling/MinecraftServerMixin.java
@@ -23,6 +23,7 @@ import eu.cloudnetservice.modules.bridge.impl.platform.fabric.util.BridgedServer
 import eu.cloudnetservice.modules.bridge.impl.platform.fabric.util.FabricInjectionHolder;
 import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.NonNull;
@@ -32,6 +33,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -53,6 +55,12 @@ public abstract class MinecraftServerMixin implements BridgedServer {
 
   @Shadow
   public abstract String getMotd();
+
+  @Shadow
+  @Final
+  private List<Runnable> tickables;
+
+  private final Runnable cloudnet_bridge$postInitTickableTask = this::cloudnet_bridge$postInitTickable;
 
   @Inject(
     at = @At(
@@ -76,7 +84,7 @@ public abstract class MinecraftServerMixin implements BridgedServer {
       this.cloudnet_bridge$injectionHolder.serviceProvider(),
       this.cloudnet_bridge$injectionHolder.wrapperConfiguration());
     this.cloudnet_bridge$management.registerServices(this.cloudnet_bridge$injectionHolder.serviceRegistry());
-    this.cloudnet_bridge$management.postInit();
+    this.tickables.add(this.cloudnet_bridge$postInitTickableTask);
   }
 
   @Override
@@ -121,5 +129,11 @@ public abstract class MinecraftServerMixin implements BridgedServer {
   @Override
   public @NonNull FabricInjectionHolder cloudnet_bridge$injectionHolder() {
     return this.cloudnet_bridge$injectionHolder;
+  }
+
+  @Override
+  public void cloudnet_bridge$postInitTickable() {
+    this.cloudnet_bridge$management.postInit();
+    this.tickables.remove(this.cloudnet_bridge$postInitTickableTask);
   }
 }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/util/BridgedServer.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/util/BridgedServer.java
@@ -39,4 +39,6 @@ public interface BridgedServer {
   @NonNull PlatformBridgeManagement<ServerPlayer, NetworkPlayerServerInfo> cloudnet_bridge$management();
 
   @NonNull FabricInjectionHolder cloudnet_bridge$injectionHolder();
+
+  void cloudnet_bridge$postInitTickable();
 }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpBridgePlugin.java
@@ -64,7 +64,8 @@ public final class LimboLoohpBridgePlugin implements PlatformEntrypoint {
   public void onLoad() {
     // init the bridge management
     this.bridgeManagement.registerServices(this.serviceRegistry);
-    this.bridgeManagement.postInit();
+
+    this.plugin.getServer().getScheduler().runTask(this.plugin, this.bridgeManagement::postInit);
     // register the bukkit listener
     this.eventsManager.registerEvents(this.plugin, this.playerListener);
   }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeExtension.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeExtension.java
@@ -26,6 +26,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
+import net.minestom.server.MinecraftServer;
 import net.minestom.server.extras.MojangAuth;
 import net.minestom.server.extras.bungee.BungeeCordProxy;
 import net.minestom.server.extras.velocity.VelocityProxy;
@@ -69,7 +70,8 @@ public final class MinestomBridgeExtension implements PlatformEntrypoint {
   @Override
   public void onLoad() {
     this.bridgeManagement.registerServices(this.serviceRegistry);
-    this.bridgeManagement.postInit();
+
+    MinecraftServer.getSchedulerManager().scheduleNextTick(this.bridgeManagement::postInit);
 
     // force initialize the bungeecord proxy forwarding
     if (!VelocityProxy.isEnabled()) {

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeExtension.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeExtension.java
@@ -26,10 +26,10 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.extras.MojangAuth;
 import net.minestom.server.extras.bungee.BungeeCordProxy;
 import net.minestom.server.extras.velocity.VelocityProxy;
+import net.minestom.server.timer.SchedulerManager;
 import org.slf4j.Logger;
 
 @Singleton
@@ -49,6 +49,7 @@ public final class MinestomBridgeExtension implements PlatformEntrypoint {
   private final Logger logger;
   private final ModuleHelper moduleHelper;
   private final ServiceRegistry serviceRegistry;
+  private final SchedulerManager schedulerManager;
   private final MinestomBridgeManagement bridgeManagement;
 
   @Inject
@@ -56,12 +57,14 @@ public final class MinestomBridgeExtension implements PlatformEntrypoint {
     @NonNull ComponentLogger logger,
     @NonNull ModuleHelper moduleHelper,
     @NonNull ServiceRegistry serviceRegistry,
+    @NonNull SchedulerManager schedulerManager,
     @NonNull MinestomBridgeManagement bridgeManagement,
     @NonNull MinestomPlayerManagementListener playerListener
   ) {
     this.logger = logger;
     this.moduleHelper = moduleHelper;
     this.serviceRegistry = serviceRegistry;
+    this.schedulerManager = schedulerManager;
     this.bridgeManagement = bridgeManagement;
 
     serviceRegistry.discoverServices(MinestomBridgeExtension.class);
@@ -70,8 +73,7 @@ public final class MinestomBridgeExtension implements PlatformEntrypoint {
   @Override
   public void onLoad() {
     this.bridgeManagement.registerServices(this.serviceRegistry);
-
-    MinecraftServer.getSchedulerManager().scheduleNextTick(this.bridgeManagement::postInit);
+    this.schedulerManager.scheduleNextTick(this.bridgeManagement::postInit);
 
     // force initialize the bungeecord proxy forwarding
     if (!VelocityProxy.isEnabled()) {

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitBridgePlugin.java
@@ -67,7 +67,8 @@ public final class NukkitBridgePlugin implements PlatformEntrypoint {
   @Override
   public void onLoad() {
     this.bridgeManagement.registerServices(this.serviceRegistry);
-    this.bridgeManagement.postInit();
+
+    this.plugin.getServer().getScheduler().scheduleTask(this.plugin, this.bridgeManagement::postInit);
     // register the listener
     this.pluginManager.registerEvents(this.playerListener, this.plugin);
   }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeBridgePlugin.java
@@ -24,7 +24,10 @@ import eu.cloudnetservice.ext.platforminject.api.stereotype.Dependency;
 import eu.cloudnetservice.ext.platforminject.api.stereotype.PlatformPlugin;
 import jakarta.inject.Inject;
 import lombok.NonNull;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.EventManager;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.util.Ticks;
 import org.spongepowered.plugin.PluginContainer;
 
 @Singleton
@@ -65,7 +68,12 @@ public final class SpongeBridgePlugin implements PlatformEntrypoint {
   @Override
   public void onLoad() {
     this.bridgeManagement.registerServices(this.serviceRegistry);
-    this.bridgeManagement.postInit();
+    Sponge.server().scheduler().submit(
+      Task.builder()
+        .delay(Ticks.of(1))
+        .plugin(this.plugin)
+        .execute(this.bridgeManagement::postInit)
+        .build());
     // register the listener
     this.eventManager.registerListeners(this.plugin, this.playerListener);
   }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeBridgePlugin.java
@@ -23,9 +23,10 @@ import eu.cloudnetservice.ext.platforminject.api.PlatformEntrypoint;
 import eu.cloudnetservice.ext.platforminject.api.stereotype.Dependency;
 import eu.cloudnetservice.ext.platforminject.api.stereotype.PlatformPlugin;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import lombok.NonNull;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.EventManager;
+import org.spongepowered.api.scheduler.Scheduler;
 import org.spongepowered.api.scheduler.Task;
 import org.spongepowered.api.util.Ticks;
 import org.spongepowered.plugin.PluginContainer;
@@ -41,6 +42,7 @@ import org.spongepowered.plugin.PluginContainer;
 )
 public final class SpongeBridgePlugin implements PlatformEntrypoint {
 
+  private final Scheduler scheduler;
   private final PluginContainer plugin;
   private final EventManager eventManager;
   private final ModuleHelper moduleHelper;
@@ -50,6 +52,7 @@ public final class SpongeBridgePlugin implements PlatformEntrypoint {
 
   @Inject
   public SpongeBridgePlugin(
+    @NonNull @Named("sync") Scheduler scheduler,
     @NonNull PluginContainer plugin,
     @NonNull EventManager eventManager,
     @NonNull ModuleHelper moduleHelper,
@@ -57,6 +60,7 @@ public final class SpongeBridgePlugin implements PlatformEntrypoint {
     @NonNull SpongeBridgeManagement bridgeManagement,
     @NonNull SpongePlayerManagementListener playerListener
   ) {
+    this.scheduler = scheduler;
     this.plugin = plugin;
     this.eventManager = eventManager;
     this.moduleHelper = moduleHelper;
@@ -68,7 +72,7 @@ public final class SpongeBridgePlugin implements PlatformEntrypoint {
   @Override
   public void onLoad() {
     this.bridgeManagement.registerServices(this.serviceRegistry);
-    Sponge.server().scheduler().submit(
+    this.scheduler.submit(
       Task.builder()
         .delay(Ticks.of(1))
         .plugin(this.plugin)

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEBridgePlugin.java
@@ -63,7 +63,7 @@ public final class WaterDogPEBridgePlugin implements PlatformEntrypoint {
   public void onLoad() {
     // init the management
     this.bridgeManagement.registerServices(this.serviceRegistry);
-    this.bridgeManagement.postInit();
+    this.proxyServer.getScheduler().scheduleDelayed(this.bridgeManagement::postInit, 1);
 
     // register the WaterDog handlers
     var handlers = new WaterDogPEHandlers(this.proxyServer, this.bridgeManagement);


### PR DESCRIPTION
### Motivation

Certain features of CloudNet react to services updating and thus changing their state to "Running". In the current implementation, this update happens at the time the bridge module/plugin/extension is enabled. This timing is not ideal as a lot of time-consuming tasks, like generating or loading the worlds/dimensions and other modules/plugins/extensions may happen after that. This causes the other components, like the signs module or the NPCs module, to report those services as being already online and ready to join by players, whilst the opposite is actually the case.

### Modification

All currently supported server software platform integrations are augmented, so that `PlatformBridgeManagement#postInit` is called in the first game tick. This tick is only called, once the server is actually initialized, loaded and running. This also means that the server is ready to accept players.

### Result

Amongst other things, signs now show the server for joining only, once the server is actually ready to accept players.

#### Testing

This change has been successfully tested with servers running Paper, Fabric and Limbo.
