### PR TITLE
ci: let explicit workflow dispatch also publish launcher metadata

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Publish updater metadata
         uses: s0/git-publish-subdir-action@develop
-        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/renovate/') && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
+        if: ${{ !startsWith(github.ref, 'refs/heads/renovate/') && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
         env:
           REPO: git@github.com:CloudNetService/launchermeta.git
           BRANCH: ${{ steps.branch-name.outputs.current_branch }}


### PR DESCRIPTION
### Motivation
Currently a workflow dispatch is not allowed to publish new launcher metadata.

### Modification
Allow workflow dispatches to update launcher metadata.

### Result
Launcher metadata can be updated by manually dispatching the build workflow.
