### PR TITLE
fix: handle SIGHUP in launcher-patcher to prevent exits before updating

### DIFF
--- a/launcher/patcher/src/main/java/eu/cloudnetservice/launcher/patcher/CloudNetLauncherPatcher.java
+++ b/launcher/patcher/src/main/java/eu/cloudnetservice/launcher/patcher/CloudNetLauncherPatcher.java
@@ -31,19 +31,23 @@ public final class CloudNetLauncherPatcher {
 
   public static void main(@NonNull String[] args) {
     try {
-      // the jvm has a signal handler for SIGHUP, which would stop the jvm
-      // tmux and screen use SIGHUP to signal the process that the session closed
+      // the jvm has a signal handler for SIGHUP, which exists the jvm when received
+      // tmux and screen use SIGHUP to signal the process that the session closed; however,
+      // this shouldn't prevent the patching process from running anyway
       Signal.handle(new Signal("HUP"), SignalHandler.SIG_IGN);
-    } catch (IllegalArgumentException exception) {
-      printf(System.err, "Signal handler registration failed: %s", exception.getMessage());
+    } catch (Throwable throwable) {
+      printf(System.err, "Unable to register signal handler: %s", throwable.getMessage());
     }
 
-    // validate that we got all required args to run (<pid> <old launcher> <new launcher>)
+    // validate that we got all required args to run (<pid> <launcher path> <new launcher path>)
     if (args.length == 3) {
       var launcherPid = Long.parseLong(args[0]);
-      var oldLauncherPath = Path.of(args[1]);
+      var launcherPath = Path.of(args[1]);
       var newLauncherPath = Path.of(args[2]);
-      printf(System.out, "Picked up options: %s -> %s (pid: %d)", oldLauncherPath, newLauncherPath, launcherPid);
+      printf(System.out, "Picked up options:");
+      printf(System.out, " - Launcher PID: %d", launcherPid);
+      printf(System.out, " - Launcher Path: %s", launcherPath);
+      printf(System.out, " - New Launcher Path: %s", newLauncherPath);
 
       // wait for the process to terminate by joining it (to block the current thread)
       ProcessHandle.of(launcherPid).ifPresent(handle -> handle.onExit()
@@ -54,23 +58,20 @@ public final class CloudNetLauncherPatcher {
         })
         .join());
 
-      printf(System.out, "Running patcher on file %s", oldLauncherPath);
-      replaceOldLauncher(oldLauncherPath, newLauncherPath);
+      printf(System.out, "Copying new launcher file...");
+      replaceOldLauncher(launcherPath, newLauncherPath);
     }
-  }
-
-  private static void printf(@NonNull PrintStream stream, @NonNull String format, Object... args) {
-    // CHECKSTYLE.OFF: Launcher has no proper logger
-    stream.printf(format + "%n", args);
-    // CHECKSTYLE.ON
   }
 
   private static void replaceOldLauncher(@NonNull Path oldPath, @NonNull Path newPath) {
     try {
-      // move the new file to the location of the old file
       Files.copy(newPath, oldPath, StandardCopyOption.REPLACE_EXISTING);
     } catch (IOException exception) {
       throw new UncheckedIOException(exception);
     }
+  }
+
+  private static void printf(@NonNull PrintStream target, @NonNull String format, @NonNull Object... args) {
+    target.printf(format + "%n", args);
   }
 }

--- a/launcher/patcher/src/main/java/eu/cloudnetservice/launcher/patcher/CloudNetLauncherPatcher.java
+++ b/launcher/patcher/src/main/java/eu/cloudnetservice/launcher/patcher/CloudNetLauncherPatcher.java
@@ -17,32 +17,52 @@
 package eu.cloudnetservice.launcher.patcher;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 public final class CloudNetLauncherPatcher {
 
   public static void main(@NonNull String[] args) {
+    try {
+      // the jvm has a signal handler for SIGHUP, which would stop the jvm
+      // tmux and screen use SIGHUP to signal the process that the session closed
+      Signal.handle(new Signal("HUP"), SignalHandler.SIG_IGN);
+    } catch (IllegalArgumentException exception) {
+      printf(System.err, "Signal handler registration failed: %s", exception.getMessage());
+    }
+
     // validate that we got all required args to run (<pid> <old launcher> <new launcher>)
     if (args.length == 3) {
       var launcherPid = Long.parseLong(args[0]);
       var oldLauncherPath = Path.of(args[1]);
       var newLauncherPath = Path.of(args[2]);
-      // just for debug reasons
-      // CHECKSTYLE.OFF: Launcher has no proper logger
-      System.out.printf("Picked up options: %s -> %s (pid: %d)%n", oldLauncherPath, newLauncherPath, launcherPid);
-      // CHECKSTYLE.ON
+      printf(System.out, "Picked up options: %s -> %s (pid: %d)", oldLauncherPath, newLauncherPath, launcherPid);
+
       // wait for the process to terminate by joining it (to block the current thread)
-      ProcessHandle.of(launcherPid).ifPresent(handle -> handle.onExit().join());
-      // the process doesn't exist or terminated - run the updater now
-      // CHECKSTYLE.OFF: Launcher has no proper logger
-      System.out.printf("Running patcher on file %s%n", oldLauncherPath);
-      // CHECKSTYLE.ON
+      ProcessHandle.of(launcherPid).ifPresent(handle -> handle.onExit()
+        .orTimeout(5, TimeUnit.SECONDS)
+        .exceptionally(__ -> {
+          printf(System.err, "Launcher process did not terminate in time, running patcher anyway");
+          return null;
+        })
+        .join());
+
+      printf(System.out, "Running patcher on file %s", oldLauncherPath);
       replaceOldLauncher(oldLauncherPath, newLauncherPath);
     }
+  }
+
+  private static void printf(@NonNull PrintStream stream, @NonNull String format, Object... args) {
+    // CHECKSTYLE.OFF: Launcher has no proper logger
+    stream.printf(format + "%n", args);
+    // CHECKSTYLE.ON
   }
 
   private static void replaceOldLauncher(@NonNull Path oldPath, @NonNull Path newPath) {


### PR DESCRIPTION
### Motivation
The launcher-patcher tries to update the launcher.jar after the node & launcher exit. This process did not work when `screen` or `tmux` was used to start the launcher due to the fact that they send a `SIGHUG` signal and the JVM handles the signal and stops the still running (waiting) launcher-patcher. This required users to download the launcher themselves when we did changes to the launcher.

### Modification
Introduced a handler for `SIGHUP` in the launcher-patcher that ignores the signal. Furthermore, this introduces a 5 second timeout  when waiting for the launcher to exit before running the patcher as the launcher should not take that long to stop and to prevent replacing the next running launcher instance getting replaced while running. 

### Result
Launcher updates are properly working when using `screen` or `tmux`