### PR TITLE
fix: NPE with not spawned npcs due to missing inventories

### DIFF
--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformSelectorEntity.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformSelectorEntity.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.modules.npc.NPC;
 import java.util.Set;
 import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface PlatformSelectorEntity<L, P, M, I, S> {
 
@@ -39,7 +40,7 @@ public interface PlatformSelectorEntity<L, P, M, I, S> {
 
   void executeAction(@NonNull P player, @NonNull NPC.ClickAction action);
 
-  @NonNull I selectorInventory();
+  @Nullable I selectorInventory();
 
   void handleInventoryInteract(@NonNull I inv, @NonNull P player, @NonNull M clickedItem);
 

--- a/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
+++ b/modules/npcs/src/main/java/eu/cloudnetservice/modules/npc/platform/bukkit/listener/BukkitFunctionalityListener.java
@@ -137,7 +137,7 @@ public final class BukkitFunctionalityListener implements Listener {
     // check if we can handle the event
     if (item != null && item.hasItemMeta() && inv != null && inv.getHolder() == null && clicker instanceof Player) {
       this.management.trackedEntities().values().stream()
-        .filter(npc -> npc.selectorInventory().equals(inv))
+        .filter(npc -> inv.equals(npc.selectorInventory()))
         .findFirst()
         .ifPresent(npc -> {
           event.setCancelled(true);


### PR DESCRIPTION
### Motivation
When an NPC is spawned, the inventory of the NPC is created too. But we only spawn NPCs if they are located in a loaded chunk, therefore we have them tracked, but they do not have a corresponding inventory yet. This leads to an NPE when interacting with an already spawned NPC.

### Modification
Turned around our equals check for inventories when processing clicks on items. This ensures that no NPE can occur.

### Result
Clicking on NPC selector items is working properly again.
