### PR TITLE
chore: allow re-using channel message builders again

### DIFF
--- a/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessage.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessage.java
@@ -21,14 +21,12 @@ import eu.cloudnetservice.driver.event.events.channel.ChannelMessageReceiveEvent
 import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.provider.CloudMessenger;
-import java.io.Closeable;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.function.UnaryOperator;
 import lombok.NonNull;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
@@ -254,18 +252,7 @@ public record ChannelMessage(
    *
    * @since 4.0
    */
-  public static final class Builder implements Closeable {
-
-    private static final VarHandle BUILD_CALLED;
-
-    static {
-      try {
-        var lookup = MethodHandles.lookup();
-        BUILD_CALLED = lookup.findVarHandle(Builder.class, "buildCalled", boolean.class);
-      } catch (NoSuchFieldException | IllegalAccessException exception) {
-        throw new ExceptionInInitializerError(exception);
-      }
-    }
+  public static final class Builder {
 
     private final Collection<ChannelMessageTarget> targets = new HashSet<>();
 
@@ -275,13 +262,7 @@ public record ChannelMessage(
     private boolean sendSync;
     private boolean prioritized;
 
-    private DataBuf content;
     private ChannelMessageSender sender;
-
-    // internal marker to ensure that build() is only called once per builder instance
-    // this is due to the content data buf, it cannot be shared between multiple channel message instances
-    @SuppressWarnings("FieldMayBeFinal") // modified by BUILD_CALLED in build()
-    private volatile boolean buildCalled = false;
 
     /**
      * Constructs a new builder instance. Use {@link ChannelMessage#builder()} instead.
@@ -294,12 +275,10 @@ public record ChannelMessage(
      *
      * @param sender the sender of this message.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given sender is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given sender is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder sender(@NonNull ChannelMessageSender sender) {
-      this.assertValidState();
       this.sender = sender;
       return this;
     }
@@ -311,12 +290,10 @@ public record ChannelMessage(
      *
      * @param channel the channel of this message.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given channel is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given channel is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder channel(@NonNull String channel) {
-      this.assertValidState();
       this.channel = channel;
       return this;
     }
@@ -327,12 +304,10 @@ public record ChannelMessage(
      *
      * @param message the message key.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given message is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given message is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder message(@NonNull String message) {
-      this.assertValidState();
       this.message = message;
       return this;
     }
@@ -343,11 +318,9 @@ public record ChannelMessage(
      *
      * @param sync if the message should get send sync.
      * @return the same builder as used to call the method, for chaining.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
      */
     @Contract("_ -> this")
     public @NonNull Builder sendSync(boolean sync) {
-      this.assertValidState();
       this.sendSync = sync;
       return this;
     }
@@ -361,28 +334,11 @@ public record ChannelMessage(
      *
      * @param prioritized if the channel message should get prioritized processing on the receiving components.
      * @return the same builder as used to call the method, for chaining.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
      */
     @Contract("_ -> this")
     @ApiStatus.Experimental
     public @NonNull Builder prioritized(boolean prioritized) {
-      this.assertValidState();
       this.prioritized = prioritized;
-      return this;
-    }
-
-    /**
-     * Sets the content of this message. If no content was given, an empty buffer will be used. Note that any previously
-     * supplied content buffer won't be released when this method is called multiple times on the same builder.
-     *
-     * @param dataBuf the content of the message.
-     * @return the same builder as used to call the method, for chaining.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
-     */
-    @Contract("_ -> this")
-    public @NonNull Builder buffer(@Nullable DataBuf dataBuf) {
-      this.assertValidState();
-      this.content = dataBuf;
       return this;
     }
 
@@ -391,12 +347,10 @@ public record ChannelMessage(
      *
      * @param target the target to add.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given target is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given target is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder target(@NonNull ChannelMessageTarget target) {
-      this.assertValidState();
       this.targets.add(target);
       return this;
     }
@@ -405,7 +359,6 @@ public record ChannelMessage(
      * Targets all components within the network.
      *
      * @return the same builder as used to call the method, for chaining.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
      */
     @Contract(" -> this")
     public @NonNull Builder targetAll() {
@@ -416,7 +369,6 @@ public record ChannelMessage(
      * Targets all nodes within the network.
      *
      * @return the same builder as used to call the method, for chaining.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
      */
     @Contract(" -> this")
     public @NonNull Builder targetNodes() {
@@ -427,7 +379,6 @@ public record ChannelMessage(
      * Targets all services within the network.
      *
      * @return the same builder as used to call the method, for chaining.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
      */
     @Contract(" -> this")
     public @NonNull Builder targetServices() {
@@ -439,8 +390,7 @@ public record ChannelMessage(
      *
      * @param nodeId the id of the node to target.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given node id is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given node id is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder targetNode(@NonNull String nodeId) {
@@ -452,8 +402,7 @@ public record ChannelMessage(
      *
      * @param serviceName the name of the service to target.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given service name is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given service name is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder targetService(@NonNull String serviceName) {
@@ -465,8 +414,7 @@ public record ChannelMessage(
      *
      * @param taskName the name of the task to target.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given task name is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given task name is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder targetServicesOfTask(@NonNull String taskName) {
@@ -478,8 +426,7 @@ public record ChannelMessage(
      *
      * @param groupName the name of the group to target.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given group name is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given group name is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder targetServicesOfGroup(@NonNull String groupName) {
@@ -491,8 +438,7 @@ public record ChannelMessage(
      *
      * @param environmentName the name of the environment to target.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given environment name is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given environment name is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder targetServicesOfEnvironment(@NonNull String environmentName) {
@@ -504,8 +450,7 @@ public record ChannelMessage(
      *
      * @param propertyKey the key of the property that must be associated on target services.
      * @return the same builder as used to call the method, for chaining.
-     * @throws NullPointerException  if the given property key is null.
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @throws NullPointerException if the given property key is null.
      */
     @Contract("_ -> this")
     public @NonNull Builder targetServicesWithProperty(@NonNull String propertyKey) {
@@ -513,7 +458,7 @@ public record ChannelMessage(
     }
 
     /**
-     * Builds a channel message from this builder.
+     * Builds a channel message from this builder, using an empty buffer as the content.
      *
      * @return the created channel message from this builder.
      * @throws NullPointerException     if no message or channel is provided.
@@ -522,17 +467,24 @@ public record ChannelMessage(
      */
     @Contract(" -> new")
     public @NonNull ChannelMessage build() {
+      return this.build(DataBuf.empty());
+    }
+
+    /**
+     * Builds a channel message from this builder, using the given buffer as the content of it.
+     *
+     * @param content the buffer containing the content of the channel message.
+     * @return the created channel message from this builder.
+     * @throws NullPointerException     if the given content buffer is null, or no channel/message was provided.
+     * @throws IllegalArgumentException if an invalid argument was provided to this builder.
+     */
+    @Contract("_ -> new")
+    public @NonNull ChannelMessage build(@NonNull DataBuf content) {
       Preconditions.checkNotNull(this.channel, "No channel provided");
       Preconditions.checkNotNull(this.message, "No message provided");
       Preconditions.checkArgument(!this.targets.isEmpty(), "No targets provided");
+      Preconditions.checkArgument(content.accessible(), "content buffer is closed");
 
-      // ensure a valid state *after* the other preconditions, the caller
-      // might recover or close this builder if any previous condition fails
-      if (!BUILD_CALLED.compareAndSet(this, false, true)) {
-        throw new IllegalStateException("ChannelMessage already built by this builder");
-      }
-
-      var content = Objects.requireNonNullElseGet(this.content, DataBuf::empty);
       var sender = Objects.requireNonNullElseGet(this.sender, ChannelMessageSender::self);
       return new ChannelMessage(
         this.sendSync,
@@ -545,33 +497,24 @@ public record ChannelMessage(
     }
 
     /**
-     * Closes the content buffer held by this builder. No further actions can be performed on this builder after this
-     * message has been called. This method should be called in special cases when a channel message (and therefore the
-     * content buffer) is no longer needed.
+     * Builds a channel message from this builder, using the given decorator function to write the content of the
+     * channel message into the buffer before building.
+     * <p>
+     * Note: the decorator function is <strong>NOT</strong> allowed to return a different buffer instance than the one
+     * passed to it. This is only a function, as it makes it easier to use compared to a consumer.
      *
-     * @throws IllegalStateException if the {@link #build()} method was already called on this builder.
+     * @param contentDecorator decorator function that writes the content of the channel message into the buffer.
+     * @return the created channel message from this builder.
+     * @throws NullPointerException  if the given decorator function is null.
+     * @throws IllegalStateException if the decorator returns a different buffer or releases the given buffer.
      */
-    @Override
-    public void close() {
-      if (!BUILD_CALLED.compareAndSet(this, false, true)) {
-        throw new IllegalStateException("ChannelMessage already built by this builder");
-      }
-
-      if (this.content != null) {
-        this.content.release();
-        this.content = null;
-      }
-    }
-
-    /**
-     * Ensures that the {@link #build()} method was not yet called on this builder.
-     *
-     * @throws IllegalStateException if the {@link #build()} method was already called.
-     */
-    private void assertValidState() {
-      if (this.buildCalled) {
-        throw new IllegalStateException("ChannelMessage already built by this builder");
-      }
+    @Contract("_ -> new")
+    public @NonNull ChannelMessage build(@NonNull UnaryOperator<DataBuf.Mutable> contentDecorator) {
+      var contentBuffer = DataBuf.empty();
+      var returnedBuffer = contentDecorator.apply(contentBuffer);
+      Preconditions.checkState(contentBuffer == returnedBuffer, "decorator returned different buffer");
+      Preconditions.checkState(contentBuffer.accessible(), "buffer was released by decorator");
+      return this.build(contentBuffer);
     }
   }
 }

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/channel/ChannelMessageReceiveEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/channel/ChannelMessageReceiveEvent.java
@@ -154,7 +154,7 @@ public final class ChannelMessageReceiveEvent extends NetworkEvent {
    * @throws IllegalArgumentException if the received channel message is not expecting a response.
    */
   public void binaryResponse(@NonNull DataBuf dataBuf) {
-    this.queryResponse(ChannelMessage.buildResponseFor(this.channelMessage).buffer(dataBuf).build());
+    this.queryResponse(ChannelMessage.buildResponseFor(this.channelMessage).build(dataBuf));
   }
 
   /**

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/builder/DefaultChunkedFileQueryBuilder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/builder/DefaultChunkedFileQueryBuilder.java
@@ -136,8 +136,7 @@ public class DefaultChunkedFileQueryBuilder implements ChunkedFileQueryBuilder {
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
       .message("chunked_query_file")
       .target(this.dataSource)
-      .buffer(queryBuffer)
-      .build();
+      .build(queryBuffer);
     return channelMessage
       .sendSingleQueryAsync()
       .thenCompose(response -> {

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/NodeBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/NodeBridgeManagement.java
@@ -16,13 +16,11 @@
 
 package eu.cloudnetservice.modules.bridge.impl.node;
 
-
 import dev.derklaro.aerogel.auto.annotation.Provides;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.document.Document;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.impl.module.ModuleHelper;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.handler.RPCHandlerRegistry;
 import eu.cloudnetservice.driver.provider.ServiceTaskProvider;
@@ -94,17 +92,13 @@ public class NodeBridgeManagement implements InternalBridgeManagement {
 
   @Override
   public void configuration(@NonNull BridgeConfiguration configuration) {
-    // update the configuration locally
     this.configurationSilently(configuration);
-    // sync the config to the cluster
     ChannelMessage.builder()
       .targetAll()
       .channel(BRIDGE_CHANNEL_NAME)
       .message("update_bridge_configuration")
-      .buffer(DataBuf.empty().writeObject(configuration))
-      .build()
+      .build(buffer -> buffer.writeObject(configuration))
       .send();
-    // call the event locally
     this.eventManager.callEvent(new BridgeConfigurationUpdateEvent(configuration));
   }
 

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/network/NodePlayerChannelMessageListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/network/NodePlayerChannelMessageListener.java
@@ -137,25 +137,20 @@ public final class NodePlayerChannelMessageListener {
 
         // proxy player server switch
         case "proxy_player_service_switch" -> {
-          // read the information
           var uniqueId = event.content().readUniqueId();
           var target = event.content().readObject(NetworkServiceInfo.class);
-          // get the associated player
+
           var player = playerManager.onlinePlayer(uniqueId);
-          // check if we know the player
           if (player != null) {
-            // the previous service
             var prev = player.connectedService();
-            // set the current connected service and fire the event
             player.connectedService(target);
+
             eventManager.callEvent(new BridgeProxyPlayerServerSwitchEvent(player, prev));
-            // redirect to the cluster
             ChannelMessage.builder()
               .targetAll()
               .message("cloud_player_service_switch")
               .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-              .buffer(DataBuf.empty().writeObject(player).writeObject(prev))
-              .build()
+              .build(buffer -> buffer.writeObject(player).writeObject(prev))
               .send();
           }
         }
@@ -179,43 +174,35 @@ public final class NodePlayerChannelMessageListener {
 
         // server player login
         case "server_player_login" -> {
-          // read the information
           var playerUniqueId = event.content().readUniqueId();
           var info = event.content().readObject(NetworkPlayerServerInfo.class);
-          // get the cloud player if known
+
           var player = playerManager.onlinePlayer(playerUniqueId);
           if (player != null) {
-            // update the player locally & call the event
             player.networkPlayerServerInfo(info);
             eventManager.callEvent(new BridgeServerPlayerLoginEvent(player, info));
-            // redirect to the cluster
             ChannelMessage.builder()
               .targetAll()
               .message("cloud_player_server_login")
               .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-              .buffer(DataBuf.empty().writeObject(player).writeObject(info))
-              .build()
+              .build(buffer -> buffer.writeObject(player).writeObject(info))
               .send();
           }
         }
 
         // server player disconnect
         case "server_player_disconnect" -> {
-          // read the information
           var playerUniqueId = event.content().readUniqueId();
           var info = event.content().readObject(NetworkServiceInfo.class);
-          // get the cloud player if known
+
           var player = playerManager.onlinePlayer(playerUniqueId);
           if (player != null) {
-            // call the event
             eventManager.callEvent(new BridgeServerPlayerDisconnectEvent(player, info));
-            // redirect to the cluster
             ChannelMessage.builder()
               .targetAll()
               .message("cloud_player_server_disconnect")
               .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-              .buffer(DataBuf.empty().writeObject(player).writeObject(info))
-              .build()
+              .build(buffer -> buffer.writeObject(player).writeObject(info))
               .send();
           }
         }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerExecutor.java
@@ -58,8 +58,7 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void connect(@NonNull String serviceName) {
     this.toProxy()
       .message("connect_to_service")
-      .buffer(DataBuf.empty().writeUniqueId(this.targetUniqueId).writeString(serviceName))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(this.targetUniqueId).writeString(serviceName))
       .send();
   }
 
@@ -67,8 +66,7 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void connectSelecting(@NonNull ServerSelectorType selectorType) {
     this.toProxy()
       .message("connect_to_selector")
-      .buffer(DataBuf.empty().writeUniqueId(this.targetUniqueId).writeObject(selectorType))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(this.targetUniqueId).writeObject(selectorType))
       .send();
   }
 
@@ -76,8 +74,7 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void connectToFallback() {
     this.toProxy()
       .message("connect_to_fallback")
-      .buffer(DataBuf.empty().writeUniqueId(this.targetUniqueId))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(this.targetUniqueId))
       .send();
   }
 
@@ -85,8 +82,7 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void connectToGroup(@NonNull String group, @NonNull ServerSelectorType selectorType) {
     this.toProxy()
       .message("connect_to_group")
-      .buffer(DataBuf.empty().writeUniqueId(this.targetUniqueId).writeString(group).writeObject(selectorType))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(this.targetUniqueId).writeString(group).writeObject(selectorType))
       .send();
   }
 
@@ -94,8 +90,7 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void connectToTask(@NonNull String task, @NonNull ServerSelectorType selectorType) {
     this.toProxy()
       .message("connect_to_task")
-      .buffer(DataBuf.empty().writeUniqueId(this.targetUniqueId).writeString(task).writeObject(selectorType))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(this.targetUniqueId).writeString(task).writeObject(selectorType))
       .send();
   }
 
@@ -103,8 +98,7 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void kick(@NonNull Component message) {
     this.toProxy()
       .message("kick_player")
-      .buffer(DataBuf.empty().writeUniqueId(this.targetUniqueId).writeObject(message))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(this.targetUniqueId).writeObject(message))
       .send();
   }
 
@@ -112,8 +106,7 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void sendTitle(@NonNull Title title) {
     this.toProxy()
       .message("send_title")
-      .buffer(DataBuf.empty().writeUniqueId(this.targetUniqueId).writeObject(title))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(this.targetUniqueId).writeObject(title))
       .send();
   }
 
@@ -121,11 +114,10 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void sendChatMessage(@NonNull Component message, @Nullable String permission) {
     this.toProxy()
       .message("send_chat_message")
-      .buffer(DataBuf.empty()
+      .build(buffer -> buffer
         .writeUniqueId(this.targetUniqueId)
         .writeObject(message)
         .writeNullable(permission, DataBuf.Mutable::writeString))
-      .build()
       .send();
   }
 
@@ -133,8 +125,7 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void sendPluginMessage(@NonNull String key, byte[] data) {
     this.toProxy()
       .message("send_plugin_message")
-      .buffer(DataBuf.empty().writeUniqueId(this.targetUniqueId).writeString(key).writeByteArray(data))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(this.targetUniqueId).writeString(key).writeByteArray(data))
       .send();
   }
 
@@ -142,8 +133,7 @@ public class NodePlayerExecutor implements PlayerExecutor {
   public void spoofCommandExecution(@NonNull String command, boolean redirectToServer) {
     this.toProxy()
       .message("spoof_command_execution")
-      .buffer(DataBuf.empty().writeUniqueId(this.targetUniqueId).writeString(command).writeBoolean(redirectToServer))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(this.targetUniqueId).writeString(command).writeBoolean(redirectToServer))
       .send();
   }
 

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerManager.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerManager.java
@@ -305,7 +305,8 @@ public class NodePlayerManager implements PlayerManager {
 
   @Override
   public @NonNull CompletableFuture<List<CloudPlayer>> environmentOnlinePlayersAsync(
-    @NonNull ServiceEnvironmentType env) {
+    @NonNull ServiceEnvironmentType env
+  ) {
     return TaskUtil.supplyAsync(() -> this.environmentOnlinePlayers(env));
   }
 

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerManager.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerManager.java
@@ -24,7 +24,6 @@ import dev.derklaro.aerogel.auto.annotation.Provides;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.document.Document;
 import eu.cloudnetservice.driver.event.EventManager;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.handler.RPCHandlerRegistry;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
@@ -241,53 +240,41 @@ public class NodePlayerManager implements PlayerManager {
 
   @Override
   public void updateOfflinePlayer(@NonNull CloudOfflinePlayer player) {
-    // push the change to the cache
     this.pushOfflinePlayerCache(player.uniqueId(), player);
-    // update the database
     this.database().insert(player.uniqueId().toString(), Document.newJsonDocument().appendTree(player));
-    // notify the cluster
+
     ChannelMessage.builder()
       .targetAll()
       .message("update_offline_cloud_player")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeObject(player))
-      .build()
+      .build(buffer -> buffer.writeObject(player))
       .send();
-    // call the update event locally
     this.eventManager.callEvent(new BridgeUpdateCloudOfflinePlayerEvent(player));
   }
 
   @Override
   public void updateOnlinePlayer(@NonNull CloudPlayer cloudPlayer) {
-    // push the change to the cache
     this.pushOnlinePlayerCache(cloudPlayer);
-    // notify the cluster
     ChannelMessage.builder()
       .targetAll()
       .message("update_online_cloud_player")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeObject(cloudPlayer))
-      .build()
+      .build(buffer -> buffer.writeObject(cloudPlayer))
       .send();
-    // call the update event locally
     this.eventManager.callEvent(new BridgeUpdateCloudPlayerEvent(cloudPlayer));
   }
 
   @Override
   public void deleteCloudOfflinePlayer(@NonNull CloudOfflinePlayer cloudOfflinePlayer) {
-    // push the change to the cache
     this.pushOfflinePlayerCache(cloudOfflinePlayer.uniqueId(), null);
-    // delete from the database
     this.database().delete(cloudOfflinePlayer.uniqueId().toString());
-    // notify the cluster
+
     ChannelMessage.builder()
       .targetAll()
       .message("delete_offline_cloud_player")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeObject(cloudOfflinePlayer))
-      .build()
+      .build(buffer -> buffer.writeObject(cloudOfflinePlayer))
       .send();
-    // call the update event locally
     this.eventManager.callEvent(new BridgeDeleteCloudOfflinePlayerEvent(cloudOfflinePlayer));
   }
 
@@ -317,7 +304,8 @@ public class NodePlayerManager implements PlayerManager {
   }
 
   @Override
-  public @NonNull CompletableFuture<List<CloudPlayer>> environmentOnlinePlayersAsync(@NonNull ServiceEnvironmentType env) {
+  public @NonNull CompletableFuture<List<CloudPlayer>> environmentOnlinePlayersAsync(
+    @NonNull ServiceEnvironmentType env) {
     return TaskUtil.supplyAsync(() -> this.environmentOnlinePlayers(env));
   }
 
@@ -448,21 +436,17 @@ public class NodePlayerManager implements PlayerManager {
   }
 
   protected void processLogin(@NonNull CloudPlayer cloudPlayer) {
-    // push the player into the cache
     this.pushOnlinePlayerCache(cloudPlayer);
-    // update the database
     this.database().insert(
       cloudPlayer.uniqueId().toString(),
       Document.newJsonDocument().appendTree(CloudOfflinePlayer.offlineCopy(cloudPlayer)));
-    // notify the other nodes that we received the login
+
     ChannelMessage.builder()
       .targetAll()
       .message("process_cloud_player_login")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeObject(cloudPlayer))
-      .build()
+      .build(buffer -> buffer.writeObject(cloudPlayer))
       .send();
-    // call the update event locally
     this.eventManager.callEvent(new BridgeProxyPlayerLoginEvent(cloudPlayer));
   }
 
@@ -536,24 +520,19 @@ public class NodePlayerManager implements PlayerManager {
   }
 
   private void logoutPlayer0(@NonNull CloudPlayer cloudPlayer) {
-    // remove the player from the cache
     this.onlinePlayers.remove(cloudPlayer.uniqueId());
     cloudPlayer.lastNetworkPlayerProxyInfo(cloudPlayer.networkPlayerProxyInfo());
-    // copy to an offline version
+
     var offlinePlayer = CloudOfflinePlayer.offlineCopy(cloudPlayer);
-    // update the offline version of the player into the cache
     this.pushOfflinePlayerCache(cloudPlayer.uniqueId(), offlinePlayer);
-    // push the change to the database
     this.database().insert(offlinePlayer.uniqueId().toString(), Document.newJsonDocument().appendTree(offlinePlayer));
-    // notify the cluster
+
     ChannelMessage.builder()
       .targetAll()
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
       .message("process_cloud_player_logout")
-      .buffer(DataBuf.empty().writeObject(cloudPlayer))
-      .build()
+      .build(buffer -> buffer.writeObject(cloudPlayer))
       .send();
-    // call the update event locally
     this.eventManager.callEvent(new BridgeProxyPlayerDisconnectEvent(cloudPlayer));
   }
 

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/helper/ProxyPlatformHelper.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/helper/ProxyPlatformHelper.java
@@ -18,7 +18,6 @@ package eu.cloudnetservice.modules.bridge.impl.platform.helper;
 
 import eu.cloudnetservice.driver.ComponentInfo;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.modules.bridge.BridgeManagement;
 import eu.cloudnetservice.modules.bridge.node.event.LocalPlayerPreLoginEvent;
 import eu.cloudnetservice.modules.bridge.player.NetworkPlayerProxyInfo;
@@ -47,8 +46,7 @@ public final class ProxyPlatformHelper {
     var response = this.toCurrentNode()
       .message("proxy_player_pre_login")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeObject(playerInfo))
-      .build()
+      .build(buffer -> buffer.writeObject(playerInfo))
       .sendSingleQuery();
     return switch (response) {
       case null -> LocalPlayerPreLoginEvent.Result.allowed();
@@ -67,8 +65,7 @@ public final class ProxyPlatformHelper {
     this.toCurrentNode()
       .message("proxy_player_login")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeObject(proxyInfo).writeObject(joinServiceInfo))
-      .build()
+      .build(buffer -> buffer.writeObject(proxyInfo).writeObject(joinServiceInfo))
       .send();
   }
 
@@ -76,8 +73,7 @@ public final class ProxyPlatformHelper {
     this.toCurrentNode()
       .message("proxy_player_service_switch")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeUniqueId(playerId).writeObject(target))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(playerId).writeObject(target))
       .send();
   }
 
@@ -85,8 +81,7 @@ public final class ProxyPlatformHelper {
     this.toCurrentNode()
       .message("proxy_player_disconnect")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeUniqueId(playerUniqueId))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(playerUniqueId))
       .send();
   }
 

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/helper/ServerPlatformHelper.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/helper/ServerPlatformHelper.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.modules.bridge.impl.platform.helper;
 
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.modules.bridge.BridgeManagement;
 import eu.cloudnetservice.modules.bridge.player.NetworkPlayerServerInfo;
 import eu.cloudnetservice.modules.bridge.player.NetworkServiceInfo;
@@ -42,8 +41,7 @@ public final class ServerPlatformHelper {
     this.proxyPlatformHelper.toCurrentNode()
       .message("server_player_login")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeUniqueId(playerUniqueId).writeObject(info))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(playerUniqueId).writeObject(info))
       .send();
   }
 
@@ -51,8 +49,7 @@ public final class ServerPlatformHelper {
     this.proxyPlatformHelper.toCurrentNode()
       .message("server_player_disconnect")
       .channel(BridgeManagement.BRIDGE_PLAYER_CHANNEL_NAME)
-      .buffer(DataBuf.empty().writeUniqueId(playerUniqueId).writeObject(info))
-      .build()
+      .build(buffer -> buffer.writeUniqueId(playerUniqueId).writeObject(info))
       .send();
   }
 }

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/node/NodeLabyModManagement.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/node/NodeLabyModManagement.java
@@ -18,7 +18,6 @@ package eu.cloudnetservice.modules.labymod.impl.node;
 
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.document.Document;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.handler.RPCHandlerRegistry;
 import eu.cloudnetservice.modules.labymod.LabyModManagement;
@@ -60,8 +59,7 @@ public class NodeLabyModManagement implements LabyModManagement {
       .targetAll()
       .channel(LabyModManagement.LABYMOD_MODULE_CHANNEL)
       .message(LabyModManagement.LABYMOD_UPDATE_CONFIG)
-      .buffer(DataBuf.empty().writeObject(configuration))
-      .build()
+      .build(buffer -> buffer.writeObject(configuration))
       .send();
   }
 

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/NodeNPCManagement.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/NodeNPCManagement.java
@@ -22,7 +22,6 @@ import eu.cloudnetservice.driver.database.DatabaseProvider;
 import eu.cloudnetservice.driver.document.Document;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.impl.module.ModuleHelper;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
 import eu.cloudnetservice.modules.npc.NPC;
@@ -119,22 +118,14 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
   public void createNPC(@NonNull NPC npc) {
     this.database.insert(documentKey(npc.location()), Document.newJsonDocument().appendTree(npc));
     this.npcs.put(npc.location(), npc);
-
-    this.channelMessage(NPC_CREATED)
-      .targetAll()
-      .buffer(DataBuf.empty().writeObject(npc))
-      .build().send();
+    this.channelMessage(NPC_CREATED).targetAll().build(buffer -> buffer.writeObject(npc)).send();
   }
 
   @Override
   public void deleteNPC(@NonNull WorldPosition position) {
     this.npcs.remove(position);
     this.database.delete(documentKey(position));
-
-    this.channelMessage(NPC_DELETED)
-      .targetAll()
-      .buffer(DataBuf.empty().writeObject(position))
-      .build().send();
+    this.channelMessage(NPC_DELETED).targetAll().build(buffer -> buffer.writeObject(position)).send();
   }
 
   @Override
@@ -148,10 +139,7 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
       this.database.delete(documentKey(position));
     });
 
-    this.channelMessage(NPC_BULK_DELETE)
-      .targetAll()
-      .buffer(DataBuf.empty().writeObject(positions))
-      .build().send();
+    this.channelMessage(NPC_BULK_DELETE).targetAll().build(buffer -> buffer.writeObject(positions)).send();
     return positions.size();
   }
 
@@ -163,16 +151,12 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
       this.database.delete(documentKey(position));
     }
 
-    this.channelMessage(NPC_BULK_DELETE)
-      .targetAll()
-      .buffer(DataBuf.empty().writeObject(positions))
-      .build().send();
+    this.channelMessage(NPC_BULK_DELETE).targetAll().build(buffer -> buffer.writeObject(positions)).send();
     return positions.size();
   }
 
   @Override
   public @NonNull Collection<NPC> npcs(@NonNull Collection<String> groups) {
-    // filter all npcs
     return this.npcs.values().stream()
       .filter(npc -> groups.contains(npc.location().group()))
       .collect(Collectors.toList());
@@ -181,10 +165,7 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
   @Override
   public void npcConfiguration(@NonNull NPCConfiguration configuration) {
     this.handleInternalNPCConfigUpdate(configuration);
-    this.channelMessage(NPC_CONFIGURATION_UPDATE)
-      .targetAll()
-      .buffer(DataBuf.empty().writeObject(configuration))
-      .build().send();
+    this.channelMessage(NPC_CONFIGURATION_UPDATE).targetAll().build(buffer -> buffer.writeObject(configuration)).send();
   }
 
   @Override

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/PlatformNPCManagement.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/PlatformNPCManagement.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.modules.npc.impl.platform;
 import eu.cloudnetservice.driver.ComponentInfo;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.event.EventManager;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
@@ -100,25 +99,17 @@ public abstract class PlatformNPCManagement<L, P, M, I, S> extends AbstractNPCMa
 
   @Override
   public void createNPC(@NonNull NPC npc) {
-    this.channelMessage(NPC_CREATE)
-      .buffer(DataBuf.empty().writeObject(npc))
-      .build()
-      .send();
+    this.channelMessage(NPC_CREATE).build(buffer -> buffer.writeObject(npc)).send();
   }
 
   @Override
   public void deleteNPC(@NonNull WorldPosition position) {
-    this.channelMessage(NPC_DELETE)
-      .buffer(DataBuf.empty().writeObject(position))
-      .build().send();
+    this.channelMessage(NPC_DELETE).build(buffer -> buffer.writeObject(position)).send();
   }
 
   @Override
   public int deleteAllNPCs(@NonNull String group) {
-    var response = this.channelMessage(NPC_BULK_DELETE)
-      .buffer(DataBuf.empty().writeString(group))
-      .build()
-      .sendSingleQuery();
+    var response = this.channelMessage(NPC_BULK_DELETE).build(buffer -> buffer.writeString(group)).sendSingleQuery();
     return switch (response) {
       case null -> 0;
       case ChannelMessage channelMessage -> {
@@ -132,8 +123,7 @@ public abstract class PlatformNPCManagement<L, P, M, I, S> extends AbstractNPCMa
   @Override
   public int deleteAllNPCs() {
     var response = this.channelMessage(NPC_ALL_DELETE)
-      .buffer(DataBuf.empty().writeObject(this.npcs.keySet()))
-      .build()
+      .build(buffer -> buffer.writeObject(this.npcs.keySet()))
       .sendSingleQuery();
     return switch (response) {
       case null -> 0;
@@ -148,8 +138,7 @@ public abstract class PlatformNPCManagement<L, P, M, I, S> extends AbstractNPCMa
   @Override
   public @NonNull Collection<NPC> npcs(@NonNull Collection<String> groups) {
     var response = this.channelMessage(NPC_GET_NPCS_BY_GROUP)
-      .buffer(DataBuf.empty().writeObject(groups))
-      .build()
+      .build(buffer -> buffer.writeObject(groups))
       .sendSingleQuery();
     return switch (response) {
       case null -> Set.of();
@@ -163,9 +152,7 @@ public abstract class PlatformNPCManagement<L, P, M, I, S> extends AbstractNPCMa
 
   @Override
   public void npcConfiguration(@NonNull NPCConfiguration configuration) {
-    this.channelMessage(NPC_SET_CONFIG)
-      .buffer(DataBuf.empty().writeObject(configuration))
-      .build().send();
+    this.channelMessage(NPC_SET_CONFIG).build(buffer -> buffer.writeObject(configuration)).send();
   }
 
   @Override

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/NodeSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/NodeSignManagement.java
@@ -20,7 +20,6 @@ import dev.derklaro.aerogel.auto.annotation.Provides;
 import eu.cloudnetservice.driver.database.Database;
 import eu.cloudnetservice.driver.database.DatabaseProvider;
 import eu.cloudnetservice.driver.document.Document;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
 import eu.cloudnetservice.modules.signs.Sign;
 import eu.cloudnetservice.modules.signs.SignManagement;
@@ -73,10 +72,7 @@ public class NodeSignManagement extends AbstractSignManagement implements SignMa
     this.database.insert(this.documentKey(sign.location()), Document.newJsonDocument().appendTree(sign));
     this.signs.put(sign.location(), sign);
 
-    this.channelMessage(SIGN_CREATED)
-      .buffer(DataBuf.empty().writeObject(sign))
-      .targetAll()
-      .build().send();
+    this.channelMessage(SIGN_CREATED).targetAll().build(buffer -> buffer.writeObject(sign)).send();
   }
 
   @Override
@@ -85,9 +81,8 @@ public class NodeSignManagement extends AbstractSignManagement implements SignMa
     this.signs.remove(position);
 
     this.channelMessage(SIGN_DELETED)
-      .buffer(DataBuf.empty().writeObject(position))
       .targetAll()
-      .build().send();
+      .build(buffer -> buffer.writeObject(position)).send();
   }
 
   @Override
@@ -103,10 +98,7 @@ public class NodeSignManagement extends AbstractSignManagement implements SignMa
       this.signs.remove(position);
     }
 
-    this.channelMessage(SIGN_BULK_DELETE)
-      .buffer(DataBuf.empty().writeObject(positions))
-      .targetAll()
-      .build().send();
+    this.channelMessage(SIGN_BULK_DELETE).targetAll().build(buffer -> buffer.writeObject(positions)).send();
     return positions.size();
   }
 
@@ -118,10 +110,7 @@ public class NodeSignManagement extends AbstractSignManagement implements SignMa
       this.signs.remove(position);
     }
 
-    this.channelMessage(SIGN_BULK_DELETE)
-      .buffer(DataBuf.empty().writeObject(positions))
-      .targetAll()
-      .build().send();
+    this.channelMessage(SIGN_BULK_DELETE).targetAll().build(buffer -> buffer.writeObject(positions)).send();
     return positions.size();
   }
 
@@ -137,9 +126,9 @@ public class NodeSignManagement extends AbstractSignManagement implements SignMa
     super.signsConfiguration(signsConfiguration);
 
     this.channelMessage(SIGN_CONFIGURATION_UPDATE)
-      .buffer(DataBuf.empty().writeObject(signsConfiguration))
       .targetAll()
-      .build().send();
+      .build(buffer -> buffer.writeObject(signsConfiguration))
+      .send();
     NodeSignsConfigurationHelper.write(signsConfiguration, this.configPath);
   }
 

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSignManagement.java
@@ -119,23 +119,20 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
 
   @Override
   public void createSign(@NonNull Sign sign) {
-    this.channelMessage(SIGN_CREATE)
-      .buffer(DataBuf.empty().writeObject(sign))
-      .build().send();
+    this.channelMessage(SIGN_CREATE).build(buffer -> buffer.writeObject(sign)).send();
   }
 
   @Override
   public void deleteSign(@NonNull WorldPosition position) {
-    this.channelMessage(SIGN_DELETE)
-      .buffer(DataBuf.empty().writeObject(position))
-      .build().send();
+    this.channelMessage(SIGN_DELETE).build(buffer -> buffer.writeObject(position)).send();
   }
 
   @Override
   public int deleteAllSigns(@NonNull String group, @Nullable String templatePath) {
     var response = this.channelMessage(SIGN_BULK_DELETE)
-      .buffer(DataBuf.empty().writeString(group).writeNullable(templatePath, DataBuf.Mutable::writeString))
-      .build()
+      .build(buffer -> buffer
+        .writeString(group)
+        .writeNullable(templatePath, DataBuf.Mutable::writeString))
       .sendSingleQuery();
     return switch (response) {
       case null -> 0;
@@ -149,17 +146,14 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
 
   @Override
   public int deleteAllSigns() {
-    this.channelMessage(SIGN_ALL_DELETE)
-      .buffer(DataBuf.empty().writeObject(this.signs.keySet()))
-      .build().send();
+    this.channelMessage(SIGN_ALL_DELETE).build(buffer -> buffer.writeObject(this.signs.keySet())).send();
     return this.signs.size();
   }
 
   @Override
   public @NonNull Collection<Sign> signs(@NonNull Collection<String> groups) {
     var response = this.channelMessage(SIGN_GET_SIGNS_BY_GROUPS)
-      .buffer(DataBuf.empty().writeObject(groups))
-      .build()
+      .build(buffer -> buffer.writeObject(groups))
       .sendSingleQuery();
     return switch (response) {
       case null -> Set.of();
@@ -173,9 +167,7 @@ public abstract class PlatformSignManagement<P, L, C> extends AbstractSignManage
 
   @Override
   public void signsConfiguration(@NonNull SignsConfiguration signsConfiguration) {
-    this.channelMessage(SET_SIGN_CONFIG)
-      .buffer(DataBuf.empty().writeObject(signsConfiguration))
-      .build().send();
+    this.channelMessage(SET_SIGN_CONFIG).build(buffer -> buffer.writeObject(signsConfiguration)).send();
   }
 
   @Override

--- a/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyConfiguration.java
+++ b/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyConfiguration.java
@@ -18,7 +18,6 @@ package eu.cloudnetservice.modules.syncproxy.config;
 
 import com.google.common.collect.ImmutableMap;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.modules.bridge.BridgeServiceHelper;
 import eu.cloudnetservice.modules.syncproxy.SyncProxyConstants;
@@ -115,8 +114,7 @@ public record SyncProxyConfiguration(
       .channel(SyncProxyConstants.SYNC_PROXY_CHANNEL)
       .message(SyncProxyConstants.SYNC_PROXY_UPDATE_CONFIG)
       .targetAll()
-      .buffer(DataBuf.empty().writeObject(this))
-      .build()
+      .build(buffer -> buffer.writeObject(SyncProxyConfiguration.this))
       .send();
   }
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/DefaultNodeServerProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/DefaultNodeServerProvider.java
@@ -130,8 +130,7 @@ public class DefaultNodeServerProvider implements NodeServerProvider {
       .targetNodes()
       .message("sync_cluster_data")
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(this.dataSyncRegistry.prepareClusterData(true))
-      .build()
+      .build(this.dataSyncRegistry.prepareClusterData(true))
       .send();
   }
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/RemoteNodeServer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/RemoteNodeServer.java
@@ -22,7 +22,6 @@ import eu.cloudnetservice.driver.cluster.NodeInfoSnapshot;
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
 import eu.cloudnetservice.driver.network.NetworkChannel;
 import eu.cloudnetservice.driver.network.NetworkClient;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCImplementationBuilder;
 import eu.cloudnetservice.driver.provider.CloudServiceFactory;
 import eu.cloudnetservice.driver.provider.CloudServiceProvider;
@@ -134,8 +133,7 @@ public class RemoteNodeServer implements NodeServer {
       .message("change_draining_state")
       .targetNode(this.info.uniqueId())
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeBoolean(doDrain))
-      .build()
+      .build(buffer -> buffer.writeBoolean(doDrain))
       .send();
   }
 
@@ -145,8 +143,7 @@ public class RemoteNodeServer implements NodeServer {
       .message("sync_cluster_data")
       .targetNode(this.info.uniqueId())
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(this.dataSyncRegistry.prepareClusterData(force))
-      .build()
+      .build(this.dataSyncRegistry.prepareClusterData(force))
       .send();
   }
 
@@ -237,8 +234,7 @@ public class RemoteNodeServer implements NodeServer {
       .message("send_command_line")
       .targetNode(this.info.uniqueId())
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeString(commandLine))
-      .build()
+      .build(buffer -> buffer.writeString(commandLine))
       .sendSingleQueryAsync()
       .thenApply(response -> {
         try (response) {

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/task/LocalNodeUpdateTask.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/task/LocalNodeUpdateTask.java
@@ -18,7 +18,6 @@ package eu.cloudnetservice.node.impl.cluster.task;
 
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.node.cluster.NodeServerProvider;
 import eu.cloudnetservice.node.cluster.NodeServerState;
 import eu.cloudnetservice.node.impl.tick.DefaultTickLoop;
@@ -61,12 +60,9 @@ public record LocalNodeUpdateTask(
             .sendSync(true) // ensure that we don't schedule too many updates while other are still waiting
             .message("update_node_info_snapshot")
             .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-            .buffer(DataBuf.empty().writeObject(localNode.nodeInfoSnapshot()))
             .prioritized(this.mainThreadProvider.get().currentTick() % 10 == 0);
-          // add all targets
           targetNodes.forEach(message::targetNode);
-          // send the update to all active nodes
-          message.build().send();
+          message.build(buffer -> buffer.writeObject(localNode.nodeInfoSnapshot())).send();
         }
       }
     } catch (Exception exception) {

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/util/NodeDisconnectHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/util/NodeDisconnectHandler.java
@@ -21,7 +21,6 @@ import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.event.events.service.CloudServiceLifecycleChangeEvent;
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
 import eu.cloudnetservice.driver.language.I18n;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.registry.Service;
 import eu.cloudnetservice.driver.service.ProcessSnapshot;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
@@ -90,8 +89,7 @@ public final class NodeDisconnectHandler {
           targetServices(localServices)
             .message("update_service_lifecycle")
             .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-            .buffer(DataBuf.empty().writeObject(lifeCycle).writeObject(newSnapshot))
-            .build()
+            .build(buffer -> buffer.writeObject(lifeCycle).writeObject(newSnapshot))
             .send();
         }
       }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/NodeChannelMessageListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/NodeChannelMessageListener.java
@@ -83,13 +83,11 @@ public final class NodeChannelMessageListener {
           // handle the sync and send back the data to override on the caller
           var result = this.dataSyncRegistry.handle(event.content(), event.content().readBoolean());
           if (result != null) {
-            // send the response content
             ChannelMessage.builder()
               .message("sync_cluster_data_response")
               .target(event.sender().toTarget())
               .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-              .buffer(result)
-              .build()
+              .build(result)
               .send();
           }
         }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/ServiceChannelMessageListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/ServiceChannelMessageListener.java
@@ -146,8 +146,10 @@ public final class ServiceChannelMessageListener {
   }
 
   @EventListener
-  public void handleRemoteLifecycleChanges(@NonNull CloudServiceLifecycleChangeEvent event,
-    @NonNull @Service I18n i18n) {
+  public void handleRemoteLifecycleChanges(
+    @NonNull CloudServiceLifecycleChangeEvent event,
+    @NonNull @Service I18n i18n
+  ) {
     var id = event.serviceInfo().serviceId();
     var replacements = new Object[]{id.uniqueId(), id.taskName(), id.name(), id.nodeUniqueId()};
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/ServiceChannelMessageListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/ServiceChannelMessageListener.java
@@ -58,8 +58,7 @@ public final class ServiceChannelMessageListener {
           var configuration = event.content().readObject(ServiceConfiguration.class);
           event.queryResponse(cloudServiceFactory.createCloudServiceAsync(configuration)
             .thenApply(service -> ChannelMessage.buildResponseFor(event.channelMessage())
-              .buffer(DataBuf.empty().writeObject(service))
-              .build()));
+              .build(buffer -> buffer.writeObject(service))));
         }
 
         // feedback from a node that a service which should have been moved to accepted
@@ -96,8 +95,7 @@ public final class ServiceChannelMessageListener {
                 .target(event.sender().toTarget())
                 .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
                 .message("node_to_head_node_unaccepted_service_ttl_exceeded")
-                .buffer(DataBuf.empty().writeUniqueId(serviceUniqueId))
-                .build()
+                .build(buffer -> buffer.writeUniqueId(serviceUniqueId))
                 .send();
             }
           }
@@ -148,7 +146,8 @@ public final class ServiceChannelMessageListener {
   }
 
   @EventListener
-  public void handleRemoteLifecycleChanges(@NonNull CloudServiceLifecycleChangeEvent event, @NonNull @Service I18n i18n) {
+  public void handleRemoteLifecycleChanges(@NonNull CloudServiceLifecycleChangeEvent event,
+    @NonNull @Service I18n i18n) {
     var id = event.serviceInfo().serviceId();
     var replacements = new Object[]{id.uniqueId(), id.taskName(), id.name(), id.nodeUniqueId()};
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeClusterNodeProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeClusterNodeProvider.java
@@ -22,7 +22,6 @@ import eu.cloudnetservice.driver.cluster.NetworkClusterNode;
 import eu.cloudnetservice.driver.cluster.NodeInfoSnapshot;
 import eu.cloudnetservice.driver.command.CommandInfo;
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.handler.RPCHandlerRegistry;
 import eu.cloudnetservice.driver.provider.ClusterNodeProvider;
@@ -96,8 +95,7 @@ public class NodeClusterNodeProvider implements ClusterNodeProvider {
         .targetNodes()
         .message("register_known_node")
         .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-        .buffer(DataBuf.empty().writeObject(node))
-        .build()
+        .build(buffer -> buffer.writeObject(node))
         .send();
       return true;
     }
@@ -116,8 +114,7 @@ public class NodeClusterNodeProvider implements ClusterNodeProvider {
         .targetNodes()
         .message("remove_known_node")
         .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-        .buffer(DataBuf.empty().writeObject(clusterNode))
-        .build()
+        .build(buffer -> buffer.writeObject(clusterNode))
         .send();
       return true;
     }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeGroupConfigurationProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeGroupConfigurationProvider.java
@@ -23,7 +23,6 @@ import eu.cloudnetservice.driver.document.Document;
 import eu.cloudnetservice.driver.document.DocumentFactory;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.handler.RPCHandlerRegistry;
 import eu.cloudnetservice.driver.provider.GroupConfigurationProvider;
@@ -141,8 +140,7 @@ public class NodeGroupConfigurationProvider implements GroupConfigurationProvide
       .targetAll()
       .message("add_group_configuration")
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeObject(groupConfigurationEvent.group()))
-      .build()
+      .build(buffer -> buffer.writeObject(groupConfigurationEvent.group()))
       .send();
     return true;
   }
@@ -166,8 +164,7 @@ public class NodeGroupConfigurationProvider implements GroupConfigurationProvide
       .targetAll()
       .message("remove_group_configuration")
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeObject(groupConfiguration))
-      .build()
+      .build(buffer -> buffer.writeObject(groupConfiguration))
       .send();
   }
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeServiceTaskProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeServiceTaskProvider.java
@@ -25,7 +25,6 @@ import eu.cloudnetservice.driver.document.DocumentFactory;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
 import eu.cloudnetservice.driver.language.I18n;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.handler.RPCHandlerRegistry;
 import eu.cloudnetservice.driver.provider.ServiceTaskProvider;
@@ -146,8 +145,7 @@ public class NodeServiceTaskProvider implements ServiceTaskProvider {
       .targetAll()
       .message("add_service_task")
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeObject(serviceTaskAddEvent.task()))
-      .build()
+      .build(buffer -> buffer.writeObject(serviceTaskAddEvent.task()))
       .send();
     return true;
   }
@@ -171,8 +169,7 @@ public class NodeServiceTaskProvider implements ServiceTaskProvider {
       .targetAll()
       .message("remove_service_task")
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeObject(serviceTask))
-      .build()
+      .build(buffer -> buffer.writeObject(serviceTask))
       .send();
   }
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/AbstractService.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/AbstractService.java
@@ -29,7 +29,6 @@ import eu.cloudnetservice.driver.impl.network.NetworkConstants;
 import eu.cloudnetservice.driver.language.I18n;
 import eu.cloudnetservice.driver.network.HostAndPort;
 import eu.cloudnetservice.driver.network.NetworkChannel;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.ssl.SSLConfiguration;
 import eu.cloudnetservice.driver.service.ProcessSnapshot;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
@@ -531,8 +530,7 @@ public abstract class AbstractService implements InternalCloudService {
         .targetService(this.serviceId().name())
         .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
         .message("request_update_service_information_with_new_properties")
-        .buffer(DataBuf.empty().writeObject(properties))
-        .build()
+        .build(buffer -> buffer.writeObject(properties))
         .send();
       return;
     }
@@ -636,8 +634,7 @@ public abstract class AbstractService implements InternalCloudService {
       .targetAll()
       .message("update_service_info")
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeObject(this.currentServiceInfo))
-      .build()
+      .build(buffer -> buffer.writeObject(this.currentServiceInfo))
       .send();
   }
 
@@ -761,8 +758,7 @@ public abstract class AbstractService implements InternalCloudService {
         .targetAll()
         .message("update_service_lifecycle")
         .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-        .buffer(DataBuf.empty().writeObject(this.lastServiceInfo.lifeCycle()).writeObject(this.currentServiceInfo))
-        .build()
+        .build(buffer -> buffer.writeObject(this.lastServiceInfo.lifeCycle()).writeObject(this.currentServiceInfo))
         .send();
     }
   }
@@ -907,12 +903,11 @@ public abstract class AbstractService implements InternalCloudService {
             .target(logTarget._1())
             .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
             .message("screen_new_line")
-            .buffer(DataBuf.empty()
+            .build(buffer -> buffer
               .writeObject(this.currentServiceInfo)
               .writeString(logTarget._2())
               .writeString(line)
               .writeBoolean(stderr))
-            .build()
             .send();
         }
       }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/NodeCloudServiceFactory.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/NodeCloudServiceFactory.java
@@ -20,7 +20,6 @@ import dev.derklaro.aerogel.auto.annotation.Provides;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.rpc.factory.RPCFactory;
 import eu.cloudnetservice.driver.network.rpc.handler.RPCHandlerRegistry;
 import eu.cloudnetservice.driver.provider.CloudServiceFactory;
@@ -205,9 +204,8 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
       ChannelMessage.builder()
         .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
         .message("head_node_to_node_finish_service_registration")
-        .buffer(DataBuf.empty().writeUniqueId(serviceUniqueId))
         .targetNode(associatedNode.info().uniqueId())
-        .build()
+        .build(buffer -> buffer.writeUniqueId(serviceUniqueId))
         .send();
       return result;
     } else {
@@ -227,8 +225,7 @@ public class NodeCloudServiceFactory implements CloudServiceFactory {
       .targetNode(targetNode)
       .message(message)
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeObject(configuration))
-      .build()
+      .build(buffer -> buffer.writeObject(configuration))
       .sendSingleQueryAsync();
     var result = TaskUtil.getOrDefault(future, Duration.ofSeconds(20), null);
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/ServiceCreateRetryTracker.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/ServiceCreateRetryTracker.java
@@ -19,7 +19,6 @@ package eu.cloudnetservice.node.impl.service.defaults;
 import com.google.common.base.Preconditions;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.provider.CloudServiceFactory;
 import eu.cloudnetservice.driver.service.ServiceConfiguration;
 import eu.cloudnetservice.driver.service.ServiceCreateResult;
@@ -95,12 +94,9 @@ final class ServiceCreateRetryTracker implements Runnable {
       // build the base message and add all channel message targets
       var messageBuilder = ChannelMessage.builder()
         .message("deferred_service_event")
-        .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-        .buffer(DataBuf.empty().writeUniqueId(this.creationId).writeObject(createResult));
+        .channel(NetworkConstants.INTERNAL_MSG_CHANNEL);
       eventListeners.forEach(messageBuilder::target);
-
-      // build the message and send it out
-      messageBuilder.build().send();
+      messageBuilder.build(buffer -> buffer.writeUniqueId(this.creationId).writeObject(createResult)).send();
     }
   }
 }

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/holder/WrapperServiceInfoHolder.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/holder/WrapperServiceInfoHolder.java
@@ -22,7 +22,6 @@ import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.document.Document;
 import eu.cloudnetservice.driver.event.EventManager;
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
-import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.service.ProcessSnapshot;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import eu.cloudnetservice.driver.service.ServiceLifeCycle;
@@ -152,8 +151,7 @@ public final class WrapperServiceInfoHolder implements ServiceInfoHolder {
       .targetAll()
       .message("update_service_info")
       .channel(NetworkConstants.INTERNAL_MSG_CHANNEL)
-      .buffer(DataBuf.empty().writeObject(serviceInfoSnapshot))
-      .build()
+      .build(buffer -> buffer.writeObject(serviceInfoSnapshot))
       .send();
   }
 


### PR DESCRIPTION
### Motivation
Currently, a builder for a ChannelMessage cannot be re-used. This is done because the content buffer provided to the builder shouldn't be shared across multiple channel message instances at the same time. However, this limits the ability to re-use a base builder that just has changing content.

### Modification
Instead of holding a state if the `build` was called before, the build methods now take in the content buffer for the channel message. While this is not a perfect prevention against a buffer re-use, it at least limits the possibility of doing it by accident while also allowing the base of a channel message build to be reused.

### Result
The chance of reusing the content buffer of a channel message on accident has been reduced, while also allowing to reuse a base channel message builder instance.
