### PR TITLE
fix: default log level is not configurable

### DIFF
--- a/launcher/java22/src/main/resources/launcher.cnl
+++ b/launcher/java22/src/main/resources/launcher.cnl
@@ -42,9 +42,9 @@ var cloudnet.updateRepo CloudNetService/launchermeta
 #                   features available. (Use this branch at your own risk!)
 var cloudnet.updateBranch beta
 
-# available default log levels: OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL
+# available default log levels: OFF, ERROR, WARN, INFO, DEBUG, TRACE, ALL
 # each level includes all messages for levels lower than itself (in the above list: left to right) too
-var cloudnet.logging.defaultlevel INFO
+var cloudnet.log.level DEBUG
 
 # This value sets the memory settings of the JVM for the cloudnet node.
 # The value set here is to be specified in megabytes and describes -xmx as well as -xms.

--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -24,6 +24,7 @@
 
   <!-- variables used in the logback configuration. Can be set using system properties. -->
   <variable name="cloudnet.log.path" value="local/logs"/>
+  <variable name="cloudnet.log.level" value="DEBUG"/>
 
   <conversionRule conversionWord="levelColor"
     class="eu.cloudnetservice.node.console.log.ConsoleLevelConversion"/>
@@ -58,7 +59,7 @@
     </encoder>
   </appender>
 
-  <root level="DEBUG">
+  <root level="${cloudnet.log.level}">
     <appender-ref ref="ConsoleLogAppender"/>
     <appender-ref ref="Rolling"/>
     <appender-ref ref="QueuedConsoleLogAppender"/>

--- a/wrapper-jvm/src/main/resources/logback.xml
+++ b/wrapper-jvm/src/main/resources/logback.xml
@@ -24,6 +24,7 @@
 
   <!-- variables used in the logback configuration. Can be set using system properties. -->
   <variable name="cloudnet.wrapper.log.path" value=".wrapper/logs"/>
+  <variable name="cloudnet.wrapper.log.level" value="DEBUG"/>
 
   <property name="LOG_PATTERN" value="[%d{dd.MM HH:mm:ss.SSS}] %-5level: %msg%n"/>
   <appender name="Rolling" class="RollingFileAppender">
@@ -59,7 +60,7 @@
     <target>System.err</target>
   </appender>
 
-  <root level="DEBUG">
+  <root level="${cloudnet.wrapper.log.level}">
     <appender-ref ref="Rolling"/>
     <appender-ref ref="STDOUT"/>
     <appender-ref ref="STDERR"/>


### PR DESCRIPTION
### Motivation
In PR #1466 a contributor noted that the log level is not really configurable without replacing the whole configuration. This changes allowes the configuration using system properties and thus the launcher.cnl

### Modification
Added a new "cloudnet.log.level" property which allows configuring the log level.

### Result
Configurable log levels

##### Other context
Closes #1466 
