### PR TITLE
Fix/template storage rpc

### DIFF
--- a/driver/api/src/main/java/eu/cloudnetservice/driver/template/TemplateStorage.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/template/TemplateStorage.java
@@ -352,7 +352,7 @@ public interface TemplateStorage extends AutoCloseable, Named {
    * @throws NullPointerException if the given template is null.
    */
   @NonNull
-  CompletableFuture<InputStream> zipTemplateAsync(@NonNull ServiceTemplate template);
+  CompletableFuture<@Nullable InputStream> zipTemplateAsync(@NonNull ServiceTemplate template);
 
   /**
    * Pulls the data of the given template into a temporary directory and zip it. When the returned input stream is
@@ -363,7 +363,7 @@ public interface TemplateStorage extends AutoCloseable, Named {
    * @throws NullPointerException if the given template is null.
    */
   @NonNull
-  CompletableFuture<ZipInputStream> openZipInputStreamAsync(@NonNull ServiceTemplate template);
+  CompletableFuture<@Nullable ZipInputStream> openZipInputStreamAsync(@NonNull ServiceTemplate template);
 
   /**
    * Deletes the given template completely from this template storage.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/PathObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/PathObjectSerializer.java
@@ -54,7 +54,7 @@ public final class PathObjectSerializer implements ObjectSerializer<Path> {
     @NonNull Type type,
     @NonNull ObjectMapper caller
   ) {
-    var pathUri = object.toUri().toString();
+    var pathUri = object.toAbsolutePath().toUri().toString();
     dataBuf.writeString(pathUri);
   }
 }

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
+import java.util.zip.ZipInputStream;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -93,6 +94,19 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
     }
   }
 
+  @Override
+  public @NonNull CompletableFuture<Boolean> deployDirectoryAsync(@NonNull ServiceTemplate target,
+    @NonNull Path directory, @Nullable Predicate<Path> filter) {
+    return TaskUtil.supplyAsync(() -> this.deployDirectory(target, directory, filter));
+  }
+
+  @Override
+  public @NonNull CompletableFuture<@Nullable ZipInputStream> openZipInputStreamAsync(
+    @NonNull ServiceTemplate template) {
+    return this.zipTemplateAsync(template)
+      .thenApply(inputStream -> inputStream == null ? null : new ZipInputStream(inputStream));
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -147,6 +161,12 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
     return this.openLocalOutputStream(template, path, FileUtil.createTempFile(), true);
   }
 
+  @Override
+  public @NonNull CompletableFuture<OutputStream> appendOutputStreamAsync(@NonNull ServiceTemplate template,
+    @NonNull String path) {
+    return TaskUtil.supplyAsync(() -> this.appendOutputStream(template, path));
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -156,6 +176,12 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
     @NonNull String path
   ) throws IOException {
     return this.openLocalOutputStream(template, path, FileUtil.createTempFile(), false);
+  }
+
+  @Override
+  public @NonNull CompletableFuture<OutputStream> newOutputStreamAsync(@NonNull ServiceTemplate template,
+    @NonNull String path) {
+    return TaskUtil.supplyAsync(() -> this.newOutputStream(template, path));
   }
 
   /**


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
RemoteTemplateStorage doesn't work with async transfers after refactor

### Modification
<!-- Describe the modification you've done to the codebase -->
Fix RemoteTemplateStorage
Serialize `java.nio.file.Path` as absolute path in transfers. Relative paths make no sense, the working directory changes when transferring

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->
Everything works again as it should

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
