### PR TITLE
chore: use java 23

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 23
           check-latest: true
           distribution: 'zulu'
 

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 23
           check-latest: true
           distribution: 'zulu'
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 23
           check-latest: true
           distribution: 'zulu'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM azul/zulu-openjdk:22-jre-headless AS build
+FROM azul/zulu-openjdk:23-jre-headless AS build
 
 COPY . /home/cloudnet-build
 WORKDIR /home/cloudnet-build
 
 RUN chmod +x gradlew && ./gradlew -x test --no-daemon --stacktrace
 
-FROM azul/zulu-openjdk:22-jre-headless
+FROM azul/zulu-openjdk:23-jre-headless
 
 RUN mkdir -p /cloudnet
 WORKDIR /cloudnet

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ just append the `-SNAPSHOT` suffix to the version.
 
 ## Compile from source
 
-To compile CloudNet you need JDK 22 and an internet connection. Then clone this repository and run `./gradlew` inside
+To compile CloudNet you need JDK 23 and an internet connection. Then clone this repository and run `./gradlew` inside
 the cloned project.
 
 ## Warnings

--- a/build-extensions/src/main/kotlin/publishing-extensions.kt
+++ b/build-extensions/src/main/kotlin/publishing-extensions.kt
@@ -120,7 +120,7 @@ fun applyDefaultJavadocOptions(options: StandardJavadocDocletOptions) {
   options.use()
   options.encoding = "UTF-8"
   options.memberLevel = JavadocMemberLevel.PRIVATE
-  options.addStringOption("source", "22")
+  options.addStringOption("source", "23")
   options.addBooleanOption("-enable-preview", true)
   options.addBooleanOption("Xdoclint:-missing", true)
   options.links(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,8 +109,8 @@ subprojects {
   }
 
   tasks.withType<JavaCompile>().configureEach {
-    sourceCompatibility = JavaVersion.VERSION_22.toString()
-    targetCompatibility = JavaVersion.VERSION_22.toString()
+    sourceCompatibility = JavaVersion.VERSION_23.toString()
+    targetCompatibility = JavaVersion.VERSION_23.toString()
 
     options.encoding = "UTF-8"
     options.isIncremental = true

--- a/common/src/test/java/eu/cloudnetservice/common/jvm/JavaVersionTest.java
+++ b/common/src/test/java/eu/cloudnetservice/common/jvm/JavaVersionTest.java
@@ -23,10 +23,10 @@ public class JavaVersionTest {
 
   @Test
   void testRuntimeVersion() {
-    // we require java 22 to build (atm)
+    // we require java 23 to build (atm)
     var runtimeVersion = JavaVersion.runtimeVersion();
-    Assertions.assertTrue(JavaVersion.JAVA_22.atOrAbove());
-    Assertions.assertTrue(runtimeVersion.isNewerOrAt(JavaVersion.JAVA_22));
+    Assertions.assertTrue(JavaVersion.JAVA_23.atOrAbove());
+    Assertions.assertTrue(runtimeVersion.isNewerOrAt(JavaVersion.JAVA_23));
   }
 
   @Test

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/BasicRPCMethodGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/BasicRPCMethodGenerator.java
@@ -112,7 +112,7 @@ final class BasicRPCMethodGenerator implements RPCMethodGenerator {
         } else {
           // unbox the primitive value
           CodeGenerationUtil.unboxPrimitive(codeBuilder, returnType.descriptorString());
-          codeBuilder.returnInstruction(returnTypeKind);
+          codeBuilder.return_(returnTypeKind);
         }
       } else {
         // cast & return the value

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ChainedRPCMethodGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/ChainedRPCMethodGenerator.java
@@ -156,7 +156,7 @@ final class ChainedRPCMethodGenerator implements RPCMethodGenerator {
         if (paramType.isPrimitive()) {
           // box primitive type before storing
           var typeKind = TypeKind.fromDescriptor(paramType.descriptorString());
-          codeBuilder.loadInstruction(typeKind, paramSlot);
+          codeBuilder.loadLocal(typeKind, paramSlot);
           CodeGenerationUtil.boxPrimitive(codeBuilder, paramType.descriptorString());
           codeBuilder.aastore();
         } else {

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/RPCImplementationGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/generation/RPCImplementationGenerator.java
@@ -98,7 +98,7 @@ final class RPCImplementationGenerator {
         codeBuilder
           .dup()
           .ldc(index)
-          .loadInstruction(typeKind, parameterSlot);
+          .loadLocal(typeKind, parameterSlot);
         CodeGenerationUtil.boxPrimitive(codeBuilder, descriptor);
         codeBuilder.aastore();
       } else {

--- a/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassCodecGenerator.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/network/rpc/defaults/object/data/DataClassCodecGenerator.java
@@ -272,7 +272,7 @@ final class DataClassCodecGenerator {
           .aload(1)
           .aload(3)
           .checkcast(targetClassDesc)
-          .invokeInstruction(
+          .invoke(
             invocationOpcode,
             targetClassDesc,
             getterMethod.getName(),
@@ -360,7 +360,7 @@ final class DataClassCodecGenerator {
       // store the variable on the stack
       var typeKind = TypeKind.fromDescriptor(fieldType.descriptorString());
       var parameterSlot = code.allocateLocal(typeKind);
-      code.storeInstruction(typeKind, parameterSlot);
+      code.storeLocal(typeKind, parameterSlot);
 
       // store the information about the parameter
       constructorParamTypes[index] = fieldType;
@@ -376,7 +376,7 @@ final class DataClassCodecGenerator {
       var type = constructorParamTypes[index];
       var storeSlot = parameterTypesStoreSlots[index];
       var typeKind = TypeKind.fromDescriptor(type.descriptorString());
-      code.loadInstruction(typeKind, storeSlot);
+      code.loadLocal(typeKind, storeSlot);
     }
 
     // invoke the constructor and return the constructed value

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # plugins
-shadow = "8.3.0"
+shadow = "8.3.2"
 juppiter = "0.4.0"
 spotless = "6.25.0"
 fabricLoom = "1.7.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 shadow = "8.3.2"
 juppiter = "0.4.0"
 spotless = "6.25.0"
-fabricLoom = "1.8.6"
+fabricLoom = "1.8.8"
 nexusPublish = "2.0.0"
 checkstyleTools = "10.18.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,7 +78,7 @@ luckPermsApi = "5.4"
 
 # fabric platform special dependencies
 minecraft = "1.21.1"
-fabricLoader = "0.16.5"
+fabricLoader = "0.16.6"
 
 
 [libraries]

--- a/launcher/java8/src/main/java/eu/cloudnetservice/launcher/java8/Launcher.java
+++ b/launcher/java8/src/main/java/eu/cloudnetservice/launcher/java8/Launcher.java
@@ -19,14 +19,14 @@ package eu.cloudnetservice.launcher.java8;
 public final class Launcher {
 
   public static void main(String[] args) throws Exception {
-    // check if we're at least on java 22
-    if (detectJavaVersion() == 22) {
+    // check if we're at least on java 23
+    if (detectJavaVersion() == 23) {
       Class.forName("eu.cloudnetservice.launcher.java22.CloudNetLauncher")
         .getConstructor(String[].class)
         .newInstance((Object) args);
     } else {
       // CHECKSTYLE.OFF: Launcher has no proper logger
-      System.err.println("CloudNet requires exactly Java 22. Download it from https://adoptium.net/");
+      System.err.println("CloudNet requires exactly Java 23. Download it from https://adoptium.net/");
       System.exit(1);
       // CHECKSTYLE.ON
     }

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
@@ -30,7 +30,7 @@ import lombok.NonNull;
   name = "CloudNet-Bridge",
   version = "@version@",
   dependencies = {
-    @Dependency(name = "fabricloader", version = ">=0.15.0"),
+    @Dependency(name = "fabricloader", version = ">=0.16.6"),
     @Dependency(name = "minecraft", version = "~1.21"),
     @Dependency(name = "java", version = ">=23")
   },

--- a/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
+++ b/modules/bridge/src/main/java/eu/cloudnetservice/modules/bridge/platform/fabric/FabricBridgeInitializer.java
@@ -32,7 +32,7 @@ import lombok.NonNull;
   dependencies = {
     @Dependency(name = "fabricloader", version = ">=0.15.0"),
     @Dependency(name = "minecraft", version = "~1.21"),
-    @Dependency(name = "java", version = ">=22")
+    @Dependency(name = "java", version = ">=23")
   },
   authors = "CloudNetService"
 )

--- a/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServicesModule.java
+++ b/modules/dockerized-services/src/main/java/eu/cloudnetservice/modules/docker/DockerizedServicesModule.java
@@ -49,7 +49,7 @@ public class DockerizedServicesModule extends DriverModule {
       () -> new DockerConfiguration(
         "docker-jvm",
         "host",
-        DockerImage.builder().repository("azul/zulu-openjdk").tag("22-jre-headless").build(),
+        DockerImage.builder().repository("azul/zulu-openjdk").tag("23-jre-headless").build(),
         Set.of(),
         Set.of(),
         Set.of(),

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/VersionCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/VersionCommand.java
@@ -72,7 +72,7 @@ public final class VersionCommand {
       .column(pair -> pair.first().name())
       .column(pair -> pair.second().name())
       .column(pair -> pair.second().deprecated())
-      .column(pair -> pair.second().minJavaVersion().orElse(JavaVersion.JAVA_22).name())
+      .column(pair -> pair.second().minJavaVersion().orElse(JavaVersion.JAVA_23).name())
       .column(pair -> pair.second().maxJavaVersion().map(JavaVersion::name).orElse("No maximum"))
       .build();
 

--- a/node/src/main/java/eu/cloudnetservice/node/provider/NodeServiceTaskProvider.java
+++ b/node/src/main/java/eu/cloudnetservice/node/provider/NodeServiceTaskProvider.java
@@ -241,9 +241,9 @@ public class NodeServiceTaskProvider implements ServiceTaskProvider {
           task = ServiceTask.builder(task).javaCommand(command).build();
         }
 
-        // remove all custom java paths that do not support Java 22
+        // remove all custom java paths that do not support Java 23
         var javaVersion = JavaVersionResolver.resolveFromJavaExecutable(task.javaCommand());
-        if (javaVersion != JavaVersion.JAVA_22) {
+        if (javaVersion != JavaVersion.JAVA_23) {
           task = ServiceTask.builder(task).javaCommand(null).build();
           LOGGER.warn(I18n.trans("cloudnet-load-task-unsupported-java-version", taskName));
         }

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/FabricLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/FabricLuckPermsPlugin.java
@@ -32,7 +32,7 @@ import net.luckperms.api.LuckPermsProvider;
   dependencies = {
     @Dependency(name = "fabricloader", version = ">=0.14.17"),
     @Dependency(name = "minecraft", version = ">=1.20.4"),
-    @Dependency(name = "java", version = ">=22"),
+    @Dependency(name = "java", version = ">=23"),
     @Dependency(name = "LuckPerms")
   },
   authors = "CloudNetService",

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/FabricLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/FabricLuckPermsPlugin.java
@@ -30,7 +30,7 @@ import net.luckperms.api.LuckPermsProvider;
   name = "CloudNet-LuckPerms",
   version = "@version@",
   dependencies = {
-    @Dependency(name = "fabricloader", version = ">=0.14.17"),
+    @Dependency(name = "fabricloader", version = ">=0.16.6"),
     @Dependency(name = "minecraft", version = ">=1.20.4"),
     @Dependency(name = "java", version = ">=23"),
     @Dependency(name = "LuckPerms")


### PR DESCRIPTION
### Motivation
Java 23 will release at September 17, 2024. As we're cuirrently running on the STS version 22 we need to update as soon as possible.

### Modification
Update all build scripts and code to use java 23, fix some issues with preview api that has changed.

### Result
Java 23 is used for CloudNet instead of java 22.
