### PR TITLE
fix: properly override template storage implementations for remote

### DIFF
--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
@@ -207,11 +207,8 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
     @NonNull Path directory,
     @Nullable Predicate<Path> filter
   ) {
-    try (var inputStream = ZipUtil.zipToStream(directory, filter)) {
-      return this.deployAsync(target, inputStream);
-    } catch (IOException exception) {
-      return CompletableFuture.completedFuture(false);
-    }
+    return TaskUtil.supplyAsync(() -> ZipUtil.zipToStream(directory, filter))
+      .thenCompose(stream -> this.deployAsync(target, stream));
   }
 
   /**

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
+import java.util.zip.ZipInputStream;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -86,11 +87,7 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
     @NonNull Path directory,
     @Nullable Predicate<Path> filter
   ) {
-    try (var inputStream = ZipUtil.zipToStream(directory, filter)) {
-      return this.deploy(target, inputStream);
-    } catch (IOException exception) {
-      return false;
-    }
+    return TaskUtil.getOrDefault(this.deployDirectoryAsync(target, directory, filter), false);
   }
 
   /**
@@ -127,15 +124,6 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
     return TaskUtil.getOrDefault(this.zipTemplateAsync(template), null);
   }
 
-  @Override
-  public @NonNull CompletableFuture<InputStream> zipTemplateAsync(@NonNull ServiceTemplate template) {
-    return ChunkedFileQueryBuilder.create()
-      .dataIdentifier("remote_templates_zip_template")
-      .requestFromNode(this.componentInfo.nodeUniqueId())
-      .configureMessageBuffer(buffer -> buffer.writeString(this.name).writeObject(template))
-      .query();
-  }
-
   /**
    * {@inheritDoc}
    */
@@ -156,6 +144,89 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
     @NonNull String path
   ) throws IOException {
     return this.openLocalOutputStream(template, path, FileUtil.createTempFile(), false);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @Nullable InputStream newInputStream(
+    @NonNull ServiceTemplate template,
+    @NonNull String path
+  ) throws IOException {
+    return TaskUtil.getOrDefault(this.newInputStreamAsync(template, path), null);
+  }
+
+  @Override
+  public @NonNull CompletableFuture<InputStream> zipTemplateAsync(@NonNull ServiceTemplate template) {
+    return ChunkedFileQueryBuilder.create()
+      .dataIdentifier("remote_templates_zip_template")
+      .requestFromNode(this.componentInfo.nodeUniqueId())
+      .configureMessageBuffer(buffer -> buffer.writeString(this.name).writeObject(template))
+      .query();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull CompletableFuture<ZipInputStream> openZipInputStreamAsync(@NonNull ServiceTemplate template) {
+    return this.zipTemplateAsync(template).thenApply(inputStream -> inputStream != null
+      ? new ZipInputStream(inputStream)
+      : null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull CompletableFuture<OutputStream> appendOutputStreamAsync(
+    @NonNull ServiceTemplate template,
+    @NonNull String path
+  ) {
+    return TaskUtil.supplyAsync(() -> this.appendOutputStream(template, path));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull CompletableFuture<OutputStream> newOutputStreamAsync(
+    @NonNull ServiceTemplate template,
+    @NonNull String path
+  ) {
+    return TaskUtil.supplyAsync(() -> this.newOutputStream(template, path));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull CompletableFuture<Boolean> deployDirectoryAsync(
+    @NonNull ServiceTemplate target,
+    @NonNull Path directory,
+    @Nullable Predicate<Path> filter
+  ) {
+    try (var inputStream = ZipUtil.zipToStream(directory, filter)) {
+      return this.deployAsync(target, inputStream);
+    } catch (IOException exception) {
+      return CompletableFuture.completedFuture(false);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull CompletableFuture<InputStream> newInputStreamAsync(
+    @NonNull ServiceTemplate template,
+    @NonNull String path
+  ) {
+    return ChunkedFileQueryBuilder.create()
+      .dataIdentifier("remote_templates_template_file")
+      .requestFromNode(this.componentInfo.nodeUniqueId())
+      .configureMessageBuffer(buffer -> buffer.writeString(this.name).writeObject(template).writeString(path))
+      .query();
   }
 
   /**
@@ -189,28 +260,5 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
         .build()
         .transferChunkedData()
         .join());
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public @Nullable InputStream newInputStream(
-    @NonNull ServiceTemplate template,
-    @NonNull String path
-  ) throws IOException {
-    return TaskUtil.getOrDefault(this.newInputStreamAsync(template, path), null);
-  }
-
-  @Override
-  public @NonNull CompletableFuture<InputStream> newInputStreamAsync(
-    @NonNull ServiceTemplate template,
-    @NonNull String path
-  ) {
-    return ChunkedFileQueryBuilder.create()
-      .dataIdentifier("remote_templates_template_file")
-      .requestFromNode(this.componentInfo.nodeUniqueId())
-      .configureMessageBuffer(buffer -> buffer.writeString(this.name).writeObject(template).writeString(path))
-      .query();
   }
 }

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
@@ -207,8 +207,11 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
     @NonNull Path directory,
     @Nullable Predicate<Path> filter
   ) {
-    return TaskUtil.supplyAsync(() -> ZipUtil.zipToStream(directory, filter))
-      .thenCompose(stream -> this.deployAsync(target, stream));
+    return TaskUtil.supplyAsync(() -> {
+      try (var inputStream = ZipUtil.zipToStream(directory, filter)) {
+        return this.deploy(target, inputStream);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
### Motivation
When api-impl splitting the RemoteTemplateStorage impl was not done correctly. Methods that handle file streams (in & out) were just called as usual RPCs which is not possible.

### Modification
This PR overrides the specific method implementations and uses the chunked file transfer api to transfer filestreams.

### Result
The template storage is working properly from the wrapper side.