### PR TITLE
fix: checks for minimum service heap memory

### DIFF
--- a/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
+++ b/driver/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
@@ -108,7 +108,7 @@ public record ProcessConfiguration(
      * @throws IllegalArgumentException if the given memory size is less than 50 mb.
      */
     public @NonNull Builder maxHeapMemorySize(@Range(from = 50, to = Integer.MAX_VALUE) int maxHeapMemorySize) {
-      Preconditions.checkArgument(maxHeapMemorySize > 50, "Max heap memory must be at least 50 mb");
+      Preconditions.checkArgument(maxHeapMemorySize >= 50, "Max heap memory must be at least 50 mb");
 
       this.maxHeapMemorySize = maxHeapMemorySize;
       return this;

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -470,7 +470,7 @@ public final class TasksCommand {
   public void setMaxHeapMemory(
     @NonNull CommandSource source,
     @NonNull @Argument("name") Collection<ServiceTask> tasks,
-    @Argument("amount") @Range(min = "0") int amount
+    @Argument("amount") @Range(min = "50") int amount
   ) {
     this.applyChange(
       source,


### PR DESCRIPTION
### Motivation
The process config states that at least 50mb of memory are needed. The check in the builder was checking for `memory > 50` thus not including 50mb.

### Modification
Made the check in the builder inclusive and added the correct range to the command.

### Result
Correct checks for heap memory in the builder & commands