### PR TITLE
fix: ensure to only remove npcs that are currently spawned

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
@@ -204,7 +204,9 @@ public abstract class PlatformNPCManagement<L, P, M, I, S> extends AbstractNPCMa
   }
 
   public void removeSpawnedEntities() {
-    this.trackedEntities.values().forEach(PlatformSelectorEntity::remove);
+    this.trackedEntities.values().stream()
+      .filter(PlatformSelectorEntity::spawned)
+      .forEach(PlatformSelectorEntity::remove);
   }
 
   public @Nullable NPCConfigurationEntry applicableNPCConfigurationEntry() {

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformNPCManagement.java
@@ -204,9 +204,7 @@ public abstract class PlatformNPCManagement<L, P, M, I, S> extends AbstractNPCMa
   }
 
   public void removeSpawnedEntities() {
-    this.trackedEntities.values().stream()
-      .filter(PlatformSelectorEntity::spawned)
-      .forEach(PlatformSelectorEntity::remove);
+    this.trackedEntities.values().forEach(PlatformSelectorEntity::remove);
   }
 
   public @Nullable NPCConfigurationEntry applicableNPCConfigurationEntry() {

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/EntityBukkitPlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/EntityBukkitPlatformSelectorEntity.java
@@ -175,8 +175,10 @@ public class EntityBukkitPlatformSelectorEntity extends BukkitPlatformSelectorEn
 
   @Override
   protected void remove0() {
-    this.entity.remove();
-    this.entity = null;
+    if (this.entity != null) {
+      this.entity.remove();
+      this.entity = null;
+    }
   }
 
   @Override

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/entity/NPCBukkitPlatformSelector.java
@@ -104,8 +104,10 @@ public class NPCBukkitPlatformSelector extends BukkitPlatformSelectorEntity {
 
   @Override
   protected void remove0() {
-    this.handleNpc.unlink();
-    this.handleNpc = null;
+    if (this.handleNpc != null) {
+      this.handleNpc.unlink();
+      this.handleNpc = null;
+    }
   }
 
   @Override


### PR DESCRIPTION
### Motivation
When stopping a service and npcs are already removed before the actual disable of the npc plugin the call to remove all npcs might result in a NPE.

### Modification
Ensured to only remove spawned npcs.

### Result
No NPE anymore.
