### PR TITLE
feat: support minecraft 1.21.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,7 +78,7 @@ adventure-serializer-bungee = "4.4.0"
 luckPermsApi = "5.5"
 
 # fabric platform special dependencies
-minecraft = "1.21.7"
+minecraft = "1.21.8"
 fabricLoader = "0.16.14"
 
 

--- a/node/impl/src/main/resources/files/versions.json
+++ b/node/impl/src/main/resources/files/versions.json
@@ -89,7 +89,7 @@
       "website": "https://papermc.io",
       "versions": [
         {
-          "name": "1.21.7",
+          "name": "1.21.8",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -101,7 +101,7 @@
               "-Dpaperclip.patchonly=true"
             ],
             "fetchOverPaperApi": true,
-            "versionGroup": "1.21.7"
+            "versionGroup": "1.21.8"
           }
         },
         {
@@ -346,8 +346,8 @@
       ],
       "versions": [
         {
-          "name": "1.21.7",
-          "url": "https://api.purpurmc.org/v2/purpur/1.21.7/latest/download",
+          "name": "1.21.8",
+          "url": "https://api.purpurmc.org/v2/purpur/1.21.8/latest/download",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -458,8 +458,8 @@
       ],
       "versions": [
         {
-          "name": "1.21.7",
-          "url": "https://s3.mcjars.app/spigot/1.21.7/4519/server.jar"
+          "name": "1.21.8",
+          "url": "https://s3.mcjars.app/spigot/1.21.8/4524/server.jar"
         },
         {
           "name": "1.21.6",
@@ -549,7 +549,7 @@
       "website": "https://fabricmc.net",
       "versions": [
         {
-          "name": "1.21.7",
+          "name": "1.21.8",
           "cacheFiles": false,
           "properties": {
             "copy": {
@@ -749,8 +749,8 @@
       ],
       "versions": [
         {
-          "name": "1.21.7",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.21.7/55/server.jar"
+          "name": "1.21.8",
+          "url": "https://s3.mcjars.app/loohp-limbo/1.21.8/58/server.jar"
         },
         {
           "name": "1.21.6",


### PR DESCRIPTION
### Motivation
Minecraft 1.21.8 was released and we want to support it.

### Modification
Updated the installs and updated the fabric minecraft version.

### Result
Minecraft 1.21.8 is supported.
