### PR TITLE
fix: provide fallback when server dies on bungeecord

### DIFF
--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordPlayerManagementListener.java
@@ -133,17 +133,20 @@ public final class BungeeCordPlayerManagementListener implements Listener {
       }
     }
 
-    // initial connect reasons, LOBBY_FALLBACK will be used if the initial fallback is not present
-    if (event.getReason() == Reason.JOIN_PROXY || event.getReason() == Reason.LOBBY_FALLBACK) {
-      var target = this.management.fallback(player)
+    var serverDownRedirect = event.getReason() == Reason.SERVER_DOWN_REDIRECT;
+    var lobbyFallbackRedirect = event.getReason() == Reason.JOIN_PROXY || event.getReason() == Reason.LOBBY_FALLBACK;
+    if (serverDownRedirect || lobbyFallbackRedirect) {
+      var fallback = this.management.fallback(player)
         .map(service -> this.proxyServer.getServerInfo(service.name()))
         .orElse(null);
-      if (target != null) {
-        // fallback found, connect to the fallback
-        event.setTarget(target);
-      } else {
-        // no fallback found, disconnect the player
-        event.setCancelled(true);
+      if (fallback != null) {
+        event.setTarget(fallback);
+        return;
+      }
+
+      // no fallback found, disconnect the player with the correct reason according to the connect reason
+      event.setCancelled(true);
+      if (lobbyFallbackRedirect) {
         var kickMessage = this.management.configuration().findMessage(
           player.getLocale(),
           "proxy-join-disconnect-because-no-hub",
@@ -153,6 +156,11 @@ public final class BungeeCordPlayerManagementListener implements Listener {
         if (kickMessage != null) {
           player.disconnect(kickMessage);
         }
+      } else {
+        var kickedFrom = player.getServer().getInfo();
+        var disconnectReason = new TextComponent("Disconnected by Server");
+        var kickReason = this.buildKickReasonMessage(player, kickedFrom, disconnectReason, "server-kick-no-other-hub");
+        player.disconnect(kickReason);
       }
     }
   }


### PR DESCRIPTION
### Motivation
Currently, when a server unexpectedly closes the connection to the proxy, the player gets disconnected as CloudNet does not provide a fallback server. This is due to the fact that the ServerKickEvent is only called when the server sends a kick packet. In case the server goes down, BungeeCord tries to connect the player to the first priority (in our case a dummy `lobby` server as BungeeCord won't start without a priority) with the connection reason `SERVER_DOWN_REDIRECT`. We can catch this reason and provide a proper fallback in `ServerConnectEvent`.

### Modification
Catch the `SERVER_DOWN_REDIRECT` reason in `ServerConnectEvent` and provide a proper fallback. If no fallback is available, disconnect the player with the new disconnection reason introduced in #1399.

### Result
Players will be provided with a proper fallback in case of an unexpected connection close by the downstream service instead of being disconnected.
