### PR TITLE
fix: dockerized-services module image handling

### DIFF
--- a/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerImage.java
+++ b/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerImage.java
@@ -31,9 +31,33 @@ public record DockerImage(
     return new Builder();
   }
 
+  /**
+   * Constructs a valid image tag as described in <a
+   * href="https://docs.docker.com/reference/cli/docker/image/tag/#description">Docker documentation</a>.
+   *
+   * @return an image tag based on the components provided to this image.
+   */
   public @NonNull String imageName() {
-    // append the tag if given, if not docker will just use the latest image
-    return this.repository + (this.tag == null ? "" : String.format(":%s", this.tag));
+    var nameBuilder = new StringBuilder();
+
+    // append registry to use, if given
+    if (this.registry != null && !this.registry.isBlank()) {
+      nameBuilder.append(this.registry).append('/');
+    }
+
+    // append namespace/repository that contains the image
+    nameBuilder.append(this.repository);
+
+    // append tag, either latest (tag not specified), @sha256:<hash> or :<tag>
+    if (this.tag == null || this.tag.isBlank()) {
+      nameBuilder.append(":latest");
+    } else if (this.tag.startsWith("sha256:")) {
+      nameBuilder.append('@').append(this.tag);
+    } else {
+      nameBuilder.append(':').append(this.tag);
+    }
+
+    return nameBuilder.toString();
   }
 
   public static final class Builder {

--- a/modules/dockerized-services/api/src/test/java/eu/cloudnetservice/modules/docker/config/DockerImageTest.java
+++ b/modules/dockerized-services/api/src/test/java/eu/cloudnetservice/modules/docker/config/DockerImageTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.modules.docker.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DockerImageTest {
+
+  @Test
+  void testDockerImageRequiredRepository() {
+    Assertions.assertThrows(NullPointerException.class, () -> DockerImage.builder().build());
+    Assertions.assertDoesNotThrow(() -> DockerImage.builder().repository("test").build());
+  }
+
+  @Test
+  void testDockerImageNameWithoutTag() {
+    var imageNullTag = DockerImage.builder().repository("test").build();
+    Assertions.assertEquals("test:latest", imageNullTag.imageName());
+
+    var imageEmptyTag = DockerImage.builder().repository("test").tag("").build();
+    Assertions.assertEquals("test:latest", imageEmptyTag.imageName());
+  }
+
+  @Test
+  void testDockerImageWithNamedTag() {
+    var image = DockerImage.builder().repository("test").tag("1.2.3").build();
+    Assertions.assertEquals("test:1.2.3", image.imageName());
+  }
+
+  @Test
+  void testDockerImageWithShaInsteadOfTag() {
+    var image = DockerImage.builder()
+      .repository("test")
+      .tag("sha256:42386c60700180ff9df762c8e091417b294336bb3e579413ff0ed34a14c2d4d5")
+      .build();
+    Assertions.assertEquals(
+      "test@sha256:42386c60700180ff9df762c8e091417b294336bb3e579413ff0ed34a14c2d4d5",
+      image.imageName());
+  }
+
+  @Test
+  void testDockerImageWithRegistry() {
+    var image = DockerImage.builder().registry("quay.io").repository("test").build();
+    Assertions.assertEquals("quay.io/test:latest", image.imageName());
+  }
+
+  @Test
+  void testDockerImageWithEverythingSet() {
+    var imageWithTagName = DockerImage.builder()
+      .registry("quay.io")
+      .repository("immobrain/zulu-openjdk-noble")
+      .tag("23")
+      .build();
+    Assertions.assertEquals("quay.io/immobrain/zulu-openjdk-noble:23", imageWithTagName.imageName());
+
+    var imageWithSha = DockerImage.builder()
+      .registry("quay.io")
+      .repository("immobrain/zulu-openjdk-noble")
+      .tag("sha256:42386c60700180ff9df762c8e091417b294336bb3e579413ff0ed34a14c2d4d5")
+      .build();
+    Assertions.assertEquals(
+      "quay.io/immobrain/zulu-openjdk-noble@sha256:42386c60700180ff9df762c8e091417b294336bb3e579413ff0ed34a14c2d4d5",
+      imageWithSha.imageName());
+  }
+}

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedService.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedService.java
@@ -238,6 +238,7 @@ public class DockerizedService extends JVMService {
         .withVolumes(volumes)
         .withEntrypoint(arguments)
         .withStopSignal("SIGTERM")
+        .withPlatform(image.platform())
         .withExposedPorts(exposedPorts)
         .withName(this.serviceId().name() + "_" + this.serviceId().uniqueId())
         .withWorkingDir(this.serviceDirectory.toAbsolutePath().toString())
@@ -378,19 +379,11 @@ public class DockerizedService extends JVMService {
   }
 
   protected @NonNull PullImageCmd buildPullCommand(@NonNull DockerImage image) {
-    var cmd = this.dockerClient.pullImageCmd(image.repository());
-    // append the tag if given
-    if (image.tag() != null) {
-      cmd.withTag(image.tag());
-    }
-    // append the registry if given
-    if (image.registry() != null) {
-      cmd.withRegistry(image.registry());
-    }
-    // append the platform if given
+    var cmd = this.dockerClient.pullImageCmd(image.imageName());
     if (image.platform() != null) {
-      cmd.withPlatform(image.platform());
+      cmd = cmd.withPlatform(image.platform());
     }
+
     return cmd;
   }
 


### PR DESCRIPTION
### Motivation
The current docker module implementation is not able to handle custom registries correctly. This is due to 2 issues:
1. The registry was not correctly preprended to image names generated by `DockerImage#imageName`
2. The PullImageCmd construction used `PullImageCmd#withRegistry` which doesn't do anything (and never did something, the query option was never implemented in the docker api as far as I could tell)

### Modification
1. Fix `DockerImage#imageName` to correctly handle registries. I've also added support for SHA256 image digests to be used instead of image tags. Also added a test to validate that the outcome of `DockerImage#imageName` is valid.
2. No longer rely on `PullImageCmd#withRegistry`, supplying the full docker image name constructed by `DockerImage#imageName` is sufficient along with supplying the platform.
3. Supply the docker image platform to CreateContainerCmd to actually select the image for the requested platform.

### Result
Custom docker registries and docker image platforms work as expected.
