### PR TITLE
fix: disable spark async profiler on non-arm based systems

### DIFF
--- a/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/spark/OldAsyncProfilerDisableTransformer.java
+++ b/wrapper-jvm/src/main/java/eu/cloudnetservice/wrapper/transform/spark/OldAsyncProfilerDisableTransformer.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.transform.spark;
+
+import eu.cloudnetservice.common.util.StringUtil;
+import eu.cloudnetservice.wrapper.transform.ClassTransformer;
+import java.lang.classfile.ClassBuilder;
+import java.lang.classfile.ClassElement;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.MethodModel;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.reflect.AccessFlag;
+import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A transformer that explicitly disables the spark async profiler integration on old spark versions.
+ *
+ * @since 4.0
+ */
+@ApiStatus.Internal
+public final class OldAsyncProfilerDisableTransformer implements ClassTransformer {
+
+  private static final String MN_LOAD = "load";
+  private static final String MN_IS_LINUX_MUSL = "isLinuxMusl";
+  private static final String CNI_ASYNC_PROFILER_ACC_PREFIX = "me/lucko/spark/";
+  private static final String CNI_ASYNC_PROFILER_ACC_SUFFIX = "/common/sampler/async/AsyncProfilerAccess";
+  private static final ClassDesc CD_UNSUPPORTED_OP_EX = ClassDesc.of(UnsupportedOperationException.class.getName());
+  private static final MethodTypeDesc MTD_UNSUPPORTED_OP_EX_NEW =
+    MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_String);
+
+  /**
+   * Constructs a new instance of this transformer, usually done via SPI.
+   */
+  public OldAsyncProfilerDisableTransformer() {
+    // used by SPI
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull ClassTransform provideClassTransform() {
+    return new AsyncProfilerAccessClassTransform();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull TransformWillingness classTransformWillingness(@NonNull String internalClassName) {
+    var isAsyncProfilerAccessClass = internalClassName.startsWith(CNI_ASYNC_PROFILER_ACC_PREFIX)
+      && internalClassName.endsWith(CNI_ASYNC_PROFILER_ACC_SUFFIX);
+    return isAsyncProfilerAccessClass ? TransformWillingness.ACCEPT_ONCE : TransformWillingness.REJECT;
+  }
+
+  /**
+   * A transformer which replaces the {@code load} method to always throw an exception on {@code AsyncProfilerAccess} in
+   * case the async profiler is not supported.
+   *
+   * @since 4.0
+   */
+  private static final class AsyncProfilerAccessClassTransform implements ClassTransform {
+
+    // holds if the "isLinuxMusl" method exists in AsyncProfilerAccess - the method was removed
+    // alongside the async profiler 3 support which added the required java 23 support
+    private boolean isLinuxMuslExists = false;
+    // the bug only happens on amd64 systems, so on aarch system we can leave the profiler
+    // enabled even when running on the old version of it
+    private boolean isLinuxAarch64 = false;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void atStart(@NonNull ClassBuilder builder) {
+      var classModel = builder.original().orElseThrow(() -> new IllegalStateException("original not preset on remap"));
+      this.isLinuxMuslExists = classModel.methods().stream().anyMatch(methodModel -> {
+        var isStatic = methodModel.flags().has(AccessFlag.STATIC);
+        return isStatic && methodModel.methodName().equalsString(MN_IS_LINUX_MUSL);
+      });
+
+      var arch = StringUtil.toLower(System.getProperty("os.arch"));
+      var osName = StringUtil.toLower(System.getProperty("os.name"));
+      this.isLinuxAarch64 = osName.equals("linux") && arch.equals("aarch64");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void accept(@NonNull ClassBuilder builder, @NonNull ClassElement element) {
+      if (element instanceof MethodModel mm
+        && !this.isLinuxAarch64
+        && this.isLinuxMuslExists
+        && mm.flags().has(AccessFlag.STATIC)
+        && mm.methodName().equalsString(MN_LOAD)) {
+        builder.withMethodBody(mm.methodName(), mm.methodType(), mm.flags().flagsMask(), code -> code
+          .new_(CD_UNSUPPORTED_OP_EX)
+          .dup()
+          .ldc("this version of spark uses a version of async-profiler which does not support java 23+")
+          .invokespecial(CD_UNSUPPORTED_OP_EX, ConstantDescs.INIT_NAME, MTD_UNSUPPORTED_OP_EX_NEW)
+          .athrow());
+      } else {
+        builder.with(element);
+      }
+    }
+  }
+}

--- a/wrapper-jvm/src/main/resources/META-INF/services/eu.cloudnetservice.wrapper.transform.ClassTransformer
+++ b/wrapper-jvm/src/main/resources/META-INF/services/eu.cloudnetservice.wrapper.transform.ClassTransformer
@@ -23,3 +23,4 @@ eu.cloudnetservice.wrapper.transform.bukkit.WorldEditJava8DetectorTransformer
 eu.cloudnetservice.wrapper.transform.bukkit.FAWEWorldEditDownloadURLTransformer
 eu.cloudnetservice.wrapper.transform.minestom.MinestomStopCleanlyTransformer
 eu.cloudnetservice.wrapper.transform.netty.OldEpollDisableTransformer
+eu.cloudnetservice.wrapper.transform.spark.OldAsyncProfilerDisableTransformer


### PR DESCRIPTION
### Motivation
The async profiler version bundled with spark (which itself is bundled in modern paper versions) does not support java 23 and causes a seqfault when being executed which crashes at least all modern paper services running on amd64 systems:
```
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x000079c43ba06ecf, pid=39327, tid=39528
#
# JRE version: OpenJDK Runtime Environment (23.0+37) (build 23+37-2369)
# Java VM: OpenJDK 64-Bit Server VM (23+37-2369, mixed mode, sharing, tiered, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# C  [spark-502cce8be50-libasyncProfiler.so.tmp+0x6ecf]  NMethod::isNMethod()+0x1f
```

### Modification
Disable the async profiler integration in spark when an old version of the async profiler is used. The detection process of the async profiler version relies on a pull request to spark which is not yet merged (so we might need to change the detection process again when that happened). Additionally the issue does not happen on arm systems, therefore the async profiler is left enabled on these systems. The `load` method of `AsyncProfilerAccess` on matching spark versions is changed so that it always throws an exception that the async profiler is not available. The message of the exception is printed into the console when starting the profiler so that the user is informed why the profiler is disabled:
```
[23:22:44 INFO]: [spark] Starting background profiler...
[23:22:44 WARN]: [spark] Unable to initialise the async-profiler engine: this version of spark uses a version of async-profiler which does not support java 23+
[23:22:44 WARN]: [spark] Please see here for more information: https://spark.lucko.me/docs/misc/Using-async-profiler
```

### Result
Non-arm servers that run modern paper versions and all servers running spark with an old version of async-profiler will no longer segfault when starting up/the plugin is enabled.
