### PR TITLE
chore: replace deprecated converterClass property in logback config

### DIFF
--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -26,7 +26,7 @@
   <variable name="cloudnet.log.path" value="local/logs"/>
 
   <conversionRule conversionWord="levelColor"
-    converterClass="eu.cloudnetservice.node.console.log.ConsoleLevelConversion"/>
+    class="eu.cloudnetservice.node.console.log.ConsoleLevelConversion"/>
   <property name="CONSOLE_PATTERN"
     value="%gray([%boldWhite(%d{dd.MM HH:mm:ss.SSS}%gray(]))) %gray(%levelColor(%-5level%gray(:))) %msg%n"/>
   <appender name="ConsoleLogAppender" class="ConsoleLogAppender">


### PR DESCRIPTION
### Motivation
Logback introduced a new deprecation in the last release which wasn't mentioned in the changelog. This a huge logback debug output when starting CloudNet to be printed into the console. Essentially the `converterClass` property of `conversionRule` was renamed to `class`.

Deprecation notice: `|-WARN in ch.qos.logback.core.joran.action.ConversionRuleAction - [converterClass] attribute is deprecated and replaced by [class]. See element [conversionRule] near line 29`

### Modification
Replace `converterClass` attribute of `conversionRule` with `class` to resolve the deprecation notice.

### Result
The deprecation is resolved and no more debug logs are printed when starting CloudNet.
