### PR TITLE
fix: testcontainers related test issues

### DIFF
--- a/driver/src/test/resources/logback-test.xml
+++ b/driver/src/test/resources/logback-test.xml
@@ -21,7 +21,12 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
   </root>
+
+  <logger name="tc" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>

--- a/modules/database-mongodb/src/test/resources/logback-test.xml
+++ b/modules/database-mongodb/src/test/resources/logback-test.xml
@@ -21,7 +21,12 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
   </root>
+
+  <logger name="tc" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>

--- a/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
+++ b/modules/database-mysql/src/test/java/eu/cloudnetservice/modules/mysql/MySQLDatabaseTest.java
@@ -40,7 +40,8 @@ class MySQLDatabaseTest {
     .withEnv("MYSQL_USER", "test")
     .withEnv("MYSQL_PASSWORD", "test")
     .withEnv("MYSQL_ROOT_PASSWORD", "test")
-    .withEnv("MYSQL_DATABASE", "cn_testing");
+    .withEnv("MYSQL_DATABASE", "cn_testing")
+    .withCommand("mariadbd", "--ssl=0");
 
   private MySQLDatabaseProvider databaseProvider;
 

--- a/modules/database-mysql/src/test/resources/logback-test.xml
+++ b/modules/database-mysql/src/test/resources/logback-test.xml
@@ -21,7 +21,12 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
   </root>
+
+  <logger name="tc" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>

--- a/modules/report/src/test/resources/logback-test.xml
+++ b/modules/report/src/test/resources/logback-test.xml
@@ -21,7 +21,12 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
   </root>
+
+  <logger name="tc" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>

--- a/modules/storage-s3/src/test/resources/logback-test.xml
+++ b/modules/storage-s3/src/test/resources/logback-test.xml
@@ -21,7 +21,12 @@
     </encoder>
   </appender>
 
-  <root level="debug">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
   </root>
+
+  <logger name="tc" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>

--- a/modules/storage-sftp/src/test/resources/logback-test.xml
+++ b/modules/storage-sftp/src/test/resources/logback-test.xml
@@ -21,7 +21,12 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
   </root>
+
+  <logger name="tc" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>

--- a/modules/syncproxy/src/test/resources/logback-test.xml
+++ b/modules/syncproxy/src/test/resources/logback-test.xml
@@ -21,7 +21,12 @@
     </encoder>
   </appender>
 
-  <root level="debug">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
   </root>
+
+  <logger name="tc" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>

--- a/node/src/test/resources/logback-test.xml
+++ b/node/src/test/resources/logback-test.xml
@@ -21,7 +21,12 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
   </root>
+
+  <logger name="tc" level="INFO"/>
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>


### PR DESCRIPTION
### Motivation
At the moment tests cannot be execurted locally due to test failures related to MariaDB. For some reason, the mariadb server issues a SSL certificate which becomes valid after a few seconds, however, the connection to the server is established 1 or 2 seconds before that. This leads to an exception being thrown as the certificate is not yet valid.

Furthermore, due to enabled debug logging we get debug logs containing stack traces from docker-java which are interpreted as test failures by IJ (while the build completes normally).

### Modification
The MariaDB issue can be fixed by simply disabling SSL in the mariadb container. The logging issue is fixed by applying the recommanded logging configuration of testcontainers (see https://java.testcontainers.org/supported_docker_environment/logging_config) which disables the debug logging of docker-java. Therefore the misinterpreted errors are no longer printed into the console.

### Result
Tests work locally as expected again.
