### PR TITLE
feat: Configurable log levels

### DIFF
--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -24,6 +24,7 @@
 
   <!-- variables used in the logback configuration. Can be set using system properties. -->
   <variable name="cloudnet.log.path" value="local/logs"/>
+  <variable name="cloudnet.log.level" value="INFO"/>
 
   <conversionRule conversionWord="levelColor"
     converterClass="eu.cloudnetservice.node.console.log.ConsoleLevelConversion"/>
@@ -58,7 +59,7 @@
     </encoder>
   </appender>
 
-  <root level="DEBUG">
+  <root level="${cloudnet.log.level}">
     <appender-ref ref="ConsoleLogAppender"/>
     <appender-ref ref="Rolling"/>
     <appender-ref ref="QueuedConsoleLogAppender"/>

--- a/wrapper-jvm/src/main/resources/logback.xml
+++ b/wrapper-jvm/src/main/resources/logback.xml
@@ -24,6 +24,7 @@
 
   <!-- variables used in the logback configuration. Can be set using system properties. -->
   <variable name="cloudnet.wrapper.log.path" value=".wrapper/logs"/>
+  <variable name="cloudnet.wrapper.log.level" value="INFO"/>
 
   <property name="LOG_PATTERN" value="[%d{dd.MM HH:mm:ss.SSS}] %-5level: %msg%n"/>
   <appender name="Rolling" class="RollingFileAppender">
@@ -59,7 +60,7 @@
     <target>System.err</target>
   </appender>
 
-  <root level="DEBUG">
+  <root level="${cloudnet.wrapper.log.level}">
     <appender-ref ref="Rolling"/>
     <appender-ref ref="STDOUT"/>
     <appender-ref ref="STDERR"/>


### PR DESCRIPTION
### Motivation
The current log file level have been hard coded to DEBUG, and this causes a huge build up of logs (more the few hundreds of megabytes on my server). Things like docker http requests, minecraft packets are all logged in here, and wouldn't be needed by the average user under normal conditions.

### Modification
Offers a way to modify the log level via system properties, and made INFO the default level of log file level

### Result
No more useless logs

##### Other context
N/A
