### PR TITLE
fix: typo in tasks set javaCommand command response

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/TasksCommand.java
@@ -552,7 +552,7 @@ public final class TasksCommand {
       tasks,
       ServiceTask.Builder::javaCommand,
       "command-tasks-set-property-success",
-      "node",
+      "javaCommand",
       executable.first());
   }
 


### PR DESCRIPTION
### Motivation
There is a typo in the response of the `tasks task <task> set javaCommand <exec>` command.

### Modification
Replaced the `node` property with the `javaCommand` property.

### Result
Correct response.