### PR TITLE
chore: don't require fixed ByteBuffer cleaner type

### DIFF
--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegate.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegate.java
@@ -115,7 +115,7 @@ public final class UnsafeReplacementDelegate {
           MethodType.methodType(cleanerMethod.getReturnType(), ByteBuffer.class));
 
         // get the method handle to invoke the clean method on the Cleaner class (type: (Cleaner):void)
-        var cleanerClass = Class.forName("jdk.internal.ref.Cleaner");
+        var cleanerClass = cleanerMethod.getReturnType();
         var cleanMethod = cleanerClass.getDeclaredMethod("clean");
         var cleanHandle = lookup.unreflect(cleanMethod);
 


### PR DESCRIPTION
### Motivation
Currently the `jdk.internal.ref.Cleaner` cleaner type is required to free direct byte buffers in our unsafe replacement. JDK-8344332 changed the internal cleaner implementation for jdk 26, we would need to migrate then.

### Modification
Instead of hardcoding the cleaner type we can just use the returned cleaner type from the `DirectBuffer#cleaner` method. This makes the implementation also resilient against future changes.

### Result
Our replacement for `Unsafe#invokeCleaner` no longer requires the `DirectBuffer#cleaner` method to return an instance of a `jdk.internal.ref.Cleaner` cleaner implementation.
