### PR TITLE
fix: use high timeout for query packets instead of weak values

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/defaults/DefaultQueryPacketManager.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/protocol/defaults/DefaultQueryPacketManager.java
@@ -23,6 +23,7 @@ import com.github.benmanes.caffeine.cache.RemovalListener;
 import eu.cloudnetservice.driver.network.NetworkChannel;
 import eu.cloudnetservice.driver.network.protocol.Packet;
 import eu.cloudnetservice.driver.network.protocol.QueryPacketManager;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -49,7 +50,7 @@ public class DefaultQueryPacketManager implements QueryPacketManager {
   public DefaultQueryPacketManager(@NonNull NetworkChannel networkChannel) {
     this.networkChannel = networkChannel;
     this.waitingHandlers = Caffeine.newBuilder()
-      .weakValues()
+      .expireAfterWrite(Duration.ofHours(8))
       .removalListener(this.newRemovalListener())
       .build();
   }


### PR DESCRIPTION
### Motivation
The new implementation of query packets resulted in possible dead locks. The dead locks were caused, when the QueryPacketManager lost the reference to the stored future, because the answer to the query would never be handled as the entry in the map is lost.

### Modification
Removed the weakValues option from the backing cache and use a really high timeout of 8 hours for cache invalidation. Usually the cache should be empty so the high timeout value is not a problem.

### Result
No more deadlocks with query packets.

##### Other context
Fixes #1480 
