### PR TITLE
fix: provide context class loader when transforming classes

### DIFF
--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/DefaultClassTransformerRegistry.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/DefaultClassTransformerRegistry.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.wrapper.transform.ClassTransformer;
 import eu.cloudnetservice.wrapper.transform.ClassTransformerRegistry;
 import jakarta.inject.Singleton;
 import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassHierarchyResolver;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.security.ProtectionDomain;
@@ -110,9 +111,15 @@ public final class DefaultClassTransformerRegistry implements ClassTransformerRe
       var transformerClassName = this.transformer.getClass().getName();
       LOGGER.debug("Transforming class {} using transformer {}", className, transformerClassName);
 
+      // use the class loader that is loading the class to transform as this loader
+      // must also know all relevant imported classes. by default this would be
+      // the system class loader, which might not have all necessary classes present
+      var classHierarchyResolver = ClassHierarchyResolver.ofClassLoading(loader);
+      var classHierarchyResolverOption = ClassFile.ClassHierarchyResolverOption.of(classHierarchyResolver);
+
       try {
         // apply the transformation to the provided class file
-        var classFile = ClassFile.of();
+        var classFile = ClassFile.of(classHierarchyResolverOption);
         var classModel = classFile.parse(classfileBuffer);
         var classTransform = this.transformer.provideClassTransform();
         return classFile.transform(classModel, classTransform);


### PR DESCRIPTION
### Motivation
When a class is currently being transformed the system class loader is used to provide access to classes that are required to build the final class file. However, this causes issues when classes are required that are not available to the system class loader, e.g. if dynamically loaded by the server software.

### Modification
Use the class loader of the class that is being transformed, as it must be able to provide all necessary classes to perform the transformation.

### Result
No more issues during class transforming due to unknown classes.
