### PR TITLE
build: replace publishing to ossrh with central portal

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -27,7 +27,7 @@ jobs:
           cache-read-only: true
           add-job-summary: always
 
-      - name: Publish release to Sonatype
+      - name: Publish release to central portal
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
           CENTRAL_USER: "${{ secrets.CENTRAL_USER }}"

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Publish release to Sonatype
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
-          SONATYPE_USER: "${{ secrets.SONATYPE_USER }}"
-          SONATYPE_TOKEN: "${{ secrets.SONATYPE_TOKEN }}"
+          CENTRAL_USER: "${{ secrets.CENTRAL_USER }}"
+          CENTRAL_PASSWORD: "${{ secrets.CENTRAL_PASSWORD }}"
           SIGNING_KEY: "${{ secrets.SIGNING_KEY }}"
           SIGNING_KEY_PASSWORD: "${{ secrets.SIGNING_KEY_PASSWORD }}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -77,7 +77,7 @@ jobs:
           fi
 
       - name: Publish snapshot to central portal
-        if: ${{ github.event_name == 'push' && env.STATUS != 'release' }}
+        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') }}
         run: ./gradlew publish
         env:
           CENTRAL_USER: "${{ secrets.CENTRAL_USER }}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -76,12 +76,12 @@ jobs:
             echo "STATUS=release" >> $GITHUB_ENV
           fi
 
-      - name: Publish snapshot to Sonatype
+      - name: Publish snapshot to central portal
         if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') }}
         run: ./gradlew publish
         env:
-          SONATYPE_USER: "${{ secrets.SONATYPE_USER }}"
-          SONATYPE_TOKEN: "${{ secrets.SONATYPE_TOKEN }}"
+          CENTRAL_USER: "${{ secrets.CENTRAL_USER }}"
+          CENTRAL_PASSWORD: "${{ secrets.CENTRAL_PASSWORD }}"
 
       - name: Prepare artifacts zip
         run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -77,7 +77,7 @@ jobs:
           fi
 
       - name: Publish snapshot to central portal
-        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') }}
+        if: ${{ github.event_name == 'push' && env.STATUS != 'release' }}
         run: ./gradlew publish
         env:
           CENTRAL_USER: "${{ secrets.CENTRAL_USER }}"

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ To add the CloudNet dependency using maven (replace `%version%` with the latest 
 
 ## Snapshots
 
-Snapshots for CloudNet are build off the `nightly` branch and are available from the sonatype snapshot repository:
-`https://s01.oss.sonatype.org/content/repositories/snapshots/`. You can declare a dependency on CloudNet as shown above
+Snapshots for CloudNet are build off the `nightly` branch and are available from the central portal snapshot repository:
+`https://central.sonatype.com/repository/maven-snapshots/`. You can declare a dependency on CloudNet as shown above
 just append the `-SNAPSHOT` suffix to the version.
 
 ## Links

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,11 +179,11 @@ tasks.register("globalJavaDoc", Javadoc::class) {
 nexusPublishing {
   repositories {
     sonatype {
-      nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-      snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
 
-      username.set(System.getenv("SONATYPE_USER"))
-      password.set(System.getenv("SONATYPE_TOKEN"))
+      username.set(System.getenv("CENTRAL_USER"))
+      password.set(System.getenv("CENTRAL_PASSWORD"))
     }
   }
 


### PR DESCRIPTION
### Motivation
OSSRH will be shut down at the end of next month and we should migrate our build to use the central portal instead.

### Modification
Replace publishing to OSSRH with central portal.

### Result
Snapshots and releases are published using the central portal instead of the old OSSRH.
