### PR TITLE
fix query packets sent from wrapper with targetAll

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerChannelMessageListener.java
@@ -123,6 +123,7 @@ public final class PacketServerChannelMessageListener implements PacketListener 
           } else {
             // just respond with nothing when an exception was thrown
             responseContent = DataBuf.empty().writeBoolean(false);
+            LOGGER.error("An error occurred while sending a query message", exception);
           }
 
           // send the results to the sender

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerChannelMessageListener.java
@@ -123,7 +123,7 @@ public final class PacketServerChannelMessageListener implements PacketListener 
           } else {
             // just respond with nothing when an exception was thrown
             responseContent = DataBuf.empty().writeBoolean(false);
-            LOGGER.error("An error occurred while sending a query message", exception);
+            LOGGER.error("Unable to relay channel message {} into cluster", message, exception);
           }
 
           // send the results to the sender

--- a/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerChannelMessageListener.java
+++ b/node/src/main/java/eu/cloudnetservice/node/network/listener/PacketServerChannelMessageListener.java
@@ -132,7 +132,7 @@ public final class PacketServerChannelMessageListener implements PacketListener 
         }).whenComplete((_, exception) -> {
           // log any internal errors
           if (exception != null) {
-            LOGGER.error("Query response packet failed", exception);
+            LOGGER.error("Unable to encode/send response to channel message {}", message, exception);
           }
 
           if (initialResponse != null) {


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
Fixes an issue I encountered where you can't respond to a query packet on the node if it is sent from the wrapper with `targetAll()`, because the node's response content buffer is cleared to early.

### Modification
<!-- Describe the modification you've done to the codebase -->
Clear the buffer after it has been sent back to the wrapper, not before. Also adds logging, because any errors in the `CompletableFuture` callback won't be logged, making it difficult to see problems

