### PR TITLE
fix: simple v4 docker image build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:23-jre-headless AS build
+FROM azul/zulu-openjdk:23-jdk-crac AS build
 
 COPY . /home/cloudnet-build
 WORKDIR /home/cloudnet-build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   cloudnet:
     build:


### PR DESCRIPTION
# fix: simple v4 docker image build 
### Motivation
Using and debugging nightly in a Docker container environment.
I am getting build errors due to missing build tools and I think the jre is not enough to build cloudnet.

### Modification
- using jdk for the docker multipart build image
- remove legacy docker compose version

### Result
After using the jdk to build it, it works, what a miracle!

##### Other context
No, **a simple fix**
