### PR TITLE
fix: singleton annotation locations

### DIFF
--- a/node/api/src/main/java/eu/cloudnetservice/node/config/Configuration.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/config/Configuration.java
@@ -20,12 +20,10 @@ import eu.cloudnetservice.driver.cluster.NetworkCluster;
 import eu.cloudnetservice.driver.cluster.NetworkClusterNode;
 import eu.cloudnetservice.driver.document.Document;
 import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
-import jakarta.inject.Singleton;
 import java.util.Collection;
 import java.util.Map;
 import lombok.NonNull;
 
-@Singleton
 public interface Configuration {
 
   boolean fileExists();

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/config/JsonConfiguration.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/config/JsonConfiguration.java
@@ -46,7 +46,6 @@ import java.util.UUID;
 import java.util.function.Function;
 import lombok.NonNull;
 
-@Singleton
 public final class JsonConfiguration implements Configuration {
 
   public static final Path CONFIG_FILE_PATH = Path.of(
@@ -131,6 +130,7 @@ public final class JsonConfiguration implements Configuration {
   }
 
   @Factory
+  @Singleton
   private static @NonNull Configuration loadFromFile(@NonNull DefaultInstallation installation) {
     if (Files.notExists(CONFIG_FILE_PATH)) {
       // register the setup if the file does not exist

--- a/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/configuration/WrapperConfiguration.java
+++ b/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/configuration/WrapperConfiguration.java
@@ -20,7 +20,6 @@ import eu.cloudnetservice.driver.network.HostAndPort;
 import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
-import jakarta.inject.Singleton;
 import lombok.NonNull;
 
 /**
@@ -29,7 +28,6 @@ import lombok.NonNull;
  *
  * @since 4.0
  */
-@Singleton
 public interface WrapperConfiguration {
 
   /**

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/configuration/DocumentWrapperConfiguration.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/configuration/DocumentWrapperConfiguration.java
@@ -23,6 +23,7 @@ import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
+import jakarta.inject.Singleton;
 import java.nio.file.Path;
 import lombok.NonNull;
 
@@ -37,6 +38,7 @@ public record DocumentWrapperConfiguration(
     System.getProperty("cloudnet.wrapper.config.path", ".wrapper/wrapper.json"));
 
   @Factory
+  @Singleton
   public static @NonNull WrapperConfiguration load() {
     return DocumentFactory.json().parse(WRAPPER_CONFIG_PATH).toInstanceOf(DocumentWrapperConfiguration.class);
   }


### PR DESCRIPTION
### Motivation
Some singleton annotations were located at the wrong places and should be moved to their respective factory methods.

### Modification
The singleton annotation for the node configuration was located both on the implementation and the interface. This is not acceptable as scope annotations are not allowed on interfaces/abstract classes and the implementation is not relevant to the binding builder, therefore the annotation was ignored there anyway. Same applies to the wrapper configuration.

### Result
The singleton scope annotations are now located at the factory methods rather than at locations where they don't have any effect.
