### PR TITLE
fix: schedule no tasks when signs are disabled

### DIFF
--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/bukkit/BukkitSignManagement.java
@@ -61,11 +61,14 @@ public class BukkitSignManagement extends PlatformSignManagement<Player, Locatio
     @NonNull @Named("taskScheduler") ScheduledExecutorService executorService
   ) {
     super(eventManager, runnable -> {
-      // check if we're already on main
-      if (server.isPrimaryThread()) {
-        runnable.run();
-      } else {
-        scheduler.runTask(plugin, runnable);
+      // only schedule tasks if the plugin is enabled, bukkit does not allow scheduling while disabled
+      if (plugin.isEnabled()) {
+        // check if we're already on main
+        if (server.isPrimaryThread()) {
+          runnable.run();
+        } else {
+          scheduler.runTask(plugin, runnable);
+        }
       }
     }, wrapperConfig, serviceProvider, executorService);
 

--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/nukkit/NukkitSignManagement.java
@@ -65,10 +65,13 @@ public class NukkitSignManagement extends PlatformSignManagement<Player, Locatio
     super(
       eventManager,
       runnable -> {
-        if (server.isPrimaryThread()) {
-          runnable.run();
-        } else {
-          scheduler.scheduleTask(plugin, runnable);
+        // only schedule tasks if the plugin is enabled, nukkit does not allow scheduling while disabled
+        if (plugin.isEnabled()) {
+          if (server.isPrimaryThread()) {
+            runnable.run();
+          } else {
+            scheduler.scheduleTask(plugin, runnable);
+          }
         }
       },
       wrapperConfig,


### PR DESCRIPTION
### Motivation
When the sign plugin (on nukkit & bukkit) is being disabled we might receive a service update which causes a task schedule. The task schedule then causes an exception.

### Modification
Added a check to only schedule tasks when the plugin is enabled

### Result
No exceptions when stopping the signs plugin.