### PR TITLE
Correct Typo in Command Help Descriptions

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/HelpCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/HelpCommand.java
@@ -40,7 +40,7 @@ import org.incendo.cloud.context.CommandInput;
 @Singleton
 @CommandAlias({"ask", "?"})
 @Permission("cloudnet.command.help")
-@Description("commnad-help-description")
+@Description("command-help-description")
 public final class HelpCommand {
 
   private static final RowedFormatter<CommandInfo> HELP_LIST_FORMATTER = RowedFormatter.<CommandInfo>builder()

--- a/node/src/main/resources/lang/de_DE.properties
+++ b/node/src/main/resources/lang/de_DE.properties
@@ -142,7 +142,7 @@ command-any-host-invalid=Die Eingabe {0$input$} ist keine gültige Host-Adresse.
 #
 # Command Help
 #
-commnad-help-description=Zeigt alle Befehle und ihre Beschreibung an
+command-help-description=Zeigt alle Befehle und ihre Beschreibung an
 command-help-docs=Folge der Url {0$url$} um zur Dokumentation für den Befehl {1$command$} zu kommen
 command-help-docs-no-url=Der Befehl {0$command$} hat keine Dokumentations-Url
 #

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -140,7 +140,7 @@ command-any-host-invalid=The given input {0$input$} is not a valid host address.
 #
 # Command Help
 #
-commnad-help-description=Shows all commands and their description
+command-help-description=Shows all commands and their description
 command-help-docs=Follow this url {0$url$} to get to the documentation for the {1$command$} command
 command-help-docs-no-url=The {0$command$} command has no documentation url
 #


### PR DESCRIPTION
### Motivation
The motivation behind this pull request is to correct typos found in the command descriptions within the annotation usage and localization properties.

### Modification
- Corrected typos in the property keys and `@Description` annotation from `commnad-help-description` to `command-help-description`.
- Updated localization files to reflect the corrected command descriptions in both English and German.
- Adjusted the relevant code where the command description keys are referenced.

### Result
With these changes, the help command descriptions are now correctly spelled.

##### Other context
This typo correction helps maintain the quality and accuracy of the project.