### PR TITLE
fix: minestom permission checking

### DIFF
--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeManagement.java
@@ -39,6 +39,7 @@ import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
 import eu.cloudnetservice.wrapper.event.ServiceInfoPropertiesConfigureEvent;
 import eu.cloudnetservice.wrapper.holder.ServiceInfoHolder;
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import java.util.Collections;
 import java.util.Optional;
@@ -61,7 +62,7 @@ public final class MinestomBridgeManagement extends PlatformBridgeManagement<Pla
   private final CommandManager commandManager;
   private final ConnectionManager connectionManager;
   private final PlayerExecutor directGlobalExecutor;
-  private final MinestomPermissionChecker permissionChecker;
+  private final Provider<MinestomPermissionChecker> permissionChecker;
 
   @Inject
   public MinestomBridgeManagement(
@@ -76,7 +77,7 @@ public final class MinestomBridgeManagement extends PlatformBridgeManagement<Pla
     @NonNull ServiceInfoHolder serviceInfoHolder,
     @NonNull CloudServiceProvider serviceProvider,
     @NonNull WrapperConfiguration wrapperConfiguration,
-    @NonNull @Service MinestomPermissionChecker permissionChecker
+    @NonNull @Service Provider<MinestomPermissionChecker> permissionChecker
   ) {
     super(
       rpcFactory,
@@ -93,7 +94,7 @@ public final class MinestomBridgeManagement extends PlatformBridgeManagement<Pla
     this.permissionChecker = permissionChecker;
 
     this.directGlobalExecutor = new MinestomDirectPlayerExecutor(
-      this.permissionChecker,
+      this.permissionFunction(),
       commandManager,
       PlayerExecutor.GLOBAL_UNIQUE_ID,
       connectionManager::getOnlinePlayers);
@@ -129,7 +130,7 @@ public final class MinestomBridgeManagement extends PlatformBridgeManagement<Pla
 
   @Override
   public @NonNull BiFunction<Player, String, Boolean> permissionFunction() {
-    return this.permissionChecker::hasPermission;
+    return (player, permission) -> this.permissionChecker.get().hasPermission(player, permission);
   }
 
   @Override
@@ -165,7 +166,7 @@ public final class MinestomBridgeManagement extends PlatformBridgeManagement<Pla
     return uniqueId.equals(PlayerExecutor.GLOBAL_UNIQUE_ID)
       ? this.directGlobalExecutor
       : new MinestomDirectPlayerExecutor(
-        this.permissionChecker,
+        this.permissionFunction(),
         this.commandManager,
         uniqueId,
         () -> Collections.singleton(this.connectionManager.getOnlinePlayerByUuid(uniqueId)));

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomDirectPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomDirectPlayerExecutor.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.modules.bridge.impl.platform.PlatformPlayerExecutorAda
 import eu.cloudnetservice.modules.bridge.player.executor.ServerSelectorType;
 import java.util.Collection;
 import java.util.UUID;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import lombok.NonNull;
 import net.kyori.adventure.text.Component;
@@ -31,10 +32,10 @@ import org.jetbrains.annotations.Nullable;
 final class MinestomDirectPlayerExecutor extends PlatformPlayerExecutorAdapter<Player> {
 
   private final CommandManager commandManager;
-  private final MinestomPermissionChecker permissionChecker;
+  private final BiFunction<Player, String, Boolean> permissionChecker;
 
   public MinestomDirectPlayerExecutor(
-    @NonNull MinestomPermissionChecker permissionChecker,
+    @NonNull BiFunction<Player, String, Boolean> permissionChecker,
     @NonNull CommandManager commandManager,
     @NonNull UUID uniqueId,
     @NonNull Supplier<? extends Collection<? extends Player>> supplier
@@ -82,7 +83,7 @@ final class MinestomDirectPlayerExecutor extends PlatformPlayerExecutorAdapter<P
   @Override
   public void sendChatMessage(@NonNull Component message, @Nullable String permission) {
     this.forEach(player -> {
-      if (permission == null || this.permissionChecker.hasPermission(player, permission)) {
+      if (permission == null || this.permissionChecker.apply(player, permission)) {
         player.sendMessage(message);
       }
     });


### PR DESCRIPTION
### Motivation
During the api-impl split we introduced a MinestomPermissionChecker service as Minestom does not have any permission checking capabilities anymore. The service discovery does not work properly as the service is resolved before the service was registered.

### Modification
Use a provider to allow lazy construction of the PermissionChecker.

### Result
The MinestomPermissionChecker is properly resolved when needed.
