### PR TITLE
fix: command parameter injection service

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/defaults/AerogelInjectionService.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/defaults/AerogelInjectionService.java
@@ -29,11 +29,15 @@ final class AerogelInjectionService implements InjectionService<CommandSource> {
 
   @Override
   public @Nullable Object handle(@NonNull InjectionRequest<CommandSource> request) {
-    // get the associated data from the input values
-    var targetClass = request.injectedClass();
-    var injectionLayer = InjectionLayer.findLayerOf(targetClass);
+    try {
+      // get the associated data from the input values
+      var targetClass = request.injectedClass();
+      var injectionLayer = InjectionLayer.findLayerOf(targetClass);
 
-    // get the instance of the given class from the injection layer
-    return injectionLayer.instance(targetClass);
+      // get the instance of the given class from the injection layer
+      return injectionLayer.instance(targetClass);
+    } catch (Exception exception) {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
### Motivation
When trying to execute specific commands, such as `version installtemplate`, an exception is thrown due to a wrong implementation of the cloud command injection service:
```
[10.10 20:55:49.130] ERROR: Exception during command execution
org.incendo.cloud.exception.InjectionException: Failed to inject type org.incendo.cloud.context.CommandContext<?>
	at org.incendo.cloud.injection.ParameterInjectorRegistry.getInjectable(ParameterInjectorRegistry.java:197)
	at org.incendo.cloud.annotations.method.AnnotatedMethodHandler.getInjectedValue(AnnotatedMethodHandler.java:135)
	at org.incendo.cloud.annotations.method.AnnotatedMethodHandler.createParameterValues(AnnotatedMethodHandler.java:206)
...
Caused by: org.incendo.cloud.services.PipelineException: Failed to retrieve result from ServiceWrapper{type=org.incendo.cloud.injection.InjectionService<C>,implementation=eu.cloudnetservice.node.command.defaults.AerogelInjectionService}
	at org.incendo.cloud.services.ServiceSpigot.complete(ServiceSpigot.java:97)
	at org.incendo.cloud.injection.ParameterInjectorRegistry.getInjectable(ParameterInjectorRegistry.java:178)
	... 13 common frames omitted
```

### Modification
Change the injection service so that it no longer throws an exception but rather returns null as required if an instance of the requested type cannot be injected.

### Result
The execution of specific commands no longer throws an exception and works as expected again.
