### PR TITLE
feat: make command confirmations skippable using extra flag

### DIFF
--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/EnableConfirmSkipFlag.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/EnableConfirmSkipFlag.java
@@ -26,24 +26,25 @@ import lombok.NonNull;
 /**
  * This annotation allows users to skip the required confirmation
  * {@link org.incendo.cloud.processors.confirmation.annotation.Confirmation} of a command. When this annotation is
- * applied to a method implicitly a flag is appended to the command which can be used to skip the confirmation.
+ * applied to a method a flag is implicitly appended to the command which can be used to skip the confirmation.
  * <p>
- * The annotations value is used as the flag name, which defaults to "skip".
+ * The annotations value is used as the flag name, which defaults to "confirm".
  *
  * @see org.incendo.cloud.processors.confirmation.annotation.Confirmation
+ * @since 4.0
  */
 @Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface SkipConfirmation {
+public @interface EnableConfirmSkipFlag {
 
   /**
    * The value of this annotation is used as the flag name to skip the confirmation. Should not include the leading
    * dashes.
    * <p>
-   * Defaults to "skip", allowing users to skip the confirmation by appending "--skip".
+   * Defaults to "skip", allowing users to skip the confirmation by appending "--confirm".
    *
    * @return the flag name that allows skipping.
    */
-  @NonNull String value() default "skip";
+  @NonNull String value() default "confirm";
 }

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/EnableConfirmSkipFlag.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/EnableConfirmSkipFlag.java
@@ -28,7 +28,7 @@ import lombok.NonNull;
  * {@link org.incendo.cloud.processors.confirmation.annotation.Confirmation} of a command. When this annotation is
  * applied to a method a flag is implicitly appended to the command which can be used to skip the confirmation.
  * <p>
- * The annotations value is used as the flag name, which defaults to "confirm".
+ * The annotations value is used as the flag name, which defaults to {@code confirm}.
  *
  * @see org.incendo.cloud.processors.confirmation.annotation.Confirmation
  * @since 4.0
@@ -42,7 +42,7 @@ public @interface EnableConfirmSkipFlag {
    * The value of this annotation is used as the flag name to skip the confirmation. Should not include the leading
    * dashes.
    * <p>
-   * Defaults to "skip", allowing users to skip the confirmation by appending "--confirm".
+   * Defaults to {@code confirm}, allowing users to skip the confirmation by appending {@code --confirm}.
    *
    * @return the flag name that allows skipping.
    */

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/SkipConfirmation.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/SkipConfirmation.java
@@ -16,16 +16,33 @@
 
 package eu.cloudnetservice.node.command.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import lombok.NonNull;
 
+/**
+ * This annotation allows users to skip the required confirmation
+ * {@link org.incendo.cloud.processors.confirmation.annotation.Confirmation} of a command. When this annotation is
+ * applied to a method implicitly a flag is appended to the command which can be used to skip the confirmation.
+ * <p>
+ * The annotations value is used as the flag name, which defaults to "skip".
+ * @see org.incendo.cloud.processors.confirmation.annotation.Confirmation
+ */
+@Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SkipConfirmation {
 
+  /**
+   * The value of this annotation is used as the flag name to skip the confirmation. Should not include the leading
+   * dashes.
+   * <p>
+   * Defaults to "skip", allowing users to skip the confirmation by appending "--skip".s
+   *
+   * @return the flag name that allows skipping.
+   */
   @NonNull String value() default "skip";
-
 }

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/SkipConfirmation.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/SkipConfirmation.java
@@ -29,6 +29,7 @@ import lombok.NonNull;
  * applied to a method implicitly a flag is appended to the command which can be used to skip the confirmation.
  * <p>
  * The annotations value is used as the flag name, which defaults to "skip".
+ *
  * @see org.incendo.cloud.processors.confirmation.annotation.Confirmation
  */
 @Documented

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/SkipConfirmation.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/SkipConfirmation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.node.command.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import lombok.NonNull;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SkipConfirmation {
+
+  @NonNull String value() default "skip";
+
+}

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/SkipConfirmation.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/SkipConfirmation.java
@@ -41,7 +41,7 @@ public @interface SkipConfirmation {
    * The value of this annotation is used as the flag name to skip the confirmation. Should not include the leading
    * dashes.
    * <p>
-   * Defaults to "skip", allowing users to skip the confirmation by appending "--skip".s
+   * Defaults to "skip", allowing users to skip the confirmation by appending "--skip".
    *
    * @return the flag name that allows skipping.
    */

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
@@ -152,9 +152,9 @@ public final class DefaultCommandProvider implements CommandProvider {
       (enableConfirmSkipFlag, builder) -> {
         var requiresConfirmation = builder.meta().getOrDefault(ConfirmationManager.META_CONFIRMATION_REQUIRED, false);
         if (!requiresConfirmation) {
-          LOGGER.warn(
-            "Command {} is annotated with @EnableConfirmSkipFlag, but does not require confirmation",
-            builder.build());
+          var components = builder.build().components();
+          var syntax = this.commandManager.commandSyntaxFormatter().apply(null, components, null);
+          LOGGER.warn("Command {} is annotated with @EnableConfirmSkipFlag, but does not require confirmation", syntax);
           return builder;
         }
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
@@ -78,8 +78,6 @@ import org.incendo.cloud.processors.confirmation.ConfirmationManager;
 import org.incendo.cloud.processors.confirmation.annotation.ConfirmationBuilderModifier;
 import org.incendo.cloud.suggestion.Suggestion;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * {@inheritDoc}
@@ -87,8 +85,6 @@ import org.slf4j.LoggerFactory;
 @Singleton
 @Provides(CommandProvider.class)
 public final class DefaultCommandProvider implements CommandProvider {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCommandProvider.class);
 
   private static final CloudKey<Set<String>> ALIAS_KEY = CloudKey.of("cloudnet:alias", new TypeToken<Set<String>>() {
   });

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
@@ -29,7 +29,7 @@ import eu.cloudnetservice.node.command.CommandProvider;
 import eu.cloudnetservice.node.command.annotation.CommandAlias;
 import eu.cloudnetservice.node.command.annotation.Description;
 import eu.cloudnetservice.node.command.annotation.Documentation;
-import eu.cloudnetservice.node.command.annotation.SkipConfirmation;
+import eu.cloudnetservice.node.command.annotation.EnableConfirmSkipFlag;
 import eu.cloudnetservice.node.command.source.CommandSource;
 import eu.cloudnetservice.node.impl.command.exception.CommandExceptionHandler;
 import eu.cloudnetservice.node.impl.command.sub.ClearCommand;
@@ -78,6 +78,8 @@ import org.incendo.cloud.processors.confirmation.ConfirmationManager;
 import org.incendo.cloud.processors.confirmation.annotation.ConfirmationBuilderModifier;
 import org.incendo.cloud.suggestion.Suggestion;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@inheritDoc}
@@ -85,6 +87,8 @@ import org.jetbrains.annotations.Nullable;
 @Singleton
 @Provides(CommandProvider.class)
 public final class DefaultCommandProvider implements CommandProvider {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCommandProvider.class);
 
   private static final CloudKey<Set<String>> ALIAS_KEY = CloudKey.of("cloudnet:alias", new TypeToken<Set<String>>() {
   });
@@ -144,12 +148,18 @@ public final class DefaultCommandProvider implements CommandProvider {
     });
 
     this.annotationParser.registerBuilderModifier(
-      SkipConfirmation.class,
-      (skipConfirmation, builder) -> {
-        var flag = CommandFlag
-          .builder(skipConfirmation.value())
-          .build();
-        return builder.meta(SKIP_CONFIRMATION_KEY, skipConfirmation.value()).flag(flag);
+      EnableConfirmSkipFlag.class,
+      (enableConfirmSkipFlag, builder) -> {
+        var requiresConfirmation = builder.meta().getOrDefault(ConfirmationManager.META_CONFIRMATION_REQUIRED, false);
+        if (!requiresConfirmation) {
+          LOGGER.warn(
+            "Command {} is annotated with @EnableConfirmSkipFlag, but does not require confirmation",
+            builder.build());
+          return builder;
+        }
+
+        var flag = CommandFlag.builder(enableConfirmSkipFlag.value()).build();
+        return builder.meta(SKIP_CONFIRMATION_KEY, enableConfirmSkipFlag.value()).flag(flag);
       });
 
     // register pre- and post-processor to call our events
@@ -335,8 +345,8 @@ public final class DefaultCommandProvider implements CommandProvider {
       .confirmationRequiredNotifier(
         (sender, _) -> sender.sendMessage(this.i18n.translate("command-confirmation-required")))
       .bypassConfirmation(ctx -> {
-        var commandMeta = ctx.command().commandMeta();
-        var skipConfirmationFlag = commandMeta.optional(SKIP_CONFIRMATION_KEY).orElse(null);
+        var meta = ctx.command().commandMeta();
+        var skipConfirmationFlag = meta.getOrDefault(SKIP_CONFIRMATION_KEY, null);
         return skipConfirmationFlag != null && ctx.flags().hasFlag(skipConfirmationFlag);
       })
       .build();

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
@@ -150,14 +150,6 @@ public final class DefaultCommandProvider implements CommandProvider {
     this.annotationParser.registerBuilderModifier(
       EnableConfirmSkipFlag.class,
       (enableConfirmSkipFlag, builder) -> {
-        var requiresConfirmation = builder.meta().getOrDefault(ConfirmationManager.META_CONFIRMATION_REQUIRED, false);
-        if (!requiresConfirmation) {
-          var components = builder.build().components();
-          var syntax = this.commandManager.commandSyntaxFormatter().apply(null, components, null);
-          LOGGER.warn("Command {} is annotated with @EnableConfirmSkipFlag, but does not require confirmation", syntax);
-          return builder;
-        }
-
         var flag = CommandFlag.builder(enableConfirmSkipFlag.value()).build();
         return builder.meta(SKIP_CONFIRMATION_KEY, enableConfirmSkipFlag.value()).flag(flag);
       });

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
@@ -29,6 +29,7 @@ import eu.cloudnetservice.node.command.CommandProvider;
 import eu.cloudnetservice.node.command.annotation.CommandAlias;
 import eu.cloudnetservice.node.command.annotation.Description;
 import eu.cloudnetservice.node.command.annotation.Documentation;
+import eu.cloudnetservice.node.command.annotation.SkipConfirmation;
 import eu.cloudnetservice.node.command.source.CommandSource;
 import eu.cloudnetservice.node.impl.command.exception.CommandExceptionHandler;
 import eu.cloudnetservice.node.impl.command.sub.ClearCommand;
@@ -70,6 +71,7 @@ import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.annotations.AnnotationParser;
 import org.incendo.cloud.key.CloudKey;
 import org.incendo.cloud.meta.CommandMeta;
+import org.incendo.cloud.parser.flag.CommandFlag;
 import org.incendo.cloud.processors.cache.CaffeineCache;
 import org.incendo.cloud.processors.confirmation.ConfirmationConfiguration;
 import org.incendo.cloud.processors.confirmation.ConfirmationManager;
@@ -88,6 +90,7 @@ public final class DefaultCommandProvider implements CommandProvider {
   });
   private static final CloudKey<String> DESCRIPTION_KEY = CloudKey.of("cloudnet:description", String.class);
   private static final CloudKey<String> DOCUMENTATION_KEY = CloudKey.of("cloudnet:documentation", String.class);
+  private static final CloudKey<String> SKIP_CONFIRMATION_KEY = CloudKey.of("cloudnet:skip-confirmation", String.class);
 
   private final I18n i18n;
   private final CommandExceptionHandler exceptionHandler;
@@ -139,6 +142,15 @@ public final class DefaultCommandProvider implements CommandProvider {
       }
       return builder;
     });
+
+    this.annotationParser.registerBuilderModifier(
+      SkipConfirmation.class,
+      (skipConfirmation, builder) -> {
+        var flag = CommandFlag
+          .builder(skipConfirmation.value())
+          .build();
+        return builder.meta(SKIP_CONFIRMATION_KEY, skipConfirmation.value()).flag(flag);
+      });
 
     // register pre- and post-processor to call our events
     this.commandManager.suggestionProcessor(suggestionProcessor);
@@ -322,6 +334,11 @@ public final class DefaultCommandProvider implements CommandProvider {
       .noPendingCommandNotifier(sender -> sender.sendMessage(this.i18n.translate("command-confirmation-no-requests")))
       .confirmationRequiredNotifier(
         (sender, _) -> sender.sendMessage(this.i18n.translate("command-confirmation-required")))
+      .bypassConfirmation(ctx -> {
+        var commandMeta = ctx.command().commandMeta();
+        var skipConfirmationFlag = commandMeta.optional(SKIP_CONFIRMATION_KEY).orElse(null);
+        return skipConfirmationFlag != null && ctx.flags().hasFlag(skipConfirmationFlag);
+      })
       .build();
     var confirmationManager = ConfirmationManager.confirmationManager(configuration);
     this.commandManager.registerCommandPostProcessor(confirmationManager.createPostprocessor());

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ExitCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ExitCommand.java
@@ -18,7 +18,7 @@ package eu.cloudnetservice.node.impl.command.sub;
 
 import eu.cloudnetservice.node.command.annotation.CommandAlias;
 import eu.cloudnetservice.node.command.annotation.Description;
-import eu.cloudnetservice.node.command.annotation.SkipConfirmation;
+import eu.cloudnetservice.node.command.annotation.EnableConfirmSkipFlag;
 import eu.cloudnetservice.node.impl.command.source.ConsoleCommandSource;
 import eu.cloudnetservice.node.impl.tick.DefaultShutdownHandler;
 import jakarta.inject.Inject;
@@ -43,7 +43,7 @@ public final class ExitCommand {
   }
 
   @Confirmation
-  @SkipConfirmation
+  @EnableConfirmSkipFlag
   @Command(value = "exit|shutdown|stop", requiredSender = ConsoleCommandSource.class)
   public void exit() {
     // call our shutdown handler, this prevents the Cleaner shutdown hook which is added

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ExitCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ExitCommand.java
@@ -18,6 +18,7 @@ package eu.cloudnetservice.node.impl.command.sub;
 
 import eu.cloudnetservice.node.command.annotation.CommandAlias;
 import eu.cloudnetservice.node.command.annotation.Description;
+import eu.cloudnetservice.node.command.annotation.SkipConfirmation;
 import eu.cloudnetservice.node.impl.command.source.ConsoleCommandSource;
 import eu.cloudnetservice.node.impl.tick.DefaultShutdownHandler;
 import jakarta.inject.Inject;
@@ -42,6 +43,7 @@ public final class ExitCommand {
   }
 
   @Confirmation
+  @SkipConfirmation
   @Command(value = "exit|shutdown|stop", requiredSender = ConsoleCommandSource.class)
   public void exit() {
     // call our shutdown handler, this prevents the Cleaner shutdown hook which is added


### PR DESCRIPTION
### Motivation
In #1579 it was requested to make command confirmations (like needed for `exit`) skippable using a flag.

### Modification
Added a new `@SkipConfirmation` annotation which allows to specify a flag name which can be used to skip the confirmation of a command. This PR also directly includes this annotation for the exit command so that it can be skipped using `--skip`

### Result
Commands that need to be confirmed can be skipped if requested.

##### Other context
Resolves #1579
