### PR TITLE
fix: override pull(Async) in RemoteTemplateStorage

### DIFF
--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Predicate;
 import java.util.zip.ZipInputStream;
 import lombok.NonNull;
@@ -102,6 +103,14 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
    * {@inheritDoc}
    */
   @Override
+  public boolean pull(@NonNull ServiceTemplate template, @NonNull Path directory) {
+    return TaskUtil.getOrDefault(this.pullAsync(template, directory), false);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   public @NonNull CompletableFuture<Boolean> deployAsync(
     @NonNull ServiceTemplate target,
     @NonNull InputStream inputStream
@@ -114,6 +123,22 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
       .build()
       .transferChunkedData()
       .thenApply(status -> status == TransferStatus.SUCCESS);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull CompletableFuture<Boolean> pullAsync(@NonNull ServiceTemplate template, @NonNull Path directory) {
+    return this.zipTemplateAsync(template).thenApply(stream -> {
+      var zipInputStream = stream instanceof ZipInputStream zis ? zis : new ZipInputStream(stream);
+      try (zipInputStream) {
+        var destinationPath = ZipUtil.extractZipStream(zipInputStream, directory);
+        return destinationPath != null;
+      } catch (IOException exception) {
+        throw new CompletionException(exception);
+      }
+    });
   }
 
   /**
@@ -157,6 +182,9 @@ public abstract class RemoteTemplateStorage implements TemplateStorage {
     return TaskUtil.getOrDefault(this.newInputStreamAsync(template, path), null);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public @NonNull CompletableFuture<InputStream> zipTemplateAsync(@NonNull ServiceTemplate template) {
     return ChunkedFileQueryBuilder.create()


### PR DESCRIPTION
### Motivation
RemoteTemplateStorage does currently not override `pull` and `pullAsync` leading to the methods being executed on the node. This leads to an issue where the template is not pulled into the a relative path to the current wrapper directory, but relative to the node directory.

### Modification
Override `pull` and `pullAsync` to let them use the chunked data transfer infrastructure and extract the zipped template into the (possible relative to the service directory) path passed to the respective `pull` method.

### Result
RemoteTemplateStorage has a correct implementation of `pull` and `pullAsync`.

##### Other context
Fixes #1303