### PR TITLE
fix: cloudnet luckperms does not load on bungeecord & nukkit

### DIFF
--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/BungeecordLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/BungeecordLuckPermsPlugin.java
@@ -30,6 +30,7 @@ import net.luckperms.api.LuckPermsProvider;
   name = "CloudNet-LuckPerms",
   authors = "CloudNetService",
   version = "@version@",
+  pluginFileNames = "bungee.yml",
   description = "Brings LuckPerms support to all server platforms",
   dependencies = @Dependency(name = "LuckPerms")
 )

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/NukkitLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/NukkitLuckPermsPlugin.java
@@ -31,6 +31,7 @@ import net.luckperms.api.LuckPermsProvider;
   name = "CloudNet-LuckPerms",
   version = "@version@",
   authors = "CloudNetService",
+  pluginFileNames = "nukkit.yml",
   description = "Brings LuckPerms support to all server platforms",
   dependencies = @Dependency(name = "LuckPerms")
 )

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/WaterDogLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/WaterDogLuckPermsPlugin.java
@@ -30,6 +30,7 @@ import net.luckperms.api.LuckPermsProvider;
   name = "CloudNet-LuckPerms",
   version = "@version@",
   authors = "CloudNetService",
+  pluginFileNames = "waterdog.yml",
   dependencies = @Dependency(name = "LuckPerms"),
   description = "Brings LuckPerms support to all server platforms"
 )


### PR DESCRIPTION
### Motivation
Due to the usage of platform inject we need to specify the name of the resulting plugin.yml. Bungeecord and nukkit lack that setting and therefore try to use the bukkit plugin.yml.

### Modification
Added the pluginFileName for nukkit & bungeecord according to their plugin loaders.

### Result
The cloudnet luckperms plugin works properly on these platforms.
