### PR TITLE
fix: remove dev command translations & sync german translations

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/DevCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/DevCommand.java
@@ -44,7 +44,7 @@ public final class DevCommand {
     var levelName = input.readString();
     var level = Level.toLevel(levelName, null);
     if (level == null) {
-      throw new ArgumentNotAvailableException(String.format("The provided log level %s does not exist.", levelName));
+      throw new ArgumentNotAvailableException(String.format("The provided log level %s does not exist", levelName));
     }
 
     return level;

--- a/node/src/main/java/eu/cloudnetservice/node/command/sub/DevCommand.java
+++ b/node/src/main/java/eu/cloudnetservice/node/command/sub/DevCommand.java
@@ -18,7 +18,6 @@ package eu.cloudnetservice.node.command.sub;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
-import eu.cloudnetservice.common.language.I18n;
 import eu.cloudnetservice.node.command.annotation.Description;
 import eu.cloudnetservice.node.command.exception.ArgumentNotAvailableException;
 import eu.cloudnetservice.node.command.source.CommandSource;
@@ -45,7 +44,7 @@ public final class DevCommand {
     var levelName = input.readString();
     var level = Level.toLevel(levelName, null);
     if (level == null) {
-      throw new ArgumentNotAvailableException(I18n.trans("command-dev-log-level-not-found"));
+      throw new ArgumentNotAvailableException(String.format("The provided log level %s does not exist.", levelName));
     }
 
     return level;
@@ -60,7 +59,7 @@ public final class DevCommand {
   public void setLogLevel(@NonNull CommandSource source, @NonNull @Argument("level") Level level) {
     var rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     if (rootLogger instanceof Logger logbackLogger) {
-      source.sendMessage(I18n.trans("command-dev-log-level-set", level.toString()));
+      source.sendMessage(String.format("The log level was set to %s", level));
       logbackLogger.setLevel(level);
     }
   }

--- a/node/src/main/resources/lang/de_DE.properties
+++ b/node/src/main/resources/lang/de_DE.properties
@@ -48,8 +48,6 @@ client-network-channel-close=Kanal [serverAddress\={0$serverAddress$} clientAddr
 client-network-channel-init=Kanal [serverAddress\={0$serverAddress$} clientAddress\={1$clientAddress$}] wurde erfolgreich mit dem Server verbunden
 server-network-channel-close=Channel [serverAddress\={0$serverAddress$} clientAddress\={1$clientAddress$}] wurde geschlossen.
 server-network-channel-init=Channel [serverAddress\={0$serverAddress$} clientAddress\={1$clientAddress$}] wurde verbunden.
-http-listener-bound=Ein HTTP-Listener wurde erfolgreich an die Adresse "{0$address$}" gebunden...
-http-listener-bound-exceptionally=Ein HTTP Listener konnte nicht auf "{0$address$}" gebunden werden\: {1$reason$}
 network-listener-bound=Ein Netzwerk-Listener wurde erfolgreich an die Adresse "{0$address$}" gebunden...
 network-listener-bound-exceptionally=Ein Netzwerk Listener konnte nicht auf "{0$address$}" gebunden werden\: {1$reason$}
 network-selected-transport=Netzwerkkomponenten verwenden {0$transport$} Transport
@@ -119,17 +117,17 @@ invalid-command-sender=Dieser Befehl kann nicht von ''{0$source$}'' ausgeführt 
 invalid-command-syntax=Ungültige Syntax\! Verwende {0$syntax$}
 no-such-command=Der Befehl konnte nicht gefunden werden\! Für Hilfe verwende den Befehl "help"
 argument-parse-failure-no-input-was-provided=Es wurde keine Eingabe gemacht
-argument-parse-failure-boolean=Die Eingabe {0$input$} ist kein boolescher Wert
-argument-parse-failure-number=Die Eingabe {0$input$} ist keine Zahl
-argument-parse-failure-char=Die Eingabe {0$input$} ist kein Zeichen
-argument-parse-failure-string=Die Eingabe {0$input$} ist kein Text
-argument-parse-failure-uuid=Die Eingabe {0$input$} ist keine eindeutige Id
-argument-parse-failure-enum=Die Eingabe {0$input$} entspricht nicht einem der folgenden {1$values$}
-argument-parse-failure-regex=Die Eingabe &b{1$input$}&r entspricht nicht dem Pattern &b{0$regex$}
-argument-parse-failure-duration=Die Eingabe {0$input$} ist keine Zeitspanne
-argument-parse-failure-flag-unknown=Die gegebene Flag {0$flag$} ist unbekannt
-argument-parse-failure-flag-duplicate-flag=Die gegebene Flag {0$flag$} kann nur einmal genutzt werden
-argument-parse-failure-flag-missing-argument=Das Argument für die Flag {0$flag$} fehlt
+argument-parse-failure-boolean=Die Eingabe &b{0$input$}&r ist kein boolescher Wert
+argument-parse-failure-number=Die Eingabe &b{0$input$}&r ist keine Zahl
+argument-parse-failure-char=Die Eingabe &b{0$input$}&r ist kein Zeichen
+argument-parse-failure-string=Die Eingabe &b{0$input$}&r ist kein Text
+argument-parse-failure-uuid=Die Eingabe &b{0$input$}&r ist keine eindeutige Id
+argument-parse-failure-enum=Die Eingabe &b{0$input$}&r entspricht nicht einem der folgenden {1$values$}
+argument-parse-failure-regex=Die Eingabe &b{0$input$}&r entspricht nicht dem Pattern &b{1$regex$}
+argument-parse-failure-duration=Die Eingabe &b{0$input$}&r ist keine Zeitspanne
+argument-parse-failure-flag-unknown=Die gegebene Flag &b{0$flag$}&r ist unbekannt
+argument-parse-failure-flag-duplicate-flag=Die gegebene Flag &b{0$flag$}&r kann nur einmal genutzt werden
+argument-parse-failure-flag-missing-argument=Das Argument für die Flag &b{0$flag$}&r fehlt
 argument-parse-failure-flag-no-permission=Es ist dir nicht gestattet die Flag zu verwenden
 missing-command-permission=Es ist dir nicht gestattet diesen Sub-Befehl auszuführen
 #
@@ -268,6 +266,7 @@ command-tasks-create-task=Der leere Task wurde erfolgreich erstellt. Dieser kann
 command-tasks-delete-task=Der Task {0$name$} wurde erfolgreich gelöscht
 command-tasks-node-not-found=Diese Node existiert nicht\!
 command-tasks-runtime-not-found=Die Runtime {0$runtime$} existiert nicht\!
+command-tasks-inclusion-cache-strategy-not-found=Die Inclusions Cache Strategie {0$strategy$} existiert nicht\!
 command-tasks-reload-success=Die Tasks wurden neu geladen\!
 command-tasks-add-collection-property={0$property$} {2$value$} wurde erfolgreich dem Task {1$task$} hinzugefügt
 command-tasks-set-property-success={0$property$} von dem Task {1$task$} wurde zu {2$value$} geändert


### PR DESCRIPTION
### Motivation
The crowdin automation has done some updates to our translations. We do not want to pull all changes from crowdin as some languages are poorly translated and not complete yet.

### Modification
Removed the usage of translations from the dev command as this command should rely on as little as possible.
Furthermore the changes from crowdin related to the german translations were pulled.

### Result
Correct german translations and no translations in the dev command anymore.