### PR TITLE
chore: update GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,15 +26,16 @@ jobs:
           check-latest: true
           distribution: 'zulu'
 
-      - name: Setup gradle cache
-        uses: gradle/actions/setup-gradle@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
+          add-job-summary: always
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          tools: latest
+          tools: linked
           languages: 'java'
 
       - name: Autobuild

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -14,9 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Setup java
         uses: actions/setup-java@v4
         with:
@@ -24,10 +21,11 @@ jobs:
           check-latest: true
           distribution: 'zulu'
 
-      - name: Setup gradle cache
-        uses: gradle/actions/setup-gradle@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
+          add-job-summary: always
 
       - name: Publish release to Sonatype
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Setup java
         uses: actions/setup-java@v4
         with:
@@ -31,9 +28,11 @@ jobs:
           check-latest: true
           distribution: 'zulu'
 
-      - name: Setup gradle cache
-        uses: gradle/actions/setup-gradle@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
+          add-job-summary: always
+          cache-cleanup: on-success
           cache-read-only: ${{ github.ref != 'refs/heads/nightly' }}
 
       - name: Setup Loom cache

--- a/.github/workflows/prbranch.yml
+++ b/.github/workflows/prbranch.yml
@@ -8,7 +8,7 @@ jobs:
   check-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: Vankka/pr-target-branch-action@v2.1
+      - uses: Vankka/pr-target-branch-action@v3
         with:
           target: release
-          exclude: nightly
+          exclude: beta


### PR DESCRIPTION
### Motivation
Some of our GitHub actions are outdated but these updates were either not detected by renovate or cannot be done automatically.

### Modification
- Bump `Vankka/pr-target-branch-action` to v3: this resolves a warning because the old 2.1 version was still running on node16 which is now deprecated. Additionally a mistake was fixed: only beta should be allowed to PR into release in the end.
- Fix a deprecation warning of `github/codeql-action/init`: The `latest` tool option name was changed to `linked` to reflect the actual CodeQL version being used: the version the action was linked (build) with.
- Buimp `gradle/actions/setup-gradle` to v4: The wrapper validation step can be removed as this is now part of the action itself. Additionally I enabled that the job summary is always appended to all GitHub action runs.

### Result
The GitHub actions versions used in the project are up to date and all relevant deprecations are resolved.

##### Other context
Supersedes #1472
