### PR TITLE
Add service uuid to LuckPerms context

### DIFF
--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/CloudNetContextCalculator.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/CloudNetContextCalculator.java
@@ -40,6 +40,7 @@ public class CloudNetContextCalculator implements StaticContextCalculator {
     var serviceId = this.wrapperConfiguration.serviceConfiguration().serviceId();
 
     contextSet.add("service", serviceId.name());
+    contextSet.add("service-uuid", serviceId.uniqueId().toString());
     contextSet.add("task", serviceId.taskName());
     contextSet.add("node", serviceId.nodeUniqueId());
     contextSet.add("environment", serviceId.environmentName());


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->
Add the uuid from the service as a LuckPerms context

### Modification
<!-- Describe the modification you've done to the codebase -->
So you have an unique way to identify a service with LuckPerms (for example for private rounds)

### Result
The `service-uuid`-property was added to the context

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
Fixes #
