### PR TITLE
feat: allow modifications to log levels using properties

### DIFF
--- a/launcher/java22/src/main/resources/launcher.cnl
+++ b/launcher/java22/src/main/resources/launcher.cnl
@@ -78,6 +78,8 @@ var cloudnet.node.memory 256
 #var cloudnet.versioncache.path local/versioncache
 # Sets the path to the cloudnet log directory
 #var cloudnet.log.path local/logs
+# Sets the path to the logback properties file which allows configuring the log levels of individual loggers.
+#var cloudnet.log.properties.file local/logs/logback.properties
 # Sets the timeout until a node gets marked as disconnected from the local node. This does not mean that the node will
 # be removed completely from the system, there is a grace period for the node to reconnect to this node (see the following
 # setting for this)

--- a/launcher/java22/src/main/resources/launcher.cnl
+++ b/launcher/java22/src/main/resources/launcher.cnl
@@ -79,7 +79,7 @@ var cloudnet.node.memory 256
 # Sets the path to the cloudnet log directory
 #var cloudnet.log.path local/logs
 # Sets the path to the logback properties file which allows configuring the log levels of individual loggers.
-#var cloudnet.log.properties.file local/logs/logback.properties
+#var cloudnet.log.properties.file logback.properties
 # Sets the timeout until a node gets marked as disconnected from the local node. This does not mean that the node will
 # be removed completely from the system, there is a grace period for the node to reconnect to this node (see the following
 # setting for this)

--- a/node/impl/src/main/resources/logback.xml
+++ b/node/impl/src/main/resources/logback.xml
@@ -25,7 +25,7 @@
   <!-- variables used in the logback configuration. Can be set using system properties. -->
   <variable name="cloudnet.log.path" value="${cloudnet.log.path:-local/logs}"/>
   <variable name="cloudnet.log.level" value="${cloudnet.log.level:-DEBUG}"/>
-  <variable name="cloudnet.log.properties.file" value="${cloudnet.log.properties.file:-local/logs/logback.properties}"/>
+  <variable name="cloudnet.log.properties.file" value="${cloudnet.log.properties.file:-logback.properties}"/>
 
   <!-- allow configuring log levels using properties file -->
   <propertiesConfigurator optional="true" file="${cloudnet.log.properties.file}"/>

--- a/node/impl/src/main/resources/logback.xml
+++ b/node/impl/src/main/resources/logback.xml
@@ -25,6 +25,10 @@
   <!-- variables used in the logback configuration. Can be set using system properties. -->
   <variable name="cloudnet.log.path" value="${cloudnet.log.path:-local/logs}"/>
   <variable name="cloudnet.log.level" value="${cloudnet.log.level:-DEBUG}"/>
+  <variable name="cloudnet.log.properties.file" value="${cloudnet.log.properties.file:-local/logs/logback.properties}"/>
+
+  <!-- allow configuring log levels using properties file -->
+  <propertiesConfigurator optional="true" file="${cloudnet.log.properties.file}"/>
 
   <conversionRule conversionWord="levelColor"
     class="eu.cloudnetservice.node.impl.console.log.ConsoleLevelConversion"/>

--- a/wrapper-jvm/impl/src/main/resources/logback.xml
+++ b/wrapper-jvm/impl/src/main/resources/logback.xml
@@ -25,6 +25,13 @@
   <!-- variables used in the logback configuration. Can be set using system properties. -->
   <variable name="cloudnet.log.path" value="${cloudnet.wrapper.log.path:-.wrapper/logs}"/>
   <variable name="cloudnet.log.level" value="${cloudnet.wrapper.log.level:-DEBUG}"/>
+  <variable
+    name="cloudnet.log.properties.file"
+    value="${cloudnet.wrapper.log.properties.file:-.wrapper/logs/logback.properties}"
+  />
+
+  <!-- allow configuring log levels using properties file -->
+  <propertiesConfigurator optional="true" file="${cloudnet.log.properties.file}"/>
 
   <property name="LOG_PATTERN" value="[%d{dd.MM HH:mm:ss.SSS}] %-5level: %msg%n"/>
   <appender name="Rolling" class="RollingFileAppender">

--- a/wrapper-jvm/impl/src/main/resources/logback.xml
+++ b/wrapper-jvm/impl/src/main/resources/logback.xml
@@ -27,7 +27,7 @@
   <variable name="cloudnet.log.level" value="${cloudnet.wrapper.log.level:-DEBUG}"/>
   <variable
     name="cloudnet.log.properties.file"
-    value="${cloudnet.wrapper.log.properties.file:-.wrapper/logs/logback.properties}"
+    value="${cloudnet.wrapper.log.properties.file:-.wrapper/logback.properties}"
   />
 
   <!-- allow configuring log levels using properties file -->


### PR DESCRIPTION
### Motivation
CloudNet provides a logback configuration which works for most users. But if someone wants to change the log level of a single logger the user would either need to change the level for all loggers or override the whole configuration.

### Modification
Added support for logbacks https://logback.qos.ch/manual/configuration.html#propertiesConfigurator which allows to set log levels using a simple properties file.

### Result
Log levels can easily be changed by the user without replacing (and potentially breaking) the whole logback configuration.
