### PR TITLE
fix: properly include adventure in bridge jar

### DIFF
--- a/modules/bridge/build.gradle.kts
+++ b/modules/bridge/build.gradle.kts
@@ -52,19 +52,20 @@ tasks.withType<Jar> {
   manifest {
     attributes["paperweight-mappings-namespace"] = "mojang"
   }
-}
 
-tasks.withType<RemapJarTask> {
   // depend on adventure helper jar task
   dependsOn(":ext:adventure-helper:jar")
-  // base setup
-  archiveFileName.set(Files.bridge)
+
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   // includes all dependencies of runtimeImpl but excludes gson because we don't need it
   from(configurations.getByName("runtimeImpl").map { if (it.isDirectory) it else zipTree(it) })
   exclude {
     it.file.absolutePath.contains(setOf("com", "google", "gson").joinToString(separator = File.separator))
   }
+}
+
+tasks.withType<RemapJarTask> {
+  archiveFileName.set(Files.bridge)
 }
 
 loom {


### PR DESCRIPTION
### Motivation
Our update to fabric loom 1.9.2 resulted in bridge jars without adventure shaded into it.

### Modification
Moved our class copy to the jar task.

### Result
Adventure is shaded again.
