### PR TITLE
[ci skip] build: increase max heap memory to 5GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.warning.mode=all
 org.gradle.logging.level=info
-org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx5G -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8


### PR DESCRIPTION
### Motivation
Our current gradle build setup easily runs out of memory.

### Modification
Increase the max build heap to 5GB.

### Result
Builds should now have enough memory and should not fail from time to time anymore.
