### PR TITLE
fix: generated velocity meta file uses name as version

### DIFF
--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPluginInfoGenerator.java
@@ -54,7 +54,7 @@ final class VelocityPluginInfoGenerator extends NightConfigInfoGenerator {
   ) {
     // base values
     target.add("name", pluginData.name());
-    target.add("version", pluginData.name());
+    target.add("version", pluginData.version());
     target.add("main", platformMainClassName);
     target.add("id", PLUGIN_ID_GENERATOR.convert(pluginData.name()));
 


### PR DESCRIPTION
### Motivation
Fixing an issue where the version of a Velocity plugin whould be the name set in the @PlatformPlugin annotation

### Modification
Changed the eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPluginInfoGenerator.java file to now set the version to the version and not to the name

### Result
It now should set the version correctly
