### PR TITLE
fix: signs checked configuration templates instead of installed templates

### DIFF
--- a/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
+++ b/modules/signs/src/main/java/eu/cloudnetservice/modules/signs/platform/PlatformSignManagement.java
@@ -309,7 +309,7 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
   }
 
   protected boolean checkTemplatePath(@NonNull ServiceInfoSnapshot snapshot, @NonNull Sign sign) {
-    for (var template : snapshot.configuration().templates()) {
+    for (var template : snapshot.provider().installedTemplates()) {
       if (template.toString().equals(sign.templatePath())) {
         return true;
       }


### PR DESCRIPTION
### Motivation
The 3.5 documentation for signs (https://cloudnetservice.eu/de/docs/next/modules/signs) says: "The tags can even be targeted to specific groups with a template path limitation, which will then only show services with the specified template." and I think that should still be valid for CloudNet 4.0. The problem is that the current implementation checks for templates in the configuration, which doesn't necessarily match the installed templates (e.x. using the smart module template configuration can change that).

### Modification
Changed the getter for templates to only get installed templates in the templatePath check.

### Result
Now, only templates that are actually installed will make a service show up on signs with the specified templatePath. This is also consistent with the templates that are displayed when the service command is used to look up its information.