### PR TITLE
fix: drop non-empty line check from console read thread

### DIFF
--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/DefaultDataSyncRegistry.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/DefaultDataSyncRegistry.java
@@ -230,7 +230,7 @@ public class DefaultDataSyncRegistry implements DataSyncRegistry {
       // wait for an input
       var input = TaskUtil.getOrDefault(console.readLine(), null);
       // check if an input was supplied
-      if (input == null) {
+      if (input == null || input.isBlank()) {
         continue;
       }
       // get the int from the input & validate

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
@@ -262,7 +262,7 @@ public final class DefaultCommandProvider implements CommandProvider {
       public void handleInput(@NonNull String line) {
         // check if the input line is empty
         var trimmedInput = line.trim();
-        if (!trimmedInput.isBlank()) {
+        if (!trimmedInput.isEmpty()) {
           // execute the command
           DefaultCommandProvider.this.execute(CommandSource.console(), trimmedInput);
         }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
@@ -262,7 +262,7 @@ public final class DefaultCommandProvider implements CommandProvider {
       public void handleInput(@NonNull String line) {
         // check if the input line is empty
         var trimmedInput = line.trim();
-        if (!trimmedInput.isEmpty()) {
+        if (!trimmedInput.isBlank()) {
           // execute the command
           DefaultCommandProvider.this.execute(CommandSource.console(), trimmedInput);
         }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/ConsoleReadThread.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/ConsoleReadThread.java
@@ -39,25 +39,24 @@ public final class ConsoleReadThread extends Thread {
         // this is done here to handle the thrown exceptions by the method correctly (see catch blocks below)
         // todo(derklaro): this can also throw an IOError, not sure how to handle that
         line = this.console.lineReader().readLine(this.console.prompt());
-        if (!line.isBlank()) {
-          // complete the current read task if any is awaiting console input
-          if (this.currentTask != null) {
-            this.currentTask.complete(line);
-            this.currentTask = null;
-          }
 
-          // post the command line to all input handlers that are enabled at the moment
-          for (var value : this.console.consoleInputHandler().values()) {
-            if (value.enabled()) {
-              value.handleInput(line);
-            }
-          }
+        // complete the current read task if any is awaiting console input
+        if (this.currentTask != null) {
+          this.currentTask.complete(line);
+          this.currentTask = null;
+        }
 
-          // notify all animations that the cursor line has been moved one down
-          // this is required to allow them to react when f. ex. re-drawing styled console input
-          for (var animation : this.console.runningAnimations()) {
-            animation.addToCursor(1);
+        // post the command line to all input handlers that are enabled at the moment
+        for (var value : this.console.consoleInputHandler().values()) {
+          if (value.enabled()) {
+            value.handleInput(line);
           }
+        }
+
+        // notify all animations that the cursor line has been moved one down
+        // this is required to allow them to react when f. ex. re-drawing styled console input
+        for (var animation : this.console.runningAnimations()) {
+          animation.addToCursor(1);
         }
       } catch (EndOfFileException ignored) {
         // just continue reading after EOT (CTRL-D)


### PR DESCRIPTION
### Motivation
The console read thread currently enforces that all read lines must contain at least one non-space char. This leads to issues with handlers that actually want to accept blank input, e.g. in the module selection in the default setup.

### Modification
Remove blank line check from console read thread, add blank check to some handlers.

### Result
Blank input is now allowed by the console read thread, meaning that handlers can now properly handle blank input as they wish.