### PR TITLE
chore: drop s01 repository as it reached EOL today

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,10 +32,7 @@ allprojects {
 
   repositories {
     releasesOnly(mavenCentral())
-
-    // old and new sonatype snapshot repository
     snapshotsOnly(maven("https://central.sonatype.com/repository/maven-snapshots/"))
-    snapshotsOnly(maven("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
 
     // ensure that we use these repositories for snapshots/releases only (improves lookup times)
     releasesOnly(maven("https://repository.derklaro.dev/releases/"))


### PR DESCRIPTION
### Motivation
The old sonatype snapshots repository (s01.oss.sonatype.org) reached EOL today and we shouldn't use it anymore.

### Modification
Drop s01 repository declaration.

### Result
No more usages of EOL snapshots repository.
