### PR TITLE
Make the useful of suggestion in node console from services.

### DIFF
--- a/driver/api/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
@@ -201,6 +201,14 @@ public interface SpecificCloudServiceProvider {
   void runCommand(@NonNull String command);
 
   /**
+   * Gets the console-suggestion(tab-complete) using ChannelMessage, if it is not supported, the response will get empty list.
+   *
+   * @param line the command line currently
+   * @return fully command list if supported
+   */
+  Collection<String> consoleSuggestion(@NonNull String line);
+
+  /**
    * Gets the templates that actually are installed on the service. If a template is present in the configuration
    * {@link eu.cloudnetservice.driver.service.ServiceConfiguration} but wasn't pulled onto the service it won't appear
    * in this collection.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformBridgeManagement.java
@@ -54,6 +54,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -210,6 +211,10 @@ public abstract class PlatformBridgeManagement<P, I> implements InternalBridgeMa
         this.cachedServices.remove(snapshot.serviceId().uniqueId());
       }
     }
+  }
+
+  public @NonNull List<String> consoleSuggestion(@NonNull String line) {
+    return List.of();
   }
 
   public @NonNull Optional<ServiceInfoSnapshot> fallback(

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitBridgeManagement.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.modules.bridge.impl.platform.bukkit;
 
+import dev.derklaro.reflexion.Reflexion;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.network.NetworkClient;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
@@ -32,18 +33,21 @@ import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
 import eu.cloudnetservice.modules.bridge.player.PlayerManager;
 import eu.cloudnetservice.modules.bridge.player.ServicePlayer;
 import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
+import eu.cloudnetservice.utils.base.concurrent.TaskUtil;
 import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
 import eu.cloudnetservice.wrapper.event.ServiceInfoPropertiesConfigureEvent;
 import eu.cloudnetservice.wrapper.holder.ServiceInfoHolder;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
+import org.bukkit.command.CommandMap;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permissible;
 import org.bukkit.plugin.Plugin;
@@ -57,6 +61,7 @@ final class BukkitBridgeManagement extends PlatformBridgeManagement<Player, Netw
 
   private final Server server;
   private final Plugin plugin;
+  private final Optional<CommandMap> commandMap;
   private final PlayerExecutor directGlobalExecutor;
 
   @Inject
@@ -84,6 +89,15 @@ final class BukkitBridgeManagement extends PlatformBridgeManagement<Player, Netw
     // init fields
     this.server = server;
     this.plugin = plugin;
+    this.commandMap = Reflexion.onBound(server)
+      .findField("commandMap")
+      .flatMap(fieldAccessor -> {
+        var value = fieldAccessor.getValue();
+        if (value.wasSuccessful()) {
+          return Optional.of((CommandMap) value.get());
+        }
+        return Optional.empty();
+      });
     this.directGlobalExecutor = new BukkitDirectPlayerExecutor(
       plugin,
       PlayerExecutor.GLOBAL_UNIQUE_ID,
@@ -121,6 +135,17 @@ final class BukkitBridgeManagement extends PlatformBridgeManagement<Player, Netw
   @Override
   public boolean isOnAnyFallbackInstance(@NonNull Player player) {
     return this.isOnAnyFallbackInstance(this.ownNetworkServiceInfo.serverName(), null, player::hasPermission);
+  }
+
+  @Override
+  public @NonNull List<String> consoleSuggestion(@NonNull String line) {
+    // Ensure better compatibility
+    var future = BukkitUtil.supplyOnMainThread(
+      this.plugin,
+      () -> this.commandMap.map(map -> map.tabComplete(this.server.getConsoleSender(), line))
+    );
+    return TaskUtil.getOrDefault(future, Optional.empty())
+      .orElseGet(List::of);
   }
 
   @Override

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitUtil.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitUtil.java
@@ -21,9 +21,13 @@ import java.lang.invoke.MethodType;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import lombok.NonNull;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
 final class BukkitUtil {
@@ -71,5 +75,31 @@ final class BukkitUtil {
 
     // resolve the locale tag from the cache, put it in if missing
     return LOCALE_CACHE.computeIfAbsent(localeTag, tag -> Locale.forLanguageTag(tag.replace('_', '-')));
+  }
+
+
+  public static <T> CompletableFuture<T> supplyOnMainThread(Plugin plugin, Supplier<T> supplier) {
+    CompletableFuture<T> future = new CompletableFuture<>();
+
+    if (Bukkit.isPrimaryThread()) {
+      try {
+        T result = supplier.get();
+        future.complete(result);
+      } catch (Throwable t) {
+        future.completeExceptionally(t);
+      }
+      return future;
+    }
+
+    Bukkit.getScheduler().runTask(plugin, () -> {
+      try {
+        T result = supplier.get();
+        future.complete(result);
+      } catch (Throwable t) {
+        future.completeExceptionally(t);
+      }
+    });
+
+    return future;
   }
 }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordBridgeManagement.java
@@ -39,7 +39,10 @@ import eu.cloudnetservice.wrapper.event.ServiceInfoPropertiesConfigureEvent;
 import eu.cloudnetservice.wrapper.holder.ServiceInfoHolder;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.BiFunction;
@@ -48,6 +51,7 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Command;
 import org.jetbrains.annotations.Nullable;
 
 @Singleton
@@ -133,6 +137,31 @@ final class BungeeCordBridgeManagement extends PlatformBridgeManagement<ProxiedP
       player.getServer() == null ? null : player.getServer().getInfo().getName(),
       this.getVirtualHostString(player.getPendingConnection()),
       player::hasPermission);
+  }
+
+  @Override
+  public @NonNull List<String> consoleSuggestion(@NonNull String line) {
+    // BungeeCord have not provided tab-complete as root directly. we need to process manually
+    var console = this.proxyServer.getConsole();
+    List<String> suggestions = new ArrayList<>();
+
+    if (line.indexOf(' ') == -1) {
+      for (Map.Entry<String, Command> entry : this.proxyServer.getPluginManager().getCommands()) {
+        var name = entry.getKey();
+        if (name.startsWith(line)) {
+          var command = entry.getValue();
+          String permission = command.getPermission();
+          if (permission == null || permission.isEmpty() || console.hasPermission(permission)) {
+            suggestions.add(command.getName());
+          }
+        }
+      }
+    } else {
+      // Complete command arguments
+      this.proxyServer.getPluginManager().dispatchCommand(console, line, suggestions);
+    }
+
+    return suggestions;
   }
 
   @Override

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/listener/PlatformChannelMessageListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/listener/PlatformChannelMessageListener.java
@@ -36,6 +36,10 @@ import eu.cloudnetservice.modules.bridge.player.CloudPlayer;
 import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
 import eu.cloudnetservice.modules.bridge.player.NetworkServiceInfo;
 import eu.cloudnetservice.modules.bridge.player.executor.ServerSelectorType;
+import eu.cloudnetservice.utils.base.concurrent.TaskUtil;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import lombok.NonNull;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
@@ -61,6 +65,28 @@ public final class PlatformChannelMessageListener {
       var configuration = event.content().readObject(BridgeConfiguration.class);
       // set the configuration
       this.management.configurationSilently(configuration);
+    }
+  }
+
+  @EventListener
+  public void handleConsoleSuggestionChannelMessage(@NonNull ChannelMessageReceiveEvent event) {
+    // TODO need a better way to get channel of 'cloudnet:internal' from NetworkConstants.INTERNAL_MSG_CHANNEL.
+    if (event.channel().equals("cloudnet:internal") && event.message()
+      .equals("request_console_suggestion")) {
+      // read the line
+      var line = event.content().readString();
+      var future = TaskUtil.supplyAsync(() -> this.management.consoleSuggestion(line));
+      // make sure normal while service console is lagging
+      var rawList = TaskUtil.getOrDefault(future, Duration.of(100, ChronoUnit.MILLIS), List.of());
+      List<String> suggestions;
+      // Preventing cloudnet console from dying
+      if (rawList.size() > 50) {
+        suggestions = rawList.subList(0, 50);
+      } else {
+        suggestions = rawList;
+      }
+
+      event.binaryResponse(DataBuf.empty().writeObject(suggestions));
     }
   }
 

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityBridgeManagement.java
@@ -18,11 +18,15 @@ package eu.cloudnetservice.modules.bridge.impl.platform.velocity;
 
 import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
 
+import com.velocitypowered.api.command.CommandManager;
+import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.permission.PermissionSubject;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
+import dev.derklaro.reflexion.MethodAccessor;
+import dev.derklaro.reflexion.Reflexion;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.network.NetworkClient;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
@@ -45,10 +49,13 @@ import eu.cloudnetservice.wrapper.event.ServiceInfoPropertiesConfigureEvent;
 import eu.cloudnetservice.wrapper.holder.ServiceInfoHolder;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
@@ -140,6 +147,26 @@ final class VelocityBridgeManagement extends PlatformBridgeManagement<Player, Ne
       player.getCurrentServer().map(connection -> connection.getServerInfo().getName()).orElse(null),
       player.getVirtualHost().map(InetSocketAddress::getHostString).orElse(null),
       player::hasPermission);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public @NonNull List<String> consoleSuggestion(@NonNull String line) {
+    CommandManager commandManager = this.proxyServer.getCommandManager();
+    CommandSource consoleSource = this.proxyServer.getConsoleCommandSource();
+
+    Optional<MethodAccessor<Method>> methodAccessorOpt = Reflexion.onBound(commandManager)
+      .findMethod("offerSuggestions", CommandSource.class, String.class);
+    MethodAccessor<Method> offerSuggestionsMethod = methodAccessorOpt.get();
+
+    Optional<Object> resultOpt = offerSuggestionsMethod.invoke(consoleSource, line).asOptional();
+
+    if (resultOpt.isPresent()) {
+      if (resultOpt.get() instanceof CompletableFuture future) {
+        return (List<String>) future.join();
+      }
+    }
+    return super.consoleSuggestion(line);
   }
 
   @Override

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityBridgeManagement.java
@@ -18,14 +18,12 @@ package eu.cloudnetservice.modules.bridge.impl.platform.velocity;
 
 import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
 
-import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.permission.PermissionSubject;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
-import dev.derklaro.reflexion.MethodAccessor;
 import dev.derklaro.reflexion.Reflexion;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.network.NetworkClient;
@@ -49,7 +47,6 @@ import eu.cloudnetservice.wrapper.event.ServiceInfoPropertiesConfigureEvent;
 import eu.cloudnetservice.wrapper.holder.ServiceInfoHolder;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
@@ -152,21 +149,15 @@ final class VelocityBridgeManagement extends PlatformBridgeManagement<Player, Ne
   @Override
   @SuppressWarnings("unchecked")
   public @NonNull List<String> consoleSuggestion(@NonNull String line) {
-    CommandManager commandManager = this.proxyServer.getCommandManager();
-    CommandSource consoleSource = this.proxyServer.getConsoleCommandSource();
+    var commandManager = this.proxyServer.getCommandManager();
+    var consoleSource = this.proxyServer.getConsoleCommandSource();
 
-    Optional<MethodAccessor<Method>> methodAccessorOpt = Reflexion.onBound(commandManager)
-      .findMethod("offerSuggestions", CommandSource.class, String.class);
-    MethodAccessor<Method> offerSuggestionsMethod = methodAccessorOpt.get();
+    CompletableFuture<List<String>> offerSuggestions = Reflexion.onBound(commandManager)
+      .findMethod("offerSuggestions", CommandSource.class, String.class)
+      .map((acc) -> (CompletableFuture<List<String>>) acc.invokeWithArgs(consoleSource, line).get())
+      .orElse(CompletableFuture.completedFuture(List.of()));
 
-    Optional<Object> resultOpt = offerSuggestionsMethod.invoke(consoleSource, line).asOptional();
-
-    if (resultOpt.isPresent()) {
-      if (resultOpt.get() instanceof CompletableFuture future) {
-        return (List<String>) future.join();
-      }
-    }
-    return super.consoleSuggestion(line);
+    return offerSuggestions.join();
   }
 
   @Override

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultSuggestionProcessor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultSuggestionProcessor.java
@@ -54,8 +54,11 @@ final class DefaultSuggestionProcessor implements SuggestionProcessor<CommandSou
     @NonNull CommandPreprocessingContext<CommandSource> context,
     @NonNull Stream<Suggestion> allSuggestions
   ) {
+    var commandInput = context.commandInput();
+    // fix the suggestion of greedy
+    commandInput.cursor(commandInput.input().length());
     // íf there is no input yet, just return all suggestions
-    var input = context.commandInput().peekString();
+    var input = commandInput.peekString();
     if (Strings.isNullOrEmpty(input)) {
       return allSuggestions;
     }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultSuggestionProcessor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultSuggestionProcessor.java
@@ -55,8 +55,13 @@ final class DefaultSuggestionProcessor implements SuggestionProcessor<CommandSou
     @NonNull Stream<Suggestion> allSuggestions
   ) {
     var commandInput = context.commandInput();
+
     // fix the suggestion of greedy
-    commandInput.cursor(commandInput.input().length());
+    var lastWhitespace = commandInput.input().lastIndexOf(' ');
+    if (lastWhitespace != -1) {
+      commandInput.cursor(lastWhitespace);
+    }
+
     // íf there is no input yet, just return all suggestions
     var input = commandInput.peekString();
     if (Strings.isNullOrEmpty(input)) {

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ServiceCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ServiceCommand.java
@@ -148,13 +148,6 @@ public final class ServiceCommand {
     return service.provider().consoleSuggestion(command).stream();
   }
 
-  /* @Parser(name = "serviceCommand", suggestions = "serviceCommands")
-  public @NonNull String suggestCommandParser(@NonNull @Service I18n i18n, @NonNull CommandInput input) {
-    var command = input.remainingInput();
-    input.cursor(input.length());
-    return command;
-  } */
-
   @Command("service|ser list|l")
   public void displayServices(
     @NonNull CommandSource source,

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ServiceCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ServiceCommand.java
@@ -148,12 +148,12 @@ public final class ServiceCommand {
     return service.provider().consoleSuggestion(command).stream();
   }
 
-  @Parser(name = "serviceCommand", suggestions = "serviceCommands")
+  /* @Parser(name = "serviceCommand", suggestions = "serviceCommands")
   public @NonNull String suggestCommandParser(@NonNull @Service I18n i18n, @NonNull CommandInput input) {
     var command = input.remainingInput();
     input.cursor(input.length());
     return command;
-  }
+  } */
 
   @Command("service|ser list|l")
   public void displayServices(
@@ -329,7 +329,7 @@ public final class ServiceCommand {
   public void sendCommand(
     @NonNull CommandSource source,
     @NonNull @Argument("name") Collection<ServiceInfoSnapshot> matchedServices,
-    @NonNull @Argument(value = "command", parserName = "serviceCommand") @Greedy String line
+    @NonNull @Argument(value = "command", suggestions = "serviceCommands") @Greedy String line
   ) {
     for (var matchedService : matchedServices) {
       matchedService.provider().runCommand(line);

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ServiceCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ServiceCommand.java
@@ -60,6 +60,7 @@ import org.incendo.cloud.annotations.Flag;
 import org.incendo.cloud.annotations.Permission;
 import org.incendo.cloud.annotations.parser.Parser;
 import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
 import org.incendo.cloud.context.CommandInput;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -125,6 +126,33 @@ public final class ServiceCommand {
     }
 
     return matchedServices;
+  }
+
+  @Suggestions("serviceCommands")
+  public @NonNull Stream<String> suggestCommands(@NonNull CommandContext<?> context, @NonNull String input) {
+    Collection<ServiceInfoSnapshot> services = context.get("name");
+    var service = services.stream().findFirst().orElseThrow();
+
+    var fullyInput = context.rawInput().input();
+    var rawInput = fullyInput.substring(fullyInput.indexOf(service.name()) + service.name().length() + 1);
+    String command;
+    if (rawInput.contains(" ")) {
+      command = rawInput.substring(rawInput.indexOf(' '));
+      if (command.startsWith(" ")) {
+        command = command.substring(1);
+      }
+    } else {
+      command = "";
+    }
+
+    return service.provider().consoleSuggestion(command).stream();
+  }
+
+  @Parser(name = "serviceCommand", suggestions = "serviceCommands")
+  public @NonNull String suggestCommandParser(@NonNull @Service I18n i18n, @NonNull CommandInput input) {
+    var command = input.remainingInput();
+    input.cursor(input.length());
+    return command;
   }
 
   @Command("service|ser list|l")
@@ -301,10 +329,10 @@ public final class ServiceCommand {
   public void sendCommand(
     @NonNull CommandSource source,
     @NonNull @Argument("name") Collection<ServiceInfoSnapshot> matchedServices,
-    @NonNull @Greedy @Argument("command") String command
+    @NonNull @Argument(value = "command", parserName = "serviceCommand") @Greedy String line
   ) {
     for (var matchedService : matchedServices) {
-      matchedService.provider().runCommand(command);
+      matchedService.provider().runCommand(line);
     }
   }
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/AbstractService.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/AbstractService.java
@@ -61,6 +61,7 @@ import eu.cloudnetservice.utils.base.StringUtil;
 import eu.cloudnetservice.utils.base.concurrent.TaskUtil;
 import eu.cloudnetservice.utils.base.io.FileUtil;
 import eu.cloudnetservice.utils.base.resource.CpuUsageResolver;
+import io.leangen.geantyref.TypeFactory;
 import io.vavr.Tuple2;
 import java.net.Inet6Address;
 import java.nio.charset.StandardCharsets;
@@ -409,6 +410,19 @@ public abstract class AbstractService implements InternalCloudService {
   public void restart() {
     this.updateLifecycle(ServiceLifeCycle.STOPPED, false);
     this.updateLifecycle(ServiceLifeCycle.RUNNING);
+  }
+
+  @Override
+  public Collection<String> consoleSuggestion(@NonNull String line) {
+    var listPropertyType = TypeFactory.parameterizedClass(List.class, String.class);
+    var response = ChannelMessage.builder()
+      .targetService(this.serviceId().name())
+      .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
+      .message("request_console_suggestion")
+      .buffer(DataBuf.empty().writeString(line))
+      .build().sendSingleQuery();
+
+    return response != null ? response.content().readObject(listPropertyType) : List.of();
   }
 
   @Override

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/provider/EmptySpecificCloudServiceProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/provider/EmptySpecificCloudServiceProvider.java
@@ -94,6 +94,11 @@ public final class EmptySpecificCloudServiceProvider implements SpecificCloudSer
   }
 
   @Override
+  public Collection<String> consoleSuggestion(@NonNull String line) {
+    return List.of();
+  }
+
+  @Override
   public @NonNull Collection<ServiceTemplate> installedTemplates() {
     return List.of();
   }


### PR DESCRIPTION
<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
As the title says, it enables node console to directly get suggestions from the service, especially when you need to use cloudnet to debug the service.

The java sub-process started by cloudnet does not have a complete terminal environment, so it cannot directly get the service suggestions. Therefore, it can only communicate with the bridge through `ChannelMessage` to get suggestions.

> btw, I think service suggestions are more useful on the web than on the node console, like https://github.com/docimin/cloudnet-webinterface

### Modification

* Added suggestion processor `ServiceCommand#suggestCommands`
* Added a method `SpecificCloudServiceProvider#consoleSuggestion` in wrapper, Implementation in `AbstractService` to request suggestions from `bridge`.
* Fixed suggestion-processor for `@Greedy` processes in `DefaultSuggestionProcessor`

#### Service Platfrom Implementations
> I think the feasibility and rationality of this function still need further discussion, so it is not adapted to all platforms.

- [x] Bukkit
- [x] BungeeCord
- [x] Velocity
- [ ] Sponge
- [ ] Fabric
- [ ] Limbo(LOOPHP)
- [ ] Nukkit
- [ ] WaterDog
- [ ] Minestom

### Result
Perfect. Like these:

| Bukkit | BungeeCord | Velocity |
|-------|-------|-------|
| <img width="1613" alt="screenshot_ 2025-05-30 at 01 50 17" src="https://github.com/user-attachments/assets/7c2e17a6-723b-4180-9b74-1ac512f115de" /> | <img width="1613" alt="screenshot_ 2025-05-30 at 01 50 44" src="https://github.com/user-attachments/assets/75416e4b-61ba-4433-943d-56a44fbf7cb8" /> | <img width="1613" alt="screenshot_ 2025-05-30 at 01 51 20" src="https://github.com/user-attachments/assets/655a5027-8ec4-4f18-b5d3-c392171ccac6" /> |

> [demo video like this](https://cdn.discordapp.com/attachments/818777626663321671/1377559779899215872/Untitled.mov?ex=68396805&is=68381685&hm=a5b7210baa06d3733f1abe7d4ee6eb155f80615c9cf698d50fcf9a94f94a1cc1&)

##### Other context
Once merged, [module-rest](https://github.com/CloudNetService/module-rest) will be directly compatible with this change, further enhancing the [web-interface](https://github.com/docimin/cloudnet-webinterface) console of service.