### PR TITLE
fix: compute field offsets per-class instead of globally

### DIFF
--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/FieldOffsetOps.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/FieldOffsetOps.java
@@ -29,12 +29,12 @@ import org.jetbrains.annotations.Nullable;
  *
  * @since 4.0
  */
-final class FieldOffsetRegistry {
+final class FieldOffsetOps {
 
   private static final int FIELD_COUNT_IN_CLASS = Class.class.getDeclaredFields().length;
   private static final Map<FieldCacheKey, Field> FIELD_LOOKUP_CACHE = new ConcurrentHashMap<>(16, 0.9f, 1);
 
-  private FieldOffsetRegistry() {
+  private FieldOffsetOps() {
     throw new UnsupportedOperationException();
   }
 

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/FieldOffsetRegistry.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/FieldOffsetRegistry.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.wrapper.impl.transform.unsafe;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Registry that holds the offsets for fields.
+ *
+ * @since 4.0
+ */
+final class FieldOffsetRegistry {
+
+  private static final int FIELD_COUNT_IN_CLASS = Class.class.getDeclaredFields().length;
+  private static final Map<FieldCacheKey, Field> FIELD_LOOKUP_CACHE = new ConcurrentHashMap<>(16, 0.9f, 1);
+
+  private FieldOffsetRegistry() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Get the base object to use for the given static field.
+   *
+   * @param field the field to get the base of.
+   * @return the base of the given field.
+   * @throws NullPointerException if the given field is null.
+   */
+  public static @NonNull Object staticFieldBase(@NonNull Field field) {
+    return field.getDeclaringClass();
+  }
+
+  /**
+   * Gets the offset of the given field in the clazz hierarchy.
+   *
+   * @param field the field to get the offset of.
+   * @return the offset of the given class in the class hierarchy.
+   * @throws NullPointerException if the given field is null.
+   */
+  public static long fieldOffset(@NonNull Field field) {
+    var offset = fieldSlot(field);
+    var clazz = field.getDeclaringClass();
+    while ((clazz = clazz.getSuperclass()) != null) {
+      var clazzFields = clazz.getDeclaredFields();
+      offset += clazzFields.length;
+    }
+
+    if (Modifier.isStatic(field.getModifiers())) {
+      // to get a static field, a class instance (declaring class of the field)
+      // is passed to getXXX(instance, offset) methods. these methods can therefore
+      // not differentiate between a request to a get an instance field of the "Class"
+      // class and a static field, and therefore the fields in "Class" are always visited
+      // by the method too. to prevent a conflict with invalid static field offsets caused
+      // by static fields in the class "Class", we move the offset here by the count of
+      // fields in "Class" to allow for a correct offset calculation when reading the value
+      offset += FIELD_COUNT_IN_CLASS;
+    }
+
+    return offset;
+  }
+
+  /**
+   * Get the slot of the given field in its declaring class.
+   *
+   * @param field the field to get the slot of.
+   * @return the slot of the field in its declaring class.
+   * @throws NullPointerException if the given field is null.
+   */
+  private static long fieldSlot(@NonNull Field field) {
+    var clazz = field.getDeclaringClass();
+    var fields = clazz.getDeclaredFields();
+    for (var slot = 0; slot < fields.length; slot++) {
+      var atSlot = fields[slot];
+      if (atSlot.equals(field)) {
+        return slot;
+      }
+    }
+
+    throw new AssertionError();
+  }
+
+  /**
+   * Resolves the field associated with the given instance and offset.
+   *
+   * @param base   the field base to get the field based of.
+   * @param offset the offset of the field to get.
+   * @return the field with the given offset in the given base.
+   * @throws NullPointerException if the given base is null.
+   */
+  public static @Nullable Field fieldFromOffset(@NonNull Object base, long offset) {
+    if (offset < 0) {
+      // bail out early, a field with a negative offset cannot exist
+      return null;
+    }
+
+    var clazz = base instanceof Class<?> c ? c : base.getClass();
+    var cacheKey = new FieldCacheKey(clazz, offset);
+    return FIELD_LOOKUP_CACHE.computeIfAbsent(cacheKey, _ -> {
+      var classHierarchy = new ArrayList<Class<?>>();
+      for (var c = clazz; c != null; c = c.getSuperclass()) {
+        if (base instanceof Class<?> && c == Object.class) {
+          // special case handling: if a class was provided as the instance to operate
+          // on, this can have 2 meanings: either the caller requests a static field or
+          // an instance field in the class "Class" which does usually not appear in
+          // instance.getDeclaredFields() [which is intended as the fields in Class are
+          // not inherited into whatever the given class is when looking though the
+          // reflection api] - we therefore need to insert the class "Class" into the
+          // hierarchy manually here to allow finding fields in there too
+          classHierarchy.add(Class.class);
+        }
+
+        classHierarchy.add(c);
+      }
+
+      var remaining = offset;
+      for (var c : classHierarchy.reversed()) {
+        var fields = c.getDeclaredFields();
+        if (remaining < fields.length) {
+          return fields[(int) remaining];
+        }
+
+        remaining -= fields.length;
+      }
+
+      return null;
+    });
+  }
+
+  /**
+   * A cache key for a resolved field based on the base class and field offset.
+   *
+   * @param clazz  the class in which the field was resolved.
+   * @param offset the offset of the field that was resolved.
+   */
+  private record FieldCacheKey(@NonNull Class<?> clazz, long offset) {
+
+  }
+}

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDefiner.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDefiner.java
@@ -42,7 +42,7 @@ final class UnsafeReplacementDefiner {
   // classes that should be appended to the bootstrap class path
   private static final Set<String> BOOTSTRAP_CLASS_PREFIXES = Set.of(
     "ArrayOps",
-    "FieldOffsetRegistry",
+    "FieldOffsetOps",
     "FieldOps",
     "LazyMemoizingSupplier",
     "MemoryControlOps",

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDefiner.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDefiner.java
@@ -42,6 +42,7 @@ final class UnsafeReplacementDefiner {
   // classes that should be appended to the bootstrap class path
   private static final Set<String> BOOTSTRAP_CLASS_PREFIXES = Set.of(
     "ArrayOps",
+    "FieldOffsetRegistry",
     "FieldOps",
     "LazyMemoizingSupplier",
     "MemoryControlOps",

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegate.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegate.java
@@ -26,11 +26,7 @@ import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.security.ProtectionDomain;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -49,11 +45,6 @@ import org.jetbrains.annotations.Nullable;
  */
 @Deprecated
 public final class UnsafeReplacementDelegate {
-
-  // counter for handing out field offsets; mapping for handed-out offsets to their actual field
-  private static final Map<Long, Field> FIELD_OFFSET_TO_FIELD_LOOKUP = new ConcurrentHashMap<>();
-  private static final AtomicLong FIELD_OFFSET_COUNTER =
-    new AtomicLong(ThreadLocalRandom.current().nextInt(Short.MAX_VALUE, Integer.MAX_VALUE));
 
   // accessors for cleaning up direct byte buffers
   private static final Supplier<Consumer<ByteBuffer>> BB_CLEANER = createByteBufferCleaner();
@@ -277,9 +268,7 @@ public final class UnsafeReplacementDelegate {
   @UnsafeReplacement(name = "objectFieldOffset")
   public static long unsafeObjectFieldOffset(Field f) {
     validateSaneFieldAccess(f);
-    var nextOffset = FIELD_OFFSET_COUNTER.getAndIncrement();
-    FIELD_OFFSET_TO_FIELD_LOOKUP.put(nextOffset, f);
-    return nextOffset;
+    return FieldOffsetRegistry.fieldOffset(f);
   }
 
   /* replacement for staticFieldOffset(Field) */
@@ -292,7 +281,7 @@ public final class UnsafeReplacementDelegate {
   @UnsafeReplacement(name = "staticFieldBase")
   public static Object unsafeStaticFieldBase(Field f) {
     validateSaneFieldAccess(f);
-    return f.getDeclaringClass();
+    return FieldOffsetRegistry.staticFieldBase(f);
   }
   //</editor-fold>
 
@@ -311,7 +300,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FIELD_OFFSET_TO_FIELD_LOOKUP.get(offset);
+      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
       return field == null ? null : FieldOps.fieldGet(field, object, op);
     } catch (Throwable throwable) {
       UnsafeLogUtil.debug("Unable to unsafe get: [obj={}, offset={}, op={}]", object, offset, op, throwable);
@@ -601,7 +590,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FIELD_OFFSET_TO_FIELD_LOOKUP.get(offset);
+      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
       if (field != null) {
         var typeKind = ValueTypeKind.of(field.getType());
         FieldOps.fieldPut(typeKind, field, object, value, op);
@@ -870,7 +859,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FIELD_OFFSET_TO_FIELD_LOOKUP.get(offset);
+      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
       if (field != null) {
         var typeKind = ValueTypeKind.of(field.getType());
         return FieldOps.fieldComparePut(typeKind, field, object, expected, value);
@@ -928,7 +917,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FIELD_OFFSET_TO_FIELD_LOOKUP.get(offset);
+      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
       if (field != null) {
         var typeKind = ValueTypeKind.of(field.getType());
         return FieldOps.fieldGetAdd(typeKind, field, object, delta);
@@ -983,7 +972,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FIELD_OFFSET_TO_FIELD_LOOKUP.get(offset);
+      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
       if (field != null) {
         var typeKind = ValueTypeKind.of(field.getType());
         return FieldOps.fieldGetPut(typeKind, field, object, value);

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegate.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegate.java
@@ -268,7 +268,7 @@ public final class UnsafeReplacementDelegate {
   @UnsafeReplacement(name = "objectFieldOffset")
   public static long unsafeObjectFieldOffset(Field f) {
     validateSaneFieldAccess(f);
-    return FieldOffsetRegistry.fieldOffset(f);
+    return FieldOffsetOps.fieldOffset(f);
   }
 
   /* replacement for staticFieldOffset(Field) */
@@ -281,7 +281,7 @@ public final class UnsafeReplacementDelegate {
   @UnsafeReplacement(name = "staticFieldBase")
   public static Object unsafeStaticFieldBase(Field f) {
     validateSaneFieldAccess(f);
-    return FieldOffsetRegistry.staticFieldBase(f);
+    return FieldOffsetOps.staticFieldBase(f);
   }
   //</editor-fold>
 
@@ -300,7 +300,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
+      var field = FieldOffsetOps.fieldFromOffset(object, offset);
       return field == null ? null : FieldOps.fieldGet(field, object, op);
     } catch (Throwable throwable) {
       UnsafeLogUtil.debug("Unable to unsafe get: [obj={}, offset={}, op={}]", object, offset, op, throwable);
@@ -590,7 +590,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
+      var field = FieldOffsetOps.fieldFromOffset(object, offset);
       if (field != null) {
         var typeKind = ValueTypeKind.of(field.getType());
         FieldOps.fieldPut(typeKind, field, object, value, op);
@@ -859,7 +859,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
+      var field = FieldOffsetOps.fieldFromOffset(object, offset);
       if (field != null) {
         var typeKind = ValueTypeKind.of(field.getType());
         return FieldOps.fieldComparePut(typeKind, field, object, expected, value);
@@ -917,7 +917,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
+      var field = FieldOffsetOps.fieldFromOffset(object, offset);
       if (field != null) {
         var typeKind = ValueTypeKind.of(field.getType());
         return FieldOps.fieldGetAdd(typeKind, field, object, delta);
@@ -972,7 +972,7 @@ public final class UnsafeReplacementDelegate {
       }
 
       // requested read of static or instance field
-      var field = FieldOffsetRegistry.fieldFromOffset(object, offset);
+      var field = FieldOffsetOps.fieldFromOffset(object, offset);
       if (field != null) {
         var typeKind = ValueTypeKind.of(field.getType());
         return FieldOps.fieldGetPut(typeKind, field, object, value);

--- a/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegateTest.java
+++ b/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegateTest.java
@@ -22,9 +22,11 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.foreign.MemorySegment;
 import java.lang.reflect.AccessFlag;
+import java.lang.reflect.Modifier;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.security.ProtectionDomain;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -326,6 +328,58 @@ public class UnsafeReplacementDelegateTest {
       Assertions.assertNotNull(value);
       Assertions.assertSame(Class.class.getName(), value);
     }
+  }
+
+  @Test
+  void testEachFieldInClassHasDifferentOffset() {
+    var inst = new ClassWithFields();
+    var seenOffsets = new HashSet<Long>();
+    var fields = ClassWithFields.class.getDeclaredFields();
+    for (var field : fields) {
+      var isStatic = Modifier.isStatic(field.getModifiers());
+      var offset = switch (isStatic) {
+        case true -> UnsafeReplacementDelegate.unsafeStaticFieldOffset(field);
+        case false -> UnsafeReplacementDelegate.unsafeObjectFieldOffset(field);
+      };
+      Assertions.assertTrue(offset >= 0);
+      Assertions.assertTrue(offset <= 25);
+      Assertions.assertTrue(seenOffsets.add(offset));
+
+      var base = switch (isStatic) {
+        case true -> UnsafeReplacementDelegate.unsafeStaticFieldBase(field);
+        case false -> inst;
+      };
+      var resolvedField = FieldOffsetOps.fieldFromOffset(base, offset);
+      Assertions.assertEquals(field, resolvedField);
+    }
+  }
+
+  @Test
+  void testEachFieldInClassHierarchyHasDifferentOffset() {
+    var inst = ByteBuffer.allocate(1);
+    var seenOffsets = new HashSet<Long>();
+
+    Class<?> current = inst.getClass();
+    do {
+      var fields = current.getDeclaredFields();
+      for (var field : fields) {
+        var isStatic = Modifier.isStatic(field.getModifiers());
+        var offset = switch (isStatic) {
+          case true -> UnsafeReplacementDelegate.unsafeStaticFieldOffset(field);
+          case false -> UnsafeReplacementDelegate.unsafeObjectFieldOffset(field);
+        };
+        Assertions.assertTrue(offset >= 0);
+        Assertions.assertTrue(offset <= 250);
+        Assertions.assertTrue(seenOffsets.add(offset));
+
+        var base = switch (isStatic) {
+          case true -> UnsafeReplacementDelegate.unsafeStaticFieldBase(field);
+          case false -> inst;
+        };
+        var resolvedField = FieldOffsetOps.fieldFromOffset(base, offset);
+        Assertions.assertEquals(field, resolvedField);
+      }
+    } while ((current = current.getSuperclass()) != null);
   }
 
   @Test

--- a/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegateTest.java
+++ b/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegateTest.java
@@ -20,7 +20,9 @@ import java.lang.classfile.ClassFile;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
+import java.lang.foreign.MemorySegment;
 import java.lang.reflect.AccessFlag;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.security.ProtectionDomain;
 import java.util.List;
@@ -282,6 +284,47 @@ public class UnsafeReplacementDelegateTest {
       UnsafeReplacementDelegate.unsafePutOrderedObject(inst, offset, "hello");
       Assertions.assertEquals("final string", oldVal);
       Assertions.assertEquals("hello", inst.getFieldValues()[4]);
+    }
+  }
+
+  @Test
+  void testGetInheritedField() throws NoSuchFieldException {
+    var addressField = Buffer.class.getDeclaredField("address");
+    var addressOffset = UnsafeReplacementDelegate.unsafeObjectFieldOffset(addressField);
+    var directBuffer = ByteBuffer.allocateDirect(5);
+    var unsafeAddress = Assertions.assertDoesNotThrow(
+      () -> UnsafeReplacementDelegate.unsafeGetLong(directBuffer, addressOffset));
+    var memSegAddress = MemorySegment.ofBuffer(directBuffer).address();
+    Assertions.assertEquals(memSegAddress, unsafeAddress);
+  }
+
+  @Test
+  void testGetFieldFromClass() throws Exception {
+    // static field
+    {
+      var annotationField = Class.class.getDeclaredField("ANNOTATION");
+      var base = UnsafeReplacementDelegate.unsafeStaticFieldBase(annotationField);
+      var off = UnsafeReplacementDelegate.unsafeStaticFieldOffset(annotationField);
+      var value = UnsafeReplacementDelegate.unsafeGetLong(base, off);
+      Assertions.assertEquals(0x00002000, value);
+    }
+
+    // instance field
+    {
+      var moduleField = Class.class.getDeclaredField("module");
+      var off = UnsafeReplacementDelegate.unsafeObjectFieldOffset(moduleField);
+      var value = UnsafeReplacementDelegate.unsafeGetObject(UnsafeReplacementDelegateTest.class, off);
+      Assertions.assertNotNull(value);
+      Assertions.assertSame(UnsafeReplacementDelegate.class.getModule(), value);
+    }
+
+    // instance field
+    {
+      var nameField = Class.class.getDeclaredField("name");
+      var off = UnsafeReplacementDelegate.unsafeObjectFieldOffset(nameField);
+      var value = UnsafeReplacementDelegate.unsafeGetObject(Class.class, off);
+      Assertions.assertNotNull(value);
+      Assertions.assertSame(Class.class.getName(), value);
     }
   }
 


### PR DESCRIPTION
### Motivation
Currently our unsafe replacement implementation computes field offsets using a global long counter (which should be fine as the documentation in `sun.misc.Unsafe` is not specifying how field offsets are resolved). However, there are cases where libraries depend on the fact that the returned offset is rather small and computed based on the class tree. This is for example the case in the google protobuf implementation, which allow a max field offset value of `(1 << 20) - 1` (1,048.575) as they do some optimizations using bit packing.

### Modification
Compute field offsets based on the class hierachy instead of globally and provide values that are much closer to the values that are actually returned by `sun.misc.Unsafe`.

### Result
No more breaking library code because of bad assumptions about the return value of field offset getter methods.

##### Other context
Code that packs the field offset and breaks: https://github.com/protocolbuffers/protobuf/blob/960e79087b332583c80537c949621108a85aa442/java/core/src/main/java/com/google/protobuf/MessageSchema.java#L568-L575
