### PR TITLE
fix: language question result conversion in default setup

### DIFF
--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultConfigSetup.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultConfigSetup.java
@@ -217,7 +217,8 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
   @Override
   public void handleResults(@NonNull ConsoleSetupAnimation animation) {
     // language
-    this.configuration.language(animation.result("language"));
+    Locale selectedLanguage = animation.result("language");
+    this.configuration.language(selectedLanguage.toLanguageTag());
 
     // init the local node identity
     HostAndPort host = animation.result("internalHost");


### PR DESCRIPTION
### Motivation
The code for selecting the language in the default task setup was changed to use locales instead of strings, however the result handling was not changed accordingly. This results in a class cast exception when the results are being processed.

### Modification
Change the default setup result handler to use locales instead of strings.

### Result
No more class cast exceptions when completing the default config setup.
