### PR TITLE
fix: complete pending queries when channel is closed

### DIFF
--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkChannel.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkChannel.java
@@ -110,6 +110,13 @@ public interface NetworkChannel extends PacketSender {
   boolean active();
 
   /**
+   * Get if this channel was marked as closed.
+   *
+   * @return if this channel was marked as closed.
+   */
+  boolean closed();
+
+  /**
    * Requests the close of the channel, flushing all outbound i/o requests before. After a channel was closed it cannot
    * be used again.
    */

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/QueryPacketManager.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/QueryPacketManager.java
@@ -31,7 +31,7 @@ public interface QueryPacketManager {
 
   /**
    * Get the network channel this manager is associated with. This channel is used to transmit query packets to the
-   * receiver, therefore the network channel of the received must be known in advance.
+   * receiver, therefore, the network channel of the received must be known in advance.
    *
    * @return the network channel to which this manager belongs.
    */
@@ -67,8 +67,7 @@ public interface QueryPacketManager {
 
   /**
    * Sends a query packet to the associated network channel, automatically selecting a query id for the packet and
-   * setting it. Equivalent to {@code manager.sendQueryPacket(packet, UUID.randomUUID()}. An existing query unique id in
-   * the packet will get overridden.
+   * setting it. An existing query unique id in the packet will get overridden.
    *
    * @param packet the packet to convert to a query packet and send to the channel.
    * @return a future completed with either the response to the packet or an empty packet if the waiting time expires.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/DefaultNetworkChannel.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/DefaultNetworkChannel.java
@@ -37,9 +37,7 @@ public abstract class DefaultNetworkChannel implements NetworkChannel {
 
   private static final AtomicLong CHANNEL_ID_COUNTER = new AtomicLong();
 
-  private final long channelId = CHANNEL_ID_COUNTER.incrementAndGet();
-
-  private final QueryPacketManager queryPacketManager;
+  protected final DefaultQueryPacketManager queryPacketManager; // protected to expose narrowed type to subclasses
   private final PacketListenerRegistry packetRegistry;
 
   private final HostAndPort serverAddress;
@@ -47,6 +45,8 @@ public abstract class DefaultNetworkChannel implements NetworkChannel {
 
   private final boolean clientProvidedChannel;
   private final NetworkChannelHandler handler;
+
+  private final long channelId = CHANNEL_ID_COUNTER.incrementAndGet();
 
   /**
    * Constructs a new default network channel instance.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyNetworkChannel.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyNetworkChannel.java
@@ -35,6 +35,7 @@ import lombok.NonNull;
 public final class NettyNetworkChannel extends DefaultNetworkChannel implements NetworkChannel {
 
   private final Channel channel;
+  private volatile boolean closed;
 
   /**
    * Constructs a new netty network channel instance.
@@ -128,7 +129,26 @@ public final class NettyNetworkChannel extends DefaultNetworkChannel implements 
    * {@inheritDoc}
    */
   @Override
+  public boolean closed() {
+    return this.closed;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   public void close() {
     this.channel.close();
+  }
+
+  /**
+   * Called when the associated channel is closed.
+   *
+   * @throws Exception if an exception occurs while posting the close event to the channel handler.
+   */
+  void handleClose() throws Exception {
+    this.closed = true;
+    this.queryPacketManager.close();
+    this.handler().handleChannelClose(this);
   }
 }

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyNetworkHandler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyNetworkHandler.java
@@ -43,12 +43,8 @@ public abstract class NettyNetworkHandler extends SimpleChannelInboundHandler<Ba
    */
   @Override
   public void channelInactive(@NonNull ChannelHandlerContext ctx) throws Exception {
-    if (!ctx.channel().isActive() || !ctx.channel().isOpen() || !ctx.channel().isWritable()) {
-      this.channel.handler().handleChannelClose(this.channel);
-
-      ctx.channel().close();
-      this.channels().remove(this.channel);
-    }
+    this.channels().remove(this.channel);
+    this.channel.handleClose();
   }
 
   /**

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultQueryPacketManager.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultQueryPacketManager.java
@@ -23,6 +23,8 @@ import com.github.benmanes.caffeine.cache.RemovalListener;
 import eu.cloudnetservice.driver.network.NetworkChannel;
 import eu.cloudnetservice.driver.network.protocol.Packet;
 import eu.cloudnetservice.driver.network.protocol.QueryPacketManager;
+import java.io.Closeable;
+import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
@@ -36,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @since 4.0
  */
-public class DefaultQueryPacketManager implements QueryPacketManager {
+public class DefaultQueryPacketManager implements QueryPacketManager, Closeable {
 
   protected final NetworkChannel networkChannel;
   protected final Cache<UUID, CompletableFuture<Packet>> waitingHandlers;
@@ -96,16 +98,39 @@ public class DefaultQueryPacketManager implements QueryPacketManager {
    */
   @Override
   public @NonNull CompletableFuture<Packet> sendQueryPacket(@NonNull Packet packet) {
+    if (this.networkChannel.closed()) {
+      return CompletableFuture.failedFuture(new ClosedChannelException());
+    }
+
     // constructs and register a task for the given query unique id. note that if a replacement by key is
     // happening in the cache, the eviction listener is called and the previous future is automatically
-    // cancelled, therefore there is no need to explicitly check for that here.
+    // canceled, therefore there is no need to explicitly check for that here.
     var responseTask = new CompletableFuture<Packet>();
     var queryUniqueId = Objects.requireNonNullElseGet(packet.uniqueId(), UUID::randomUUID);
     this.waitingHandlers.put(queryUniqueId, responseTask);
 
+    // while registering the query future handler, the channel was closed. if a close happens
+    // after this, the future can just be cleaned up by retrieving it from the waiting handlers cache
+    if (this.networkChannel.closed()) {
+      return CompletableFuture.failedFuture(new ClosedChannelException());
+    }
+
     packet.uniqueId(queryUniqueId);
     this.networkChannel.sendPacketSync(packet);
     return responseTask;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void close() {
+    var cacheValuesItr = this.waitingHandlers.asMap().values().iterator();
+    while (cacheValuesItr.hasNext()) {
+      var next = cacheValuesItr.next();
+      cacheValuesItr.remove(); // evict from cache after retrieval
+      next.completeExceptionally(new ClosedChannelException());
+    }
   }
 
   /**

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/util/QueuedNetworkChannel.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/util/QueuedNetworkChannel.java
@@ -88,6 +88,11 @@ public final class QueuedNetworkChannel implements NetworkChannel {
   }
 
   @Override
+  public boolean closed() {
+    return false;
+  }
+
+  @Override
   public void close() {
     this.wrappedChannel.close();
     this.scheduledPackets.clear();


### PR DESCRIPTION
### Motivation
Currently, pending queries are not completed when the connection to a network component is lost, making them stall until the query timeout is reached.

### Modification
Complete pending queries with a `ClosedChannelException` when a channel gets closed.

### Result
No more stalling queries due to network components disconnecting.
