### PR TITLE
ci: fine-tune the build action a bit

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,7 +6,6 @@ on:
     tags-ignore: [ "**" ]
   pull_request:
   workflow_dispatch:
-  merge_group:
 
 concurrency:
   cancel-in-progress: true
@@ -46,10 +45,11 @@ jobs:
         run: ./gradlew build test shadowJar genUpdaterInformation --stacktrace
 
       - name: Publish test summary
-        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
+        if: ${{ always() }}
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          junit_files: "**/build/test-results/test/TEST-*.xml"
+          files: "**/build/test-results/test/TEST-*.xml"
+          comment_mode: ${{ github.event_name == 'pull_request' && 'always' || 'off' }}
 
       - name: Get branch name
         id: branch-name
@@ -57,7 +57,7 @@ jobs:
 
       - name: Publish updater metadata
         uses: s0/git-publish-subdir-action@develop
-        if: ${{ !startsWith(github.ref, 'refs/heads/renovate/') && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
+        if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/heads/renovate/') }}
         env:
           REPO: git@github.com:CloudNetService/launchermeta.git
           BRANCH: ${{ steps.branch-name.outputs.current_branch }}
@@ -77,14 +77,13 @@ jobs:
           fi
 
       - name: Publish snapshot to Sonatype
-        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
+        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') }}
         run: ./gradlew publish
         env:
           SONATYPE_USER: "${{ secrets.SONATYPE_USER }}"
           SONATYPE_TOKEN: "${{ secrets.SONATYPE_TOKEN }}"
 
       - name: Prepare artifacts zip
-        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
         run: |
           mkdir -p temp/;
           mkdir -p temp/plugins;
@@ -97,7 +96,6 @@ jobs:
 
       - name: Upload artifacts zip
         uses: actions/upload-artifact@v4
-        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
         with:
           name: CloudNet
           path: temp/


### PR DESCRIPTION
### Motivation
The build action needs some fine tuning and cleanup as it does not work as expected in some scenarios.

### Modification
1. Remove all references to the old github merge queue experiment, this is no longer needed and is annoying when reading the action.
2. Replace deprecated `junit_files` input of the unit test publish action and always publish unit tests results. Comments on pull requests are now disabled unless the action is triggered by a pull request (to prevent duplicate comments for pushes and the pull request run).
3. The updater metadata is now only published if the action is triggered by a push or workflow dispatch.
4. Artifacts generated by the action are now always uploaded (there is no reason to not do it).

### Result
The build action is easier to read and behaves more as expected.