### PR TITLE
chore: improve sign layout ticking

### DIFF
--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
@@ -16,19 +16,34 @@
 
 package eu.cloudnetservice.modules.signs.configuration;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+import org.jetbrains.annotations.ApiStatus;
 
 @ToString
 @EqualsAndHashCode
 public class SignLayoutsHolder {
 
+  private static final VarHandle LAST_UPDATE_TICK;
+
+  static {
+    try {
+      var lookup = MethodHandles.lookup();
+      LAST_UPDATE_TICK = lookup.findVarHandle(SignLayoutsHolder.class, "lastUpdateTick", long.class);
+    } catch (NoSuchFieldException | IllegalAccessException exception) {
+      throw new ExceptionInInitializerError(exception);
+    }
+  }
+
   private final int animationsPerSecond;
   private final List<SignLayout> signLayouts;
 
-  private transient boolean tickBlocked;
+  @SuppressWarnings("unused") // accessed/changed by LAST_UPDATE_TICK
+  private transient long lastUpdateTick;
   private transient int currentAnimation = -1;
 
   public SignLayoutsHolder(int animationsPerSecond, @NonNull List<SignLayout> signLayouts) {
@@ -52,33 +67,26 @@ public class SignLayoutsHolder {
     return !this.signLayouts.isEmpty();
   }
 
-  public boolean tickBlocked() {
-    return this.tickBlocked;
-  }
+  /* == apis only accessed by platforms, not for external use == */
 
-  public void enableTickBlock() {
-    this.tickBlocked = true;
-  }
-
-  public @NonNull SignLayoutsHolder releaseTickBlock() {
-    this.tickBlocked = false;
-    return this;
-  }
-
+  @ApiStatus.Internal
   public @NonNull SignLayout currentLayout() {
-    return this.signLayouts().get(this.currentAnimation());
+    return this.signLayouts().get(this.currentAnimation);
   }
 
-  public @NonNull SignLayoutsHolder tick() {
-    if (!this.tickBlocked()) {
+  @ApiStatus.Internal
+  public void tick(long currentTick) {
+    // check if the layout was already ticked
+    var lastUpdateTick = (long) LAST_UPDATE_TICK.getVolatile(this);
+    if (lastUpdateTick == currentTick) {
+      return;
+    }
+
+    // update the current animation unless the value was already updated in the current tick
+    if (LAST_UPDATE_TICK.compareAndSet(this, lastUpdateTick, currentTick)) {
       if (++this.currentAnimation >= this.signLayouts.size()) {
         this.currentAnimation = 0;
       }
     }
-    return this;
-  }
-
-  public int currentAnimation() {
-    return Math.max(0, this.currentAnimation);
   }
 }

--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
@@ -23,6 +23,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 @ToString
 @EqualsAndHashCode
@@ -44,7 +45,6 @@ public class SignLayoutsHolder {
 
   @SuppressWarnings("unused") // accessed/changed by LAST_UPDATE_TICK
   private transient long lastUpdateTick;
-  private transient int currentAnimation = -1;
 
   public SignLayoutsHolder(int animationsPerSecond, @NonNull List<SignLayout> signLayouts) {
     this.animationsPerSecond = animationsPerSecond;
@@ -70,23 +70,25 @@ public class SignLayoutsHolder {
   /* == apis only accessed by platforms, not for external use == */
 
   @ApiStatus.Internal
-  public @NonNull SignLayout currentLayout() {
-    return this.signLayouts().get(this.currentAnimation);
+  public @Nullable SignLayout currentLayout(int tps) {
+    var layouts = this.signLayouts;
+    var layoutEntryCount = layouts.size();
+    return switch (layoutEntryCount) {
+      case 0 -> null;
+      case 1 -> layouts.getFirst();
+      default -> {
+        var lastUpdateTick = (long) LAST_UPDATE_TICK.getAcquire(this);
+        var animationsPerSecond = Math.min(tps, this.animationsPerSecond); // cannot display more animations per second
+        var animationIntervalTicks = tps / animationsPerSecond;
+        var steps = lastUpdateTick / animationIntervalTicks;
+        var layoutIndex = (int) (steps % layoutEntryCount);
+        yield layouts.get(layoutIndex);
+      }
+    };
   }
 
   @ApiStatus.Internal
   public void tick(long currentTick) {
-    // check if the layout was already ticked
-    var lastUpdateTick = (long) LAST_UPDATE_TICK.getVolatile(this);
-    if (lastUpdateTick == currentTick) {
-      return;
-    }
-
-    // update the current animation unless the value was already updated in the current tick
-    if (LAST_UPDATE_TICK.compareAndSet(this, lastUpdateTick, currentTick)) {
-      if (++this.currentAnimation >= this.signLayouts.size()) {
-        this.currentAnimation = 0;
-      }
-    }
+    LAST_UPDATE_TICK.setRelease(this, currentTick);
   }
 }

--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
@@ -34,7 +34,9 @@ public class SignLayoutsHolder {
   static {
     try {
       var lookup = MethodHandles.lookup();
-      LAST_UPDATE_TICK = lookup.findVarHandle(SignLayoutsHolder.class, "lastUpdateTick", long.class);
+      LAST_UPDATE_TICK = lookup
+        .findVarHandle(SignLayoutsHolder.class, "lastUpdateTick", long.class)
+        .withInvokeExactBehavior();
     } catch (NoSuchFieldException | IllegalAccessException exception) {
       throw new ExceptionInInitializerError(exception);
     }

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSignManagement.java
@@ -327,14 +327,15 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
         var holder = LayoutUtil.layoutHolder(ownEntry, sign.base(), sign.currentTarget());
         if (holder.hasLayouts() && holder.animationsPerSecond() > 0) {
           var animationIntervalTicks = this.tps() / holder.animationsPerSecond();
-          if (this.currentTick % animationIntervalTicks == 0) {
+          if (animationIntervalTicks == 0 || this.currentTick % animationIntervalTicks == 0) {
             holder.tick(this.currentTick);
-            if (sign.needsUpdates()) {
+            var nextLayout = holder.currentLayout(this.tps());
+            if (nextLayout != null && sign.needsUpdates()) {
               // the sign is loaded and needs an update to display the new layout
               if (signsToTick == null) {
                 signsToTick = new ArrayList<>();
               }
-              signsToTick.add(new Tuple2<>(holder.currentLayout(), sign));
+              signsToTick.add(new Tuple2<>(nextLayout, sign));
             }
           }
         }

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSignManagement.java
@@ -28,16 +28,17 @@ import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.configuration.SignConfigurationEntry;
-import eu.cloudnetservice.modules.signs.configuration.SignLayoutsHolder;
+import eu.cloudnetservice.modules.signs.configuration.SignLayout;
 import eu.cloudnetservice.modules.signs.configuration.SignsConfiguration;
 import eu.cloudnetservice.modules.signs.impl.AbstractSignManagement;
 import eu.cloudnetservice.modules.signs.impl.SharedChannelMessageListener;
 import eu.cloudnetservice.modules.signs.impl.util.LayoutUtil;
 import eu.cloudnetservice.modules.signs.impl.util.PriorityUtil;
 import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
+import io.vavr.Tuple2;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -76,7 +77,7 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
   protected final Map<WorldPosition, PlatformSign<P, C>> platformSigns = new ConcurrentHashMap<>();
   protected final Queue<ServiceInfoSnapshot> waitingAssignments = new ConcurrentLinkedQueue<>();
 
-  protected int currentTick;
+  protected long currentTick;
 
   protected PlatformSignManagement(
     @NonNull EventManager eventManager,
@@ -246,10 +247,6 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
   }
 
   public void initialize() {
-    this.initialize(new HashMap<>());
-  }
-
-  public void initialize(@NonNull Map<SignLayoutsHolder, Set<PlatformSign<P, C>>> signsNeedingTicking) {
     if (this.signsConfiguration != null) {
       // initialize the platform signs
       for (var value : this.signs.values()) {
@@ -259,7 +256,7 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
       // start the needed tasks
       this.executorService.scheduleWithFixedDelay(() -> {
         try {
-          this.tick(signsNeedingTicking);
+          this.tick();
         } catch (Throwable throwable) {
           LOGGER.error("Exception ticking signs", throwable);
         }
@@ -318,43 +315,38 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
   }
 
   @ApiStatus.Internal
-  protected void tick(@NonNull Map<SignLayoutsHolder, Set<PlatformSign<P, C>>> signsNeedingTicking) {
+  protected void tick() {
     this.currentTick++;
 
     var ownEntry = this.applicableSignConfigurationEntry();
     if (ownEntry != null) {
-      // marker if there are any updates we need to do - if there are no updates there is no need to schedule them
-      // which saves server resources
-      var hasUpdates = false;
-      for (var value : this.platformSigns.values()) {
-        // tick all sign layouts which we need to tick in the current tick
-        var holder = LayoutUtil.layoutHolder(ownEntry, value.base(), value.currentTarget());
-        if (holder.hasLayouts() && holder.animationsPerSecond() > 0
-          && this.currentTick % (this.tps() / holder.animationsPerSecond()) == 0) {
-          // tick the holder, then block the tick
-          holder.tick().enableTickBlock();
-          // register the sign for updates if we need to
-          if (value.needsUpdates()) {
-            hasUpdates = true;
-            signsNeedingTicking.computeIfAbsent(holder, $ -> new HashSet<>()).add(value);
+      List<Tuple2<SignLayout, PlatformSign<P, C>>> signsToTick = null;
+      for (var sign : this.platformSigns.values()) {
+        // update all sign layouts that need an animation tick,
+        // also register the sign for an update if the associated layout changed
+        var holder = LayoutUtil.layoutHolder(ownEntry, sign.base(), sign.currentTarget());
+        if (holder.hasLayouts() && holder.animationsPerSecond() > 0) {
+          var animationIntervalTicks = this.tps() / holder.animationsPerSecond();
+          if (this.currentTick % animationIntervalTicks == 0) {
+            holder.tick(this.currentTick);
+            if (sign.needsUpdates()) {
+              // the sign is loaded and needs an update to display the new layout
+              if (signsToTick == null) {
+                signsToTick = new ArrayList<>();
+              }
+              signsToTick.add(new Tuple2<>(holder.currentLayout(), sign));
+            }
           }
         }
       }
 
-      // execute updates if there are any
-      if (hasUpdates) {
+      if (signsToTick != null) {
+        var finalSignsToTick = signsToTick; // must not be modified anymore
         this.mainThreadExecutor.execute(() -> {
-          for (var entry : signsNeedingTicking.entrySet()) {
-            var layout = entry.getKey().releaseTickBlock().currentLayout();
-            // push out all sign changes we recorded previously
-            // we need to copy all entries of the set into a new array in case we have a thread de-sync (for example async
-            // tick but sync update) as we need to clear the underlying set after the call to prevent double ticks
-            var iterator = entry.getValue().iterator();
-            while (iterator.hasNext()) {
-              // update the sign, at this point the sign must be loaded - we can just push the change and unregister it
-              iterator.next().updateSign(layout);
-              iterator.remove();
-            }
+          for (var layoutSignTuple : finalSignsToTick) {
+            var layout = layoutSignTuple._1();
+            var sign = layoutSignTuple._2();
+            sign.updateSign(layout);
           }
         });
       }
@@ -362,22 +354,13 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
       // check if we have waiting services which are not yet assigned - try to assign them to a sign
       if (!this.waitingAssignments.isEmpty()) {
         for (var waitingAssignment : this.waitingAssignments) {
-          // get the next free sign to which can assign the service
           var freeSign = this.nextFreeSign(waitingAssignment);
           if (freeSign != null) {
-            // remove instantly
             this.waitingAssignments.remove(waitingAssignment);
-            // assign the service to the sign, the layout of it will be updated within the next second
-            // we could directly update the layout but there is no need to do that
             freeSign.currentTarget(waitingAssignment);
           }
         }
       }
-    }
-
-    // reset the tick counter if we reached the max tps
-    if (this.currentTick >= this.tps()) {
-      this.currentTick = 0;
     }
   }
 

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/SpongeSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/SpongeSignManagement.java
@@ -22,7 +22,6 @@ import eu.cloudnetservice.ext.platforminject.api.stereotype.ProvidesFor;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.SignManagement;
-import eu.cloudnetservice.modules.signs.configuration.SignLayoutsHolder;
 import eu.cloudnetservice.modules.signs.impl.InternalSignManagement;
 import eu.cloudnetservice.modules.signs.impl.platform.PlatformSign;
 import eu.cloudnetservice.modules.signs.impl.platform.PlatformSignManagement;
@@ -30,8 +29,6 @@ import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
@@ -133,10 +130,8 @@ public class SpongeSignManagement extends PlatformSignManagement<ServerPlayer, S
   }
 
   @Override
-  protected void tick(@NonNull Map<SignLayoutsHolder, Set<PlatformSign<ServerPlayer, Component>>> signsNeedingTicking) {
-    this.mainThreadExecutor.execute(() -> {
-      super.tick(signsNeedingTicking);
-    });
+  protected void tick() {
+    this.mainThreadExecutor.execute(super::tick);
   }
 
   @Override

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/util/LayoutUtil.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/util/LayoutUtil.java
@@ -47,14 +47,6 @@ public final class LayoutUtil {
     return layoutHolder(entry, sign, snapshot).currentLayout();
   }
 
-  public static @NonNull SignLayout layoutAndTick(
-    @NonNull SignConfigurationEntry entry,
-    @NonNull Sign sign,
-    @Nullable ServiceInfoSnapshot snapshot
-  ) {
-    return layoutHolder(entry, sign, snapshot).tick().currentLayout();
-  }
-
   public static boolean switchToSearching(
     @NonNull ServiceInfoSnapshot snapshot,
     @Nullable SignConfigurationEntry entry

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/util/LayoutUtil.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/util/LayoutUtil.java
@@ -39,14 +39,6 @@ public final class LayoutUtil {
     throw new UnsupportedOperationException();
   }
 
-  public static @NonNull SignLayout layout(
-    @NonNull SignConfigurationEntry entry,
-    @NonNull Sign sign,
-    @Nullable ServiceInfoSnapshot snapshot
-  ) {
-    return layoutHolder(entry, sign, snapshot).currentLayout();
-  }
-
   public static boolean switchToSearching(
     @NonNull ServiceInfoSnapshot snapshot,
     @Nullable SignConfigurationEntry entry


### PR DESCRIPTION
### Motivation
The current sign layout ticking process is based on the assumption that there won't be any race conditions. However, there is a slim chance that a race happens which will then cause all layouts of a holder to freeze until a server restart or config reload.

### Modification
Base the sign ticking process and layout retrieval entirely on the last tick when the sign was updated. This removes the need for different places to lock/unlock sign layout ticking and therefore prevents races between the sign ticking thread and the main server thread. This also applies to the map that tracks the layouts that need to be updated as a result of the current tick.

### Result
Sign layout ticking is resistent against race conditions and uses the server tick count as the single point of truth when retrieving the applicable sign layout.
