### PR TITLE
fix: wrong java version in translation

### DIFF
--- a/node/src/main/resources/lang/de_DE.properties
+++ b/node/src/main/resources/lang/de_DE.properties
@@ -257,7 +257,7 @@ command-groups-rename-success=Die Gruppe {0$group$} wurde erfolgreich zu {1$new$
 #
 # Tasks
 #
-cloudnet-load-task-unsupported-java-version=Der Java Befehl wird von Task {0$task$} entfernt da er keine valide Java-Installation ist oder nicht kompatibel mit Java 22 ist
+cloudnet-load-task-unsupported-java-version=Der Java Befehl wird von Task {0$task$} entfernt da er keine valide Java-Installation ist oder nicht kompatibel mit Java 23 ist
 #
 # Command Tasks
 #

--- a/node/src/main/resources/lang/en_US.properties
+++ b/node/src/main/resources/lang/en_US.properties
@@ -257,7 +257,7 @@ command-groups-rename-success=The group {0$group$} was successfully renamed to {
 #
 # Tasks
 #
-cloudnet-load-task-unsupported-java-version=Removing java command from {0$task$} because it isn't a valid java installation or incompatible with Java 22
+cloudnet-load-task-unsupported-java-version=Removing java command from {0$task$} because it isn't a valid java installation or incompatible with Java 23
 #
 # Command Tasks
 #


### PR DESCRIPTION
### Motivation
The current message for the bad task java version still incorrectly says java 22 while it should be java 23.

### Modification
Replace Java 22 with Java 23.

### Result
The reason why the task java command setting was removed now shows the correct java version.
