### PR TITLE
chore: reduce heap usage when doing chunked data transfer

### DIFF
--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
@@ -18,10 +18,13 @@ package eu.cloudnetservice.driver.network.buffer;
 
 import eu.cloudnetservice.driver.network.object.ObjectMapper;
 import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import lombok.NonNull;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -257,11 +260,59 @@ public interface DataBuf extends AutoCloseable {
   // utility for reading
 
   /**
-   * Get the number of remaining bytes in the buffer until the buffer gets released (when enabled).
+   * Get the remaining number of bytes that are filled with readable content.
    *
-   * @return the number of remaining bytes in the buffer.
+   * @return the remaining number of bytes that are filled with readable content.
    */
   int readableBytes();
+
+  /**
+   * Get the current reader offset. The next read to this buffer will happen at the returned offset.
+   *
+   * @return the current reader offset.
+   */
+  int readerOffset();
+
+  /**
+   * Sets the current reader offset of this buffer. The next read will happen from the given offset.
+   *
+   * @param offset the new reader offset to use.
+   * @return this buffer, for chaining.
+   * @throws IllegalStateException     if this buffer was released.
+   * @throws IndexOutOfBoundsException if the given offset is beyond the end of this buffer.
+   */
+  @NonNull
+  @Contract("_ -> this")
+  DataBuf readerOffset(int offset);
+
+  /**
+   * Advances the current reader offset of this buffer by the given delta. The next read to this buffer happens at the
+   * current reader index plus the given delta. Note: the given delta cannot be negative.
+   *
+   * @param delta the number of bytes to move the reader index by.
+   * @return this buffer, for chaining.
+   * @throws IllegalArgumentException  if the given delta is negative.
+   * @throws IllegalStateException     if this buffer was released.
+   * @throws IndexOutOfBoundsException if advancing by the given delta would move beyond the end of this buffer.
+   */
+  @NonNull
+  @Contract("_ -> this")
+  DataBuf advanceReaderOffset(int delta);
+
+  /**
+   * Get a byte buffer instance that shares the memory region of this buffer. The returned buffer is marked as read-only
+   * which prevents write operations to it. The initial byte buffer offset is the current reader offset, and it's
+   * limited to the number of readable bytes beyond the current reader offset.
+   * <p>
+   * Note: this api is marked as experimental as the lifecycle of the returned buffer cannot be controlled. This means
+   * that a returned byte buffer instance can still refer to memory already released by this buffer.
+   *
+   * @return a read-only byte buffer sharing the memory region of this buffer, but with a separate position.
+   * @throws IllegalStateException if this buffer was released.
+   */
+  @NonNull
+  @ApiStatus.Experimental
+  ByteBuffer readableNioBuffer();
 
   /**
    * Starts a transaction to the buffer. Starting a transaction while another transaction is active will override the
@@ -292,6 +343,8 @@ public interface DataBuf extends AutoCloseable {
    */
   @NonNull
   DataBuf.Mutable asMutable();
+
+  // lifecycle management
 
   /**
    * Get if the current buffer is still accessible or if it was released already.
@@ -515,6 +568,8 @@ public interface DataBuf extends AutoCloseable {
       @Nullable T object,
       @NonNull BiConsumer<Mutable, T> handlerWhenNonNull);
 
+    // utility for writing
+
     /**
      * Ensures that this buffer has at least the given number of bytes available for writing data. If the buffer already
      * has the number of bytes present, this method returns immediately.
@@ -526,6 +581,61 @@ public interface DataBuf extends AutoCloseable {
      */
     @NonNull
     DataBuf.Mutable ensureWriteable(int bytes);
+
+    /**
+     * Get the remaining number of bytes available for write operations.
+     *
+     * @return the remaining number of bytes available for write operations.
+     */
+    int writeableBytes();
+
+    /**
+     * Get the current writer offset. The next write operation to this buffer will happen at the returned offset.
+     *
+     * @return the current writer offset.
+     */
+    int writerOffset();
+
+    /**
+     * Sets the current writer offset of this buffer. The next write operation will happen from the given offset.
+     *
+     * @param offset the new writer offset to use.
+     * @return this buffer, for chaining.
+     * @throws IllegalStateException     if this buffer was released.
+     * @throws IndexOutOfBoundsException if the given offset is beyond the end of this buffer.
+     */
+    @NonNull
+    @Contract("_ -> this")
+    DataBuf writerOffset(int offset);
+
+    /**
+     * Advances the current writer offset of this buffer by the given delta. The next write operation to this buffer
+     * happens at the current writer index plus the given delta. Note: the given delta cannot be negative.
+     *
+     * @param delta the number of bytes to move the writer index by.
+     * @return this buffer, for chaining.
+     * @throws IllegalArgumentException  if the given delta is negative.
+     * @throws IllegalStateException     if this buffer was released.
+     * @throws IndexOutOfBoundsException if advancing by the given delta would move beyond the end of this buffer.
+     */
+    @NonNull
+    @Contract("_ -> this")
+    DataBuf advanceWriterOffset(int delta);
+
+    /**
+     * Get a byte buffer instance that shares the memory region of this buffer. The returned buffer can be used to read
+     * and write data to this buffer. The initial byte buffer offset is the current writer offset, and it's limited to
+     * the number of writable bytes beyond the current writer offset.
+     * <p>
+     * Note: this api is marked as experimental as the lifecycle of the returned buffer cannot be controlled. This means
+     * that a returned byte buffer instance can still refer to memory already released by this buffer.
+     *
+     * @return a byte buffer sharing the memory region of this buffer, but with a separate position.
+     * @throws IllegalStateException if this buffer was released.
+     */
+    @NonNull
+    @ApiStatus.Experimental
+    ByteBuffer writeableNioBuffer();
 
     /**
      * Wraps the underlying buffer into a read-only variant. The underlying memory, lifetime and reader/writer positions

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
@@ -300,9 +300,9 @@ public interface DataBuf extends AutoCloseable {
   DataBuf advanceReaderOffset(int delta);
 
   /**
-   * Get a byte buffer instance that shares the memory region of this buffer. The returned buffer is marked as read-only
-   * which prevents write operations to it. The initial byte buffer offset is the current reader offset, and it's
-   * limited to the number of readable bytes beyond the current reader offset.
+   * Get a new byte buffer instance that shares the memory region of this buffer. The returned buffer is marked as
+   * read-only which prevents write operations to it. The initial byte buffer offset is the current reader offset, and
+   * it's limited to the number of readable bytes beyond the current reader offset.
    * <p>
    * Note: this api is marked as experimental as the lifecycle of the returned buffer cannot be controlled. This means
    * that a returned byte buffer instance can still refer to memory already released by this buffer.
@@ -623,9 +623,9 @@ public interface DataBuf extends AutoCloseable {
     DataBuf advanceWriterOffset(int delta);
 
     /**
-     * Get a byte buffer instance that shares the memory region of this buffer. The returned buffer can be used to read
-     * and write data to this buffer. The initial byte buffer offset is the current writer offset, and it's limited to
-     * the number of writable bytes beyond the current writer offset.
+     * Get a new byte buffer instance that shares the memory region of this buffer. The returned buffer can be used to
+     * read and write data to this buffer. The initial byte buffer offset is the current writer offset, and it's limited
+     * to the number of writable bytes beyond the current writer offset.
      * <p>
      * Note: this api is marked as experimental as the lifecycle of the returned buffer cannot be controlled. This means
      * that a returned byte buffer instance can still refer to memory already released by this buffer.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkSessionInformation.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkSessionInformation.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.driver.network.chunk;
 
-import com.google.common.base.Utf8;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.buffer.DataBufable;
 import java.io.Closeable;
@@ -65,24 +64,6 @@ public final class ChunkSessionInformation implements DataBufable, Closeable {
     this.sessionUniqueId = sessionUniqueId;
     this.transferChannel = transferChannel;
     this.transferInformation = transferInformation;
-  }
-
-  /**
-   * Returns the bytes required to write this session information into a buffer.
-   *
-   * @return the bytes required to write this session information into a buffer.
-   */
-  @ApiStatus.Internal
-  public int packetSizeBytes() {
-    var channelBytes = Utf8.encodedLength(this.transferChannel);
-    var transferBytes = this.transferInformation.readableBytes();
-    return Byte.BYTES              // nullable
-      + Integer.BYTES              // chunk size
-      + (Long.BYTES * 2)           // session id
-      + 5                          // channel name (max length)
-      + channelBytes
-      + 5                          // extra transfer info (max length)
-      + transferBytes;
   }
 
   /**

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketSender.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketSender.java
@@ -20,11 +20,10 @@ import eu.cloudnetservice.driver.network.NetworkChannel;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import eu.cloudnetservice.driver.network.protocol.Packet;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -59,7 +58,7 @@ public interface ChunkedPacketSender extends ChunkedPacketProvider {
    */
   static @NonNull ChunkedPacketSender.Builder forFileTransfer(@NonNull Path filePath) {
     try {
-      var fileStream = Files.newInputStream(filePath, StandardOpenOption.READ);
+      var fileStream = new FileInputStream(filePath.toFile()); // FIS can be optimized during actual transfer
       return forStreamTransfer().source(fileStream);
     } catch (IOException exception) {
       throw new IllegalArgumentException("Unable to open file for reading: " + filePath, exception);

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultFileChunkPacketSender.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultFileChunkPacketSender.java
@@ -22,7 +22,10 @@ import eu.cloudnetservice.driver.network.chunk.ChunkedPacketSender;
 import eu.cloudnetservice.driver.network.chunk.TransferStatus;
 import eu.cloudnetservice.driver.network.protocol.Packet;
 import eu.cloudnetservice.utils.base.concurrent.TaskUtil;
+import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import lombok.NonNull;
@@ -35,7 +38,9 @@ import lombok.NonNull;
  */
 public class DefaultFileChunkPacketSender extends DefaultChunkedPacketProvider implements ChunkedPacketSender {
 
-  protected final InputStream source;
+  protected static final int CHUNK_INFO_DATA_BYTES = Byte.BYTES + Integer.BYTES; // eof (Z) + byte count (I)
+
+  protected final ReadableByteChannel source;
   protected final Consumer<Packet> packetSplitter;
 
   /**
@@ -52,9 +57,8 @@ public class DefaultFileChunkPacketSender extends DefaultChunkedPacketProvider i
     @NonNull Consumer<Packet> packetSplitter
   ) {
     super(sessionInformation);
-
-    this.source = source;
     this.packetSplitter = packetSplitter;
+    this.source = source instanceof FileInputStream fis ? fis.getChannel() : Channels.newChannel(source);
   }
 
   /**
@@ -64,28 +68,35 @@ public class DefaultFileChunkPacketSender extends DefaultChunkedPacketProvider i
   public @NonNull CompletableFuture<TransferStatus> transferChunkedData() {
     return TaskUtil.supplyAsync(() -> {
       var chunkIndex = 0;
-      var backingArray = new byte[this.chunkSessionInformation.chunkSize()];
-
+      var chunkSize = this.chunkSessionInformation.chunkSize();
+      var bufferGrowthPerChunk = CHUNK_INFO_DATA_BYTES + chunkSize; // chunk info + actual chunk data
       while (true) {
-        var bytesRead = Math.max(0, this.source.read(backingArray));
-        if (bytesRead == backingArray.length) {
-          // if the bytes read is the same size as the backing array, then a full chunk of data has been read from the
-          // backing file. this usually indicates that the chunk is not the last chunk in the transfer
-          var chunkPacket = ChunkedPacket.createFullChunk(chunkIndex++, backingArray, this.chunkSessionInformation);
-          this.packetSplitter.accept(chunkPacket);
-        } else {
-          // final chunk to send out, this is one is allowed to not contain as much data as the other chunks
-          var chunkPacket = ChunkedPacket.createFinalChunk(
-            chunkIndex,
-            bytesRead,
-            backingArray,
-            this.chunkSessionInformation);
-          this.packetSplitter.accept(chunkPacket);
+        var chunkDataBuffer = ChunkedPacket
+          .createBaseChunkDataBuffer(chunkIndex++, this.chunkSessionInformation)
+          .ensureWriteable(bufferGrowthPerChunk);
+        var writerOffset = chunkDataBuffer.writerOffset();
 
-          // close all allocated resources used for the transfer
+        // advance the writer offset to skip the bytes for the EOF and chunk size info. these
+        // are only available after writing the data, so that has to be done first
+        chunkDataBuffer.advanceWriterOffset(CHUNK_INFO_DATA_BYTES);
+        var chunkDataNioBuffer = chunkDataBuffer
+          .writeableNioBuffer()
+          .limit(chunkDataBuffer.writerOffset() + chunkSize);
+        var bytesRead = Math.max(0, this.source.read(chunkDataNioBuffer));
+
+        // move the writer offset back to write the EOF and chunk size info,
+        // then move the writer offset back to the end of the buffer
+        chunkDataBuffer.writerOffset(writerOffset);
+        var finalChunk = bytesRead != chunkSize;
+        chunkDataBuffer.writeBoolean(finalChunk).writeInt(bytesRead);
+        chunkDataBuffer.advanceWriterOffset(bytesRead);
+
+        var chunkPacket = new ChunkedPacket(chunkDataBuffer);
+        this.packetSplitter.accept(chunkPacket);
+
+        if (finalChunk) {
           this.source.close();
           this.chunkSessionInformation.close();
-
           return TransferStatus.SUCCESS;
         }
       }

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultFileChunkedPacketHandler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultFileChunkedPacketHandler.java
@@ -23,10 +23,12 @@ import eu.cloudnetservice.driver.network.chunk.TransferStatus;
 import eu.cloudnetservice.utils.base.io.FileUtil;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import lombok.NonNull;
@@ -39,8 +41,16 @@ import org.jetbrains.annotations.Nullable;
  */
 public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvider implements ChunkedPacketHandler {
 
+  protected static final Set<OpenOption> FILE_CHANNEL_OPEN_OPTIONS = Set.of(
+    StandardOpenOption.READ,
+    StandardOpenOption.WRITE,
+    StandardOpenOption.DSYNC,
+    StandardOpenOption.CREATE,
+    StandardOpenOption.TRUNCATE_EXISTING
+  );
+
   protected final Path tempFilePath;
-  protected final RandomAccessFile targetFile;
+  protected final FileChannel targetFile;
   protected final Callback writeCompleteHandler;
   protected final Lock lock = new ReentrantLock();
 
@@ -48,7 +58,7 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
   protected int expectedFileParts = -1;
 
   /**
-   * Creates the session handler initially. Sessions should be manged by some sort of handler which is responsible for
+   * Creates the session handler initially. Sessions should be manged by some sort of handler that is responsible for
    * handling incoming chunk parts as well.
    *
    * @param sessionInformation the information transferred by the sender initially.
@@ -63,7 +73,7 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
   }
 
   /**
-   * Creates the session handler initially. Sessions should be manged by some sort of handler which is responsible for
+   * Creates the session handler initially. Sessions should be manged by some sort of handler that is responsible for
    * handling incoming chunk parts as well.
    *
    * @param sessionInformation the information transferred by the sender initially.
@@ -84,21 +94,15 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
   }
 
   /**
-   * Opens a random access file at the provided temp path, creating the file if it does not exist. Note that this method
-   * does not create the parent directory of the file, it must exist prior to invocation.
+   * Opens a file channel to the provided temp path, creating the file if it does not exist. Note that this method does
+   * not create the parent directory of the file, it must exist prior to invocation.
    *
-   * @return the opened temp file for random access.
+   * @return the opened file channel to the target file.
    * @throws IllegalStateException if the temp file cannot be opened or created.
    */
-  private @NonNull RandomAccessFile openTempFile() {
+  private @NonNull FileChannel openTempFile() {
     try {
-      // create the file in case it does not exist
-      if (Files.notExists(this.tempFilePath)) {
-        Files.createFile(this.tempFilePath);
-      }
-
-      var pathAsFile = this.tempFilePath.toFile();
-      return new RandomAccessFile(pathAsFile, "rwd");
+      return FileChannel.open(this.tempFilePath, FILE_CHANNEL_OPEN_OPTIONS);
     } catch (IOException exception) {
       throw new IllegalStateException("cannot open chunk transfer temp file for writing", exception);
     }
@@ -142,7 +146,6 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
           var closeStream = true;
           var stream = InputStream.nullInputStream();
           try {
-            // open the stream to the data and post it to the write handler
             stream = Files.newInputStream(this.tempFilePath, StandardOpenOption.DELETE_ON_CLOSE);
             closeStream = this.writeCompleteHandler.handleSessionComplete(this.chunkSessionInformation, stream);
           } finally {
@@ -167,16 +170,19 @@ public class DefaultFileChunkedPacketHandler extends DefaultChunkedPacketProvide
   }
 
   /**
-   * Writes the content of a chunk part to the backing file, increasing the amount of written bytes by one.
+   * Writes the content of a chunk part to the backing file channel.
    *
    * @param chunkPosition the index of the chunk to write.
    * @param dataBuf       the buf transferred to this handler, the next content should be the actual chunk data.
    * @throws IOException          if an i/o error occurs during the chunk write.
    * @throws NullPointerException if the given buffer is null.
    */
+  @SuppressWarnings("ResultOfMethodCallIgnored") // don't care about the number of bytes written
   protected void writePacketContent(int chunkPosition, @NonNull DataBuf dataBuf) throws IOException {
-    var filePosition = Math.multiplyFull(chunkPosition, this.chunkSessionInformation.chunkSize());
-    this.targetFile.seek(filePosition);
-    this.targetFile.write(dataBuf.readByteArray());
+    var chunkSize = dataBuf.readInt(); // size of the current chunk
+    var standardChunkSize = this.chunkSessionInformation.chunkSize(); // size in which chunks are transmitted
+    var fileOffset = Math.multiplyFull(chunkPosition, standardChunkSize);
+    var chunkBuffer = dataBuf.readableNioBuffer().limit(dataBuf.readerOffset() + chunkSize);
+    this.targetFile.write(chunkBuffer, fileOffset);
   }
 }

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/network/ChunkedPacket.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/network/ChunkedPacket.java
@@ -17,9 +17,7 @@
 package eu.cloudnetservice.driver.impl.network.chunk.network;
 
 import eu.cloudnetservice.driver.impl.network.NetworkConstants;
-import eu.cloudnetservice.driver.impl.network.netty.NettyUtil;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
-import eu.cloudnetservice.driver.network.buffer.DataBufFactory;
 import eu.cloudnetservice.driver.network.chunk.ChunkSessionInformation;
 import eu.cloudnetservice.driver.network.protocol.BasePacket;
 import lombok.NonNull;
@@ -31,77 +29,34 @@ import lombok.NonNull;
  */
 public final class ChunkedPacket extends BasePacket {
 
+  // impl note: packet structure
+  //  - object: session info
+  //  - int: chunk index
+  //  - bool: final chunk
+  //  - int: written byte count
+
   /**
    * Constructs a new chunked transfer part packet.
    *
    * @param dataBuf the data for the handling process of the chunk part.
    * @throws NullPointerException if the given buffer is null.
    */
-  private ChunkedPacket(@NonNull DataBuf dataBuf) {
+  public ChunkedPacket(@NonNull DataBuf dataBuf) {
     super(NetworkConstants.CHUNKED_PACKET_COM_CHANNEL, dataBuf);
   }
 
   /**
-   * Creates a new full chunk in the middle of a transfer. This method assumes that tbe amount of bytes that were read
-   * from the underlying source is the same as the chunk size of the transfer, only the last chunk is allowed to contain
-   * less or no data.
+   * Creates the base chunk data buffer for transferring a chunk of data.
    *
    * @param chunkIndex  the 0-based index of the chunk that is being sent.
-   * @param sourceData  the data that was read from the underlying source.
    * @param sessionInfo the information about the transfer session that this packet is related to.
    * @return a full chunk packet containing all the information provided to this method.
    * @throws NullPointerException if the given source data or chunk information is null.
    */
-  public static @NonNull ChunkedPacket createFullChunk(
+  public static @NonNull DataBuf.Mutable createBaseChunkDataBuffer(
     int chunkIndex,
-    byte[] sourceData,
     @NonNull ChunkSessionInformation sessionInfo
   ) {
-    var sourceDataLengthSize = NettyUtil.varIntBytes(sourceData.length);
-    var transferBytes = Byte.BYTES
-      + Integer.BYTES
-      + sourceDataLengthSize
-      + sourceData.length
-      + sessionInfo.packetSizeBytes();
-    var informationBuffer = DataBufFactory.defaultFactory().createWithExpectedSize(transferBytes)
-      .writeObject(sessionInfo)
-      .writeInt(chunkIndex)
-      .writeBoolean(false) // not the final chunk
-      .writeByteArray(sourceData);
-    return new ChunkedPacket(informationBuffer);
-  }
-
-  /**
-   * Creates a new final chunk which must be sent to terminate a chunked data transfer on the remote side. Due to this
-   * the provided chunk index is assumed to be the last index, which means that the total amount of chunks will be set
-   * to {@code index + 1}. The final chunk of a transfer is allowed to contain fewer or no bytes than the chunk size of
-   * the session. To properly serialize the smaller chunk data which can be provided in a bigger data byte array, the
-   * given read bytes will be used to only serialize the chunk of bytes in the given array that are actually relevant.
-   *
-   * @param chunkIndex  the 0-based index of the chunk that is being sent.
-   * @param readBytes   the amount of bytes that were read from the underlying source.
-   * @param sourceData  the data that was read from the underlying source.
-   * @param sessionInfo the information about the transfer session that this packet is related to.
-   * @return the created chunk packet based on the information.
-   * @throws NullPointerException if the given chunk information is null.
-   */
-  public static @NonNull ChunkedPacket createFinalChunk(
-    int chunkIndex,
-    int readBytes,
-    byte[] sourceData,
-    @NonNull ChunkSessionInformation sessionInfo
-  ) {
-    var sourceDataLengthSize = NettyUtil.varIntBytes(readBytes);
-    var transferBytes = Byte.BYTES
-      + Integer.BYTES
-      + sourceDataLengthSize
-      + readBytes
-      + sessionInfo.packetSizeBytes();
-    var informationBuffer = DataBufFactory.defaultFactory().createWithExpectedSize(transferBytes)
-      .writeObject(sessionInfo)
-      .writeInt(chunkIndex)
-      .writeBoolean(true) // final chunk
-      .writeByteArray(sourceData, readBytes);
-    return new ChunkedPacket(informationBuffer);
+    return DataBuf.empty().writeObject(sessionInfo).writeInt(chunkIndex);
   }
 }

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyImmutableDataBuf.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyImmutableDataBuf.java
@@ -21,9 +21,11 @@ import eu.cloudnetservice.driver.impl.network.netty.NettyUtil;
 import eu.cloudnetservice.driver.impl.network.object.DefaultObjectMapper;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import io.netty5.buffer.Buffer;
+import io.netty5.buffer.BufferComponent;
 import io.netty5.buffer.internal.InternalBufferUtils;
 import io.netty5.buffer.internal.ResourceSupport;
 import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.function.Function;
@@ -48,9 +50,10 @@ public sealed class NettyImmutableDataBuf implements DataBuf permits NettyMutabl
    *
    * @param buffer the netty buffer to wrap.
    * @throws NullPointerException     if the given buffer is null.
-   * @throws IllegalArgumentException if the given buffer does not extend {@code ResourceSupport}.
+   * @throws IllegalArgumentException if the given buffer cannot be wrapped into a data buf.
    */
   public NettyImmutableDataBuf(@NonNull Buffer buffer) {
+    Preconditions.checkArgument(buffer instanceof BufferComponent, "buffer must implement BufferComponent");
     Preconditions.checkArgument(buffer instanceof ResourceSupport<?, ?>, "buffer must extend ResourceSupport");
     this.buffer = buffer;
   }
@@ -209,6 +212,41 @@ public sealed class NettyImmutableDataBuf implements DataBuf permits NettyMutabl
   @Override
   public int readableBytes() {
     return this.buffer.readableBytes();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int readerOffset() {
+    return this.buffer.readerOffset();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull DataBuf readerOffset(int offset) {
+    this.buffer.readerOffset(offset);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull DataBuf advanceReaderOffset(int delta) {
+    this.buffer.skipReadableBytes(delta);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull ByteBuffer readableNioBuffer() {
+    var bufferAsBufferComponent = (BufferComponent) this.buffer;
+    return bufferAsBufferComponent.readableBuffer();
   }
 
   /**

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyMutableDataBuf.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyMutableDataBuf.java
@@ -21,6 +21,8 @@ import eu.cloudnetservice.driver.impl.network.netty.NettyUtil;
 import eu.cloudnetservice.driver.impl.network.object.DefaultObjectMapper;
 import eu.cloudnetservice.driver.network.buffer.DataBuf;
 import io.netty5.buffer.Buffer;
+import io.netty5.buffer.BufferComponent;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.function.BiConsumer;
@@ -202,6 +204,49 @@ public final class NettyMutableDataBuf extends NettyImmutableDataBuf implements 
   public @NonNull DataBuf.Mutable ensureWriteable(int bytes) {
     this.buffer.ensureWritable(bytes);
     return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int writeableBytes() {
+    return this.buffer.writableBytes();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int writerOffset() {
+    return this.buffer.writerOffset();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull DataBuf writerOffset(int offset) {
+    this.buffer.writerOffset(offset);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull DataBuf advanceWriterOffset(int delta) {
+    this.buffer.skipWritableBytes(delta);
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull ByteBuffer writeableNioBuffer() {
+    var bufferAsBufferComponent = (BufferComponent) this.buffer;
+    return bufferAsBufferComponent.writableBuffer();
   }
 
   /**

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/chunk/ChunkedPacketSenderTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/chunk/ChunkedPacketSenderTest.java
@@ -49,7 +49,7 @@ public class ChunkedPacketSenderTest {
   @Timeout(20)
   void testChunkPacketSender() throws Exception {
     var packetSplits = new AtomicInteger();
-    var chunkData = this.generateRandomChunkData();
+    var chunkData = this.generateRandomChunkData(false);
 
     var sessionId = UUID.randomUUID();
     DataBuf dataBuf = DataBuf.empty().writeString("hello").writeInt(10).writeString("world");
@@ -74,7 +74,7 @@ public class ChunkedPacketSenderTest {
   @Timeout(20)
   void testNetworkChannelSplitter() throws Exception {
     var packetSplits = new AtomicInteger();
-    var chunkData = this.generateRandomChunkData();
+    var chunkData = this.generateRandomChunkData(true);
 
     var sessionId = UUID.randomUUID();
     DataBuf dataBuf = DataBuf.empty().writeString("hello").writeInt(10).writeString("world");
@@ -98,8 +98,8 @@ public class ChunkedPacketSenderTest {
       .get());
   }
 
-  private byte[] generateRandomChunkData() {
-    var data = new byte[4096];
+  private byte[] generateRandomChunkData(boolean exactMultiply) {
+    var data = new byte[16 * 256 + (exactMultiply ? 0 : 69)];
     ThreadLocalRandom.current().nextBytes(data);
     return data;
   }
@@ -108,11 +108,13 @@ public class ChunkedPacketSenderTest {
     var info = packet.content().readObject(ChunkSessionInformation.class);
     var chunkIndex = packet.content().readInt();
     var finalChunk = packet.content().readBoolean();
+    var chunkDataSize = packet.content().readInt();
 
     Assertions.assertEquals(256, info.chunkSize());
     Assertions.assertEquals(sessionId, info.sessionUniqueId());
     Assertions.assertEquals("hello_world", info.transferChannel());
     Assertions.assertEquals(splits.get(), chunkIndex);
+    Assertions.assertTrue(finalChunk || chunkDataSize == 256);
 
     Assertions.assertEquals("hello", info.transferInformation().readString());
     Assertions.assertEquals(10, info.transferInformation().readInt());
@@ -123,17 +125,9 @@ public class ChunkedPacketSenderTest {
       Assertions.assertEquals(data.length / 256, chunkIndex);
     }
 
-    // this prevents a weird bug happening. When copying an array beginning at the length of the array (in this case
-    // 4096) it will not throw an exception as expected but give you back an array with the expected 256 size full
-    // of zeros which will cause this test to fail.
     var sourcePosition = splits.get() * 256;
-    var contentAtPosition = sourcePosition == data.length
-      ? new byte[0]
-      : Arrays.copyOfRange(data, sourcePosition, (splits.get() + 1) * 256);
-
-    Assertions.assertArrayEquals(
-      contentAtPosition,
-      packet.content().readByteArray());
+    var contentAtPosition = Arrays.copyOfRange(data, sourcePosition, sourcePosition + chunkDataSize);
+    Assertions.assertArrayEquals(contentAtPosition, packet.content().toByteArray());
   }
 
   private NetworkChannel mockNetworkChannel(Consumer<Packet> packetSyncSendHandler) {

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ClusterCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ClusterCommand.java
@@ -38,11 +38,14 @@ import eu.cloudnetservice.node.impl.util.NetworkUtil;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import eu.cloudnetservice.utils.base.column.ColumnFormatter;
 import eu.cloudnetservice.utils.base.column.RowedFormatter;
+import eu.cloudnetservice.utils.base.io.FileUtil;
 import eu.cloudnetservice.utils.base.io.ZipUtil;
 import eu.cloudnetservice.utils.base.resource.ResourceFormatter;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -309,14 +312,11 @@ public final class ClusterCommand {
     @Flag("overwrite") boolean overwrite
   ) {
     var staticServicePath = this.serviceProvider.persistentServicesDirectory();
-    // check if we need to push all static services or just a specific one
     if (service == null) {
-      // resolve all existing static services, that are not running and push them
       for (var serviceName : this.resolveAllStaticServices()) {
         this.pushStaticService(i18n, source, staticServicePath.resolve(serviceName), serviceName, overwrite);
       }
     } else {
-      // only push the specific static service that was given
       this.pushStaticService(i18n, source, staticServicePath.resolve(service), service, overwrite);
     }
   }
@@ -328,24 +328,36 @@ public final class ClusterCommand {
     @NonNull String serviceName,
     boolean overwrite
   ) {
-    // zip the whole directory into a stream
-    var stream = ZipUtil.zipToStream(servicePath);
-    // notify the source about the deployment
-    source.sendMessage(i18n.translate("command-cluster-push-static-service-starting"));
-    // deploy the static service into the cluster
-    this.nodeServerProvider.deployStaticServiceToCluster(serviceName, stream, overwrite)
-      .thenAccept(transferStatus -> {
-        if (transferStatus == TransferStatus.FAILURE) {
-          // the transfer failed
-          source.sendMessage(i18n.translate("command-cluster-push-static-service-failed"));
-        } else {
-          // the transfer was successful
-          source.sendMessage(i18n.translate("command-cluster-push-static-service-success"));
-        }
-      });
+    // zip the service directory into a temp file and create an input stream to deploy from the file
+    var target = FileUtil.createTempFile();
+    var zipOutputFile = ZipUtil.zipToFile(servicePath, target, path -> !target.equals(path));
+    if (zipOutputFile == null) {
+      source.sendMessage(i18n.translate("command-cluster-push-static-service-failed"));
+      return;
+    }
+
+    try {
+      source.sendMessage(i18n.translate("command-cluster-push-static-service-starting"));
+      var zipOutputFileStream = new FileInputStream(zipOutputFile.toFile()); // FIS for optimized transfer
+      this.nodeServerProvider.deployStaticServiceToCluster(serviceName, zipOutputFileStream, overwrite)
+        .thenAccept(transferStatus -> {
+          if (transferStatus == TransferStatus.FAILURE) {
+            source.sendMessage(i18n.translate("command-cluster-push-static-service-failed"));
+          } else {
+            source.sendMessage(i18n.translate("command-cluster-push-static-service-success"));
+          }
+        });
+    } catch (FileNotFoundException _) {
+      // should not happen as ZipUtil.zipToFile should return null in this case
+      source.sendMessage(i18n.translate("command-cluster-push-static-service-failed"));
+    }
   }
 
-  private void pushTemplate(@NonNull @Service I18n i18n, @NonNull CommandSource source, @NonNull ServiceTemplate template) {
+  private void pushTemplate(
+    @NonNull @Service I18n i18n,
+    @NonNull CommandSource source,
+    @NonNull ServiceTemplate template
+  ) {
     var templateName = template.toString();
     try {
       source.sendMessage(


### PR DESCRIPTION
### Motivation
Currently, chunked data transfers are copying the data via the heap into the target netty buffer (and vice-versa). This is very inefficient as this means that a native memory segment is copied to the heap and then back into a native memory segment. 

### Modification
Use nio Channels in combination with ByteBuffers to directly read/write the content being transferred to/from the netty buffer, completely removing the need for (almost) any heap allocations.

### Result
Reduced heap usage when doing a chunked data transfers.
