### PR TITLE
chore: update checkstyle, enable NewlineAtEndOfFile check

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -35,6 +35,9 @@
     <property name="max" value="140"/>
     <property name="ignorePattern" value="^package.*|^import.*|a href|http://|https://|ftp://|//.*"/>
   </module>
+  <module name="NewlineAtEndOfFile">
+    <property name="lineSeparator" value="lf"/>
+  </module>
   <module name="TreeWalker">
     <property name="skipFileOnJavaParseException" value="true"/>
     <property name="javaParseExceptionSeverity" value="info"/>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ juppiter = "0.4.0"
 spotless = "7.0.4"
 fabricLoom = "1.10.5"
 nexusPublish = "2.0.0"
-checkstyleTools = "10.26.0"
+checkstyleTools = "10.26.1"
 
 # google libs
 gson = "2.13.1"


### PR DESCRIPTION
### Motivation
checkstyle has a new version and a new check `NewlineAtEndOfFile` and we should update & activate the check.

### Modification
Update checkstyle to 10.26.1 and activate the check.

### Result
checkstyle is up-to-date and newlines at the end of files are required.
