### PR TITLE
feat: allow node host override in docker module

### DIFF
--- a/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerConfiguration.java
+++ b/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerConfiguration.java
@@ -17,6 +17,7 @@
 package eu.cloudnetservice.modules.docker.config;
 
 import com.google.common.base.Preconditions;
+import eu.cloudnetservice.driver.network.HostAndPort;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,7 +37,8 @@ public record DockerConfiguration(
   @Nullable String registryEmail,
   @Nullable String registryPassword,
   @Nullable String registryUrl,
-  @Nullable String user
+  @Nullable String user,
+  @Nullable HostAndPort nodeHostOverride
 ) {
 
   public static @NonNull Builder builder() {
@@ -77,7 +79,9 @@ public record DockerConfiguration(
     private String registryEmail;
     private String registryPassword;
     private String registryUrl;
+
     private String user;
+    private HostAndPort nodeHostOverride;
 
     public @NonNull Builder javaImage(@NonNull DockerImage javaImage) {
       this.javaImage = javaImage;
@@ -159,6 +163,11 @@ public record DockerConfiguration(
       return this;
     }
 
+    public @NonNull Builder nodeHostOverride(@Nullable HostAndPort nodeHostOverride) {
+      this.nodeHostOverride = nodeHostOverride;
+      return this;
+    }
+
     public @NonNull DockerConfiguration build() {
       Preconditions.checkNotNull(this.javaImage, "Java docker image must be given");
       return new DockerConfiguration(
@@ -174,7 +183,8 @@ public record DockerConfiguration(
         this.registryEmail,
         this.registryPassword,
         this.registryUrl,
-        this.user);
+        this.user,
+        this.nodeHostOverride);
     }
   }
 }

--- a/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/TaskDockerConfig.java
+++ b/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/TaskDockerConfig.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.modules.docker.config;
 
+import eu.cloudnetservice.driver.network.HostAndPort;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.NonNull;
@@ -23,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 public record TaskDockerConfig(
   @Nullable DockerImage javaImage,
+  @Nullable HostAndPort nodeHostOverride,
   @NonNull Set<String> volumes,
   @NonNull Set<String> binds,
   @NonNull Set<DockerPortMapping> exposedPorts
@@ -43,12 +45,18 @@ public record TaskDockerConfig(
   public static class Builder {
 
     private DockerImage javaImage;
+    private HostAndPort nodeHostOverride;
     private Set<String> volumes = new HashSet<>();
     private Set<String> binds = new HashSet<>();
     private Set<DockerPortMapping> exposedPorts = new HashSet<>();
 
     public @NonNull Builder javaImage(@Nullable DockerImage javaImage) {
       this.javaImage = javaImage;
+      return this;
+    }
+
+    public @NonNull Builder nodeHostOverride(@Nullable HostAndPort nodeHostOverride) {
+      this.nodeHostOverride = nodeHostOverride;
       return this;
     }
 
@@ -85,6 +93,7 @@ public record TaskDockerConfig(
     public @NonNull TaskDockerConfig build() {
       return new TaskDockerConfig(
         this.javaImage,
+        this.nodeHostOverride,
         Set.copyOf(this.volumes),
         Set.copyOf(this.binds),
         Set.copyOf(this.exposedPorts));

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerCommand.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerCommand.java
@@ -17,6 +17,7 @@
 package eu.cloudnetservice.modules.docker.impl;
 
 import eu.cloudnetservice.driver.language.I18n;
+import eu.cloudnetservice.driver.network.HostAndPort;
 import eu.cloudnetservice.driver.provider.ServiceTaskProvider;
 import eu.cloudnetservice.driver.registry.Service;
 import eu.cloudnetservice.driver.service.ServiceTask;
@@ -72,6 +73,31 @@ public record DockerCommand(@NonNull DockerizedServicesModule module, @NonNull S
   ) {
     this.updateTaskDockerConfig(task, (_, builder) -> builder.javaImage(null));
     source.sendMessage(i18n.translate("command-tasks-set-property-success", "javaImage", task.name(), "null"));
+  }
+
+  @Command("docker task <task> nodeHostOverride <host>")
+  public void setNodeHostOverride(
+    @NonNull @Service I18n i18n,
+    @NonNull CommandSource source,
+    @Argument("task") @NonNull ServiceTask task,
+    @Argument(value = "host", parserName = "anyHostAndPort") @NonNull HostAndPort hostOverride
+  ) {
+    this.updateTaskDockerConfig(task, (_, builder) -> builder.nodeHostOverride(hostOverride));
+    source.sendMessage(i18n.translate(
+      "command-tasks-set-property-success",
+      "nodeHostOverride",
+      task.name(),
+      hostOverride));
+  }
+
+  @Command("docker task <task> remove nodeHostOverride")
+  public void removeNodeHostOverride(
+    @NonNull @Service I18n i18n,
+    @NonNull CommandSource source,
+    @Argument("task") @NonNull ServiceTask task
+  ) {
+    this.updateTaskDockerConfig(task, (_, builder) -> builder.nodeHostOverride(null));
+    source.sendMessage(i18n.translate("command-tasks-set-property-success", "nodeHostOverride", task.name(), "null"));
   }
 
   @Command("docker task <task> add bind <bind>")
@@ -249,6 +275,22 @@ public record DockerCommand(@NonNull DockerizedServicesModule module, @NonNull S
     source.sendMessage(i18n.translate("module-docker-command-remove-success", "user"));
   }
 
+  @Command("docker config nodeHostOverride <host>")
+  public void setNodeHostOverride(
+    @NonNull @Service I18n i18n,
+    @NonNull CommandSource source,
+    @Argument(value = "host", parserName = "anyHostAndPort") @NonNull HostAndPort hostOverride
+  ) {
+    this.updateDockerConfig((_, builder) -> builder.nodeHostOverride(hostOverride));
+    source.sendMessage(i18n.translate("module-docker-command-set-success", "nodeHostOverride", hostOverride));
+  }
+
+  @Command("docker config remove nodeHostOverride")
+  public void removeNodeHostOverride(@NonNull @Service I18n i18n, @NonNull CommandSource source) {
+    this.updateDockerConfig((_, builder) -> builder.nodeHostOverride(null));
+    source.sendMessage(i18n.translate("module-docker-command-remove-success", "nodeHostOverride"));
+  }
+
   @Command("docker config add bind <bind>")
   public void addBind(
     @NonNull @Service I18n i18n,
@@ -290,7 +332,11 @@ public record DockerCommand(@NonNull DockerizedServicesModule module, @NonNull S
   }
 
   @Command("docker config remove volume <volume>")
-  public void removeVolumes(@NonNull @Service I18n i18n, @NonNull CommandSource source, @Argument("volume") String volume) {
+  public void removeVolumes(
+    @NonNull @Service I18n i18n,
+    @NonNull CommandSource source,
+    @Argument("volume") String volume
+  ) {
     this.updateDockerConfig((config, builder) -> builder.volumes(config.volumes().stream()
       .filter(entry -> !entry.equals(volume))
       .collect(Collectors.toSet())));

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedService.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedService.java
@@ -34,6 +34,7 @@ import com.github.dockerjava.api.model.Volume;
 import eu.cloudnetservice.driver.document.property.DocProperty;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.language.I18n;
+import eu.cloudnetservice.driver.network.HostAndPort;
 import eu.cloudnetservice.driver.provider.ServiceTaskProvider;
 import eu.cloudnetservice.driver.registry.Service;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
@@ -318,6 +319,16 @@ public class DockerizedService extends JVMService {
         LOGGER.debug("Unable to remove docker container", exception);
       }
     }
+  }
+
+  @Override
+  protected @NonNull HostAndPort selectConnectListener(@NonNull List<HostAndPort> listeners) {
+    var taskConfig = this.resolveTaskDockerConfig();
+    var overriddenNodeHostFromTask = this.readFromTaskConfig(taskConfig, TaskDockerConfig::nodeHostOverride);
+    var nodeHostOverride = overriddenNodeHostFromTask != null
+      ? overriddenNodeHostFromTask
+      : this.configuration.nodeHostOverride();
+    return Objects.requireNonNullElseGet(nodeHostOverride, () -> super.selectConnectListener(listeners));
   }
 
   protected @NonNull Bind[] collectBinds(@NonNull Path wrapperFilePath, @Nullable TaskDockerConfig config) {

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedServicesModule.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedServicesModule.java
@@ -58,6 +58,7 @@ public class DockerizedServicesModule extends DriverModule {
         null,
         null,
         null,
+        null,
         null),
       DocumentFactory.json());
   }


### PR DESCRIPTION
### Motivation
The ip/port that can be used from inside a docker network to connect to a node listener on the host system might be different that any configured listener on the node (e.g. `host.docker.internal` in some cases). There is currently no way to connect to a node listener outside the docker network (except for custom modules/server implementations).

### Modification
Add the possibility to override the node host (globally and task-specific) to allow specifying a different host and port to connect to from inside a docker network.

### Result
Services can connect to a node listener bound outside of a docker network.
