### PR TITLE
build: remove outdated oss.sonatype repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,15 +34,15 @@ allprojects {
     releasesOnly(mavenCentral())
 
     // old and new sonatype snapshot repository
-    snapshotsOnly(maven("https://oss.sonatype.org/content/repositories/snapshots/"))
+    snapshotsOnly(maven("https://central.sonatype.com/repository/maven-snapshots/"))
     snapshotsOnly(maven("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
-
-    // must be after sonatype as sponge mirrors sonatype which leads to outdated dependencies
-    maven("https://repo.spongepowered.org/maven/")
 
     // ensure that we use these repositories for snapshots/releases only (improves lookup times)
     releasesOnly(maven("https://repository.derklaro.dev/releases/"))
     snapshotsOnly(maven("https://repository.derklaro.dev/snapshots/"))
+
+    // must be after sonatype as sponge mirrors sonatype which leads to outdated dependencies
+    maven("https://repo.spongepowered.org/maven/")
   }
 }
 


### PR DESCRIPTION
### Motivation
The `oss.sonatype.org` repository is outdated and will be shut down soon. The only usage we current have is netty.

### Modification
Replace the `oss.sonatype.org` repository with the new `central.sonatype.com` repository. Netty artifacts are downloaded from my mirror for the time being, especially due to issues with smapshot retention that started to arise in the past days. Once netty is migrated to the new `central.sonatype.com` snapshot repo, the build will automatically start using the artifacts from there.

### Result
No more usages of the outdated `oss.sonatype.org` repository.
