### PR TITLE
fix: syncproxy module does not reload config file

### DIFF
--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/CloudNetSyncProxyModule.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/CloudNetSyncProxyModule.java
@@ -23,7 +23,6 @@ import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.driver.module.ModuleLifeCycle;
 import eu.cloudnetservice.driver.module.ModuleTask;
 import eu.cloudnetservice.driver.module.driver.DriverModule;
-import eu.cloudnetservice.driver.registry.Service;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.modules.syncproxy.SyncProxyManagement;
 import eu.cloudnetservice.modules.syncproxy.config.SyncProxyConfiguration;
@@ -38,10 +37,13 @@ import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import java.nio.file.Files;
 import lombok.NonNull;
-import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public final class CloudNetSyncProxyModule extends DriverModule {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CloudNetSyncProxyModule.class);
 
   @Inject
   public CloudNetSyncProxyModule(@NonNull @Named("module") InjectionLayer<?> layer) {
@@ -113,13 +115,12 @@ public final class CloudNetSyncProxyModule extends DriverModule {
   }
 
   @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
-  public void handleReload(@Nullable @Service SyncProxyManagement management) {
-    if (management != null) {
-      management.configuration(this.loadConfiguration());
-    }
+  public void handleReload(@NonNull SyncProxyManagement management) {
+    management.configuration(this.loadConfiguration());
   }
 
   private @NonNull SyncProxyConfiguration loadConfiguration() {
+    LOGGER.debug("Loading SyncProxy module configuration");
     return this.readConfig(
       SyncProxyConfiguration.class,
       () -> SyncProxyConfiguration.createDefault("Proxy"),


### PR DESCRIPTION
### Motivation
An user reported that the `modules reload CloudNet-SyncProxy` command would reload the SyncProxy module but the module would not update the loaded configuration due to a wrongly placed `@Service` annotation.

### Modification
Removed the wrong `@Service` annotation and the unnecessary null check. The management class is created by aerogel. If aerogel cannot find it / construct it, aerogel will throw an exception.

### Result
The module configuration is properly reloaded on module reload.

##### Other context
See https://discord.com/channels/325362837184577536/818777626663321671/1357362934732292187
