### PR TITLE
fix: add the default task setup back to the initial setup

### DIFF
--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -33,6 +33,7 @@ import eu.cloudnetservice.driver.network.def.NetworkConstants;
 import eu.cloudnetservice.driver.network.netty.NettyUtil;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.handler.RPCHandlerRegistry;
+import eu.cloudnetservice.driver.provider.ServiceTaskProvider;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.driver.registry.injection.Service;
 import eu.cloudnetservice.driver.template.TemplateStorage;
@@ -241,7 +242,8 @@ public final class Node {
   @Inject
   @Order(450)
   private void executeSetupIfRequired(
-    @NonNull DefaultInstallation installation
+    @NonNull DefaultInstallation installation,
+    @NonNull ServiceTaskProvider taskProvider
   ) {
     // execute the setup if needed
     installation.executeFirstStartSetup();

--- a/node/src/main/java/eu/cloudnetservice/node/Node.java
+++ b/node/src/main/java/eu/cloudnetservice/node/Node.java
@@ -243,6 +243,7 @@ public final class Node {
   @Order(450)
   private void executeSetupIfRequired(
     @NonNull DefaultInstallation installation,
+    // we have to inject the task provider here so that it registers the default task setup when initialized
     @NonNull ServiceTaskProvider taskProvider
   ) {
     // execute the setup if needed


### PR DESCRIPTION
### Motivation
After the removal of CloudPerms the initial setup did not contain the default task setup for `Lobby` and `Proxy` anymore because it only relied on the fact that the task provider was initialized before the setup was started. The removal of CloudPerms also removed that early init and thus the setup was not complete anymore.

### Modification
Added the task provider as parameter to the setup step of the node. Aerogel is forced to init the provider first and therefore the setup is registered before the actual start of the setup.

### Result
The default task setup is back.