### PR TITLE
change login from PlayerSpawnEvent from AsyncPlayerConfigurationEvent

### DIFF
--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomPlayerManagementListener.java
@@ -28,6 +28,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventFilter;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.event.GlobalEventHandler;
+import net.minestom.server.event.player.AsyncPlayerConfigurationEvent;
 import net.minestom.server.event.player.PlayerDisconnectEvent;
 import net.minestom.server.event.player.PlayerSpawnEvent;
 
@@ -51,13 +52,13 @@ public final class MinestomPlayerManagementListener {
     // listen on these events and redirect them into the methods
     var node = EventNode.type("cloudnet-bridge", EventFilter.PLAYER);
     eventHandler.addChild(node
-      .addListener(PlayerSpawnEvent.class, this::handleLogin)
+      .addListener(AsyncPlayerConfigurationEvent.class, this::handleLogin)
       .addListener(PlayerSpawnEvent.class, this::handleJoin)
       .addListener(PlayerDisconnectEvent.class, this::handleDisconnect));
   }
 
-  private void handleLogin(@NonNull PlayerSpawnEvent event) {
-    if (!event.isFirstSpawn()) {
+  private void handleLogin(@NonNull AsyncPlayerConfigurationEvent event) {
+    if (!event.isFirstConfig()) {
       return;
     }
 


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
Maintainance kicks on minestom kick the player after he has joined. This causes join/leave messages for that player to be visible, even though he was disallowed to join.

### Modification
<!-- Describe the modification you've done to the codebase -->
I changed the event with the permission check from PlayerSpawnEvent to AsyncPlayerConfigurationEvent.
Permission systems have time to load the permission data before that time by using `AsyncPlayerPreLoginEvent`, and the player won't be in the world yet. Perfect time for permission checks to deny login.

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
The player properly gets denied on "login", not kicked right after he was able to join.

