### PR TITLE
fix: logging configuration properties not working from launcher.cnl

### DIFF
--- a/node/impl/src/main/resources/logback.xml
+++ b/node/impl/src/main/resources/logback.xml
@@ -22,10 +22,6 @@
   <import class="eu.cloudnetservice.node.impl.console.log.ConsoleLogAppender"/>
   <import class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"/>
 
-  <!-- variables used in the logback configuration. Can be set using system properties. -->
-  <variable name="cloudnet.log.path" value="local/logs"/>
-  <variable name="cloudnet.log.level" value="DEBUG"/>
-
   <conversionRule conversionWord="levelColor"
     class="eu.cloudnetservice.node.impl.console.log.ConsoleLevelConversion"/>
   <property name="CONSOLE_PATTERN"
@@ -47,9 +43,9 @@
     </encoder>
   </appender>
   <appender name="Rolling" class="RollingFileAppender">
-    <file>${cloudnet.log.path}/latest.log</file>
+    <file>${cloudnet.log.path:-local/logs}/latest.log</file>
     <rollingPolicy class="SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${cloudnet.log.path}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+      <fileNamePattern>${cloudnet.log.path:-local/logs}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
       <maxFileSize>15MB</maxFileSize>
       <maxHistory>5</maxHistory>
       <totalSizeCap>5GB</totalSizeCap>
@@ -59,7 +55,7 @@
     </encoder>
   </appender>
 
-  <root level="${cloudnet.log.level}">
+  <root level="${cloudnet.log.level:-DEBUG}">
     <appender-ref ref="ConsoleLogAppender"/>
     <appender-ref ref="Rolling"/>
     <appender-ref ref="QueuedConsoleLogAppender"/>

--- a/node/impl/src/main/resources/logback.xml
+++ b/node/impl/src/main/resources/logback.xml
@@ -22,6 +22,10 @@
   <import class="eu.cloudnetservice.node.impl.console.log.ConsoleLogAppender"/>
   <import class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"/>
 
+  <!-- variables used in the logback configuration. Can be set using system properties. -->
+  <variable name="cloudnet.log.path" value="${cloudnet.log.path:-local/logs}"/>
+  <variable name="cloudnet.log.level" value="${cloudnet.log.level:-DEBUG}"/>
+
   <conversionRule conversionWord="levelColor"
     class="eu.cloudnetservice.node.impl.console.log.ConsoleLevelConversion"/>
   <property name="CONSOLE_PATTERN"
@@ -43,9 +47,9 @@
     </encoder>
   </appender>
   <appender name="Rolling" class="RollingFileAppender">
-    <file>${cloudnet.log.path:-local/logs}/latest.log</file>
+    <file>${cloudnet.log.path}/latest.log</file>
     <rollingPolicy class="SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${cloudnet.log.path:-local/logs}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+      <fileNamePattern>${cloudnet.log.path}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
       <maxFileSize>15MB</maxFileSize>
       <maxHistory>5</maxHistory>
       <totalSizeCap>5GB</totalSizeCap>
@@ -55,7 +59,7 @@
     </encoder>
   </appender>
 
-  <root level="${cloudnet.log.level:-DEBUG}">
+  <root level="${cloudnet.log.level}">
     <appender-ref ref="ConsoleLogAppender"/>
     <appender-ref ref="Rolling"/>
     <appender-ref ref="QueuedConsoleLogAppender"/>

--- a/wrapper-jvm/impl/src/main/resources/logback.xml
+++ b/wrapper-jvm/impl/src/main/resources/logback.xml
@@ -22,11 +22,15 @@
   <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
   <import class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"/>
 
+  <!-- variables used in the logback configuration. Can be set using system properties. -->
+  <variable name="cloudnet.wrapper.log.path" value="${cloudnet.wrapper.log.path:-.wrapper/logs}"/>
+  <variable name="cloudnet.wrapper.log.level" value="${cloudnet.wrapper.log.level:-DEBUG}"/>
+
   <property name="LOG_PATTERN" value="[%d{dd.MM HH:mm:ss.SSS}] %-5level: %msg%n"/>
   <appender name="Rolling" class="RollingFileAppender">
-    <file>${cloudnet.wrapper.log.path:-.wrapper/logs}/latest.log</file>
+    <file>${cloudnet.wrapper.log.path}/latest.log</file>
     <rollingPolicy class="SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${cloudnet.wrapper.log.path:-.wrapper/logs}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+      <fileNamePattern>${cloudnet.wrapper.log.path}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
       <maxFileSize>15MB</maxFileSize>
       <maxHistory>3</maxHistory>
       <totalSizeCap>50MB</totalSizeCap>
