### PR TITLE
fix: unsafe transformer disable system property

### DIFF
--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Premain.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Premain.java
@@ -41,8 +41,8 @@ final class Premain {
     // init and registers the unsafe transformer very early in the process. this is done here
     // as we usually don't allow transformers to be registered so early as they're intended to
     // transform classes brought in by the wrapped application, not by the jdk
-    var transformerDisabled = Boolean.getBoolean("cloudnet.wrapper.unsafe-transform-disabled");
-    if (!transformerDisabled) {
+    var unsafeTransformerDisabled = Boolean.getBoolean("cloudnet.wrapper.unsafe-transform-disabled");
+    if (!unsafeTransformerDisabled) {
       UnsafeTransformer.init(inst);
       Premain.transformerRegistry.registerTransformer(new UnsafeTransformer());
     }

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Premain.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Premain.java
@@ -41,8 +41,11 @@ final class Premain {
     // init and registers the unsafe transformer very early in the process. this is done here
     // as we usually don't allow transformers to be registered so early as they're intended to
     // transform classes brought in by the wrapped application, not by the jdk
-    UnsafeTransformer.init(inst);
-    Premain.transformerRegistry.registerTransformer(new UnsafeTransformer());
+    var transformerDisabled = Boolean.getBoolean("cloudnet.wrapper.unsafe-transform-disabled");
+    if (!transformerDisabled) {
+      UnsafeTransformer.init(inst);
+      Premain.transformerRegistry.registerTransformer(new UnsafeTransformer());
+    }
   }
 
   public static void preloadClasses(@NonNull Path file, @NonNull ClassLoader loader) {

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeTransformer.java
@@ -67,13 +67,9 @@ public final class UnsafeTransformer implements ClassTransformer {
     MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_String, ConstantDescs.CD_String);
 
   /**
-   * Constructs a new instance of this transformer, usually done via SPI.
+   * Constructs a new instance of this transformer, only public for internal use.
    */
   public UnsafeTransformer() {
-    var transformerDisabled = Boolean.getBoolean("cloudnet.wrapper.unsafe-transform-disabled");
-    if (transformerDisabled) {
-      throw new UnsupportedOperationException("transformer disabled via system property");
-    }
   }
 
   /**


### PR DESCRIPTION
### Motivation
The unsafe transformer is registered in a different way than usual (usually transformers are registered via SPI), so disabling the transformer by throwing an exception is not a viable option as it results in a jvm crash.

### Modification
Move the transformer disabled check into the premain class and don't try to construct/register the transformer if it is disabled.

### Result
No more jvm crashes when the unsafe transformer is disabled using a system property.