@@ -56,7 +60,7 @@
     <target>System.err</target>
   </appender>
 
-  <root level="${cloudnet.wrapper.log.level:-DEBUG}">
+  <root level="${cloudnet.wrapper.log.level}">
     <appender-ref ref="Rolling"/>
     <appender-ref ref="STDOUT"/>
     <appender-ref ref="STDERR"/>

--- a/wrapper-jvm/impl/src/main/resources/logback.xml
+++ b/wrapper-jvm/impl/src/main/resources/logback.xml
@@ -22,15 +22,11 @@
   <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
   <import class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"/>
 
-  <!-- variables used in the logback configuration. Can be set using system properties. -->
-  <variable name="cloudnet.wrapper.log.path" value=".wrapper/logs"/>
-  <variable name="cloudnet.wrapper.log.level" value="DEBUG"/>
-
   <property name="LOG_PATTERN" value="[%d{dd.MM HH:mm:ss.SSS}] %-5level: %msg%n"/>
   <appender name="Rolling" class="RollingFileAppender">
-    <file>${cloudnet.wrapper.log.path}/latest.log</file>
+    <file>${cloudnet.wrapper.log.path:-.wrapper/logs}/latest.log</file>
     <rollingPolicy class="SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${cloudnet.wrapper.log.path}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+      <fileNamePattern>${cloudnet.wrapper.log.path:-.wrapper/logs}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
       <maxFileSize>15MB</maxFileSize>
       <maxHistory>3</maxHistory>
       <totalSizeCap>50MB</totalSizeCap>
@@ -60,7 +56,7 @@
     <target>System.err</target>
   </appender>
 
-  <root level="${cloudnet.wrapper.log.level}">
+  <root level="${cloudnet.wrapper.log.level:-DEBUG}">
     <appender-ref ref="Rolling"/>
     <appender-ref ref="STDOUT"/>
     <appender-ref ref="STDERR"/>

--- a/wrapper-jvm/impl/src/main/resources/logback.xml
+++ b/wrapper-jvm/impl/src/main/resources/logback.xml
@@ -23,14 +23,14 @@
   <import class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"/>
 
   <!-- variables used in the logback configuration. Can be set using system properties. -->
-  <variable name="cloudnet.wrapper.log.path" value="${cloudnet.wrapper.log.path:-.wrapper/logs}"/>
-  <variable name="cloudnet.wrapper.log.level" value="${cloudnet.wrapper.log.level:-DEBUG}"/>
+  <variable name="cloudnet.log.path" value="${cloudnet.wrapper.log.path:-.wrapper/logs}"/>
+  <variable name="cloudnet.log.level" value="${cloudnet.wrapper.log.level:-DEBUG}"/>
 
   <property name="LOG_PATTERN" value="[%d{dd.MM HH:mm:ss.SSS}] %-5level: %msg%n"/>
   <appender name="Rolling" class="RollingFileAppender">
-    <file>${cloudnet.wrapper.log.path}/latest.log</file>
+    <file>${cloudnet.log.path}/latest.log</file>
     <rollingPolicy class="SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${cloudnet.wrapper.log.path}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+      <fileNamePattern>${cloudnet.log.path}/cloudnet-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
       <maxFileSize>15MB</maxFileSize>
       <maxHistory>3</maxHistory>
       <totalSizeCap>50MB</totalSizeCap>
@@ -60,7 +60,7 @@
     <target>System.err</target>
   </appender>
 
-  <root level="${cloudnet.wrapper.log.level}">
+  <root level="${cloudnet.log.level}">
     <appender-ref ref="Rolling"/>
     <appender-ref ref="STDOUT"/>
     <appender-ref ref="STDERR"/>


### PR DESCRIPTION
Motivation
Logging properties set in launcher.cnl (like var cloudnet.log.level OFF) were being ignored.

Modification
Changed logback XML files to read system properties directly instead of using cached variables:
${cloudnet.log.level} → ${cloudnet.log.level:-DEBUG}
${cloudnet.log.path} → ${cloudnet.log.path:-local/logs}

Result
Logging configuration from launcher.cnl now works correctly. Users can set custom log levels and paths.

Other context
Fixes timing issue where logback initialized before system properties were available.