### PR TITLE
chore: prevent invalid packets/network state

### DIFF
--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/NetworkConstants.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/NetworkConstants.java
@@ -17,10 +17,7 @@
 package eu.cloudnetservice.driver.impl.network;
 
 /**
- * Holds some internal constants for network communication which are shared between wrappers and nodes. The class is
- * marked as internal, however developers are allowed to use this class. <strong>BUT</strong> there might be changes to
- * this class which are breaking, even when doing a patch release (for example a constant can get removed or changed).
- * This class should therefore be used with caution.
+ * Holds some internal constants for network communication that are shared between wrappers and nodes.
  *
  * @since 4.0
  */
@@ -35,6 +32,9 @@ public final class NetworkConstants {
 
   // channel message channels
   public static final String INTERNAL_MSG_CHANNEL = "cloudnet:internal";
+
+  // magic packet header added to all packets to identify them as sent by CloudNet
+  public static final int MAGIC_PACKET_HEADER = (0x43 << 16) | (0x4E << 8) | 0x53;
 
   private NetworkConstants() {
     throw new UnsupportedOperationException();

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketDecoder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketDecoder.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.driver.impl.network.netty.codec;
 
+import eu.cloudnetservice.driver.impl.network.NetworkConstants;
 import eu.cloudnetservice.driver.impl.network.netty.NettyUtil;
 import eu.cloudnetservice.driver.impl.network.netty.buffer.NettyImmutableDataBuf;
 import eu.cloudnetservice.driver.network.protocol.BasePacket;
@@ -51,6 +52,17 @@ public final class NettyPacketDecoder extends ByteToMessageDecoder {
   @Override
   protected void decode(@NonNull ChannelHandlerContext ctx, @NonNull Buffer in) {
     try {
+      // packet must be prefixed with our magic header to distinguish it from other, similar
+      // protocols (e.g., the minecraft protocol uses the same framing as we do)
+      var magic = in.readableBytes() > 3 ? in.readMedium() : 0;
+      if (magic != NetworkConstants.MAGIC_PACKET_HEADER) {
+        ctx.channel().close();
+        LOGGER.warn(
+          "Received invalid packet from {} (not prefixed by magic header), closing connection",
+          ctx.channel().remoteAddress());
+        return;
+      }
+
       // read the required base data from the buffer
       var channel = NettyUtil.readVarInt(in);
       var prioritized = in.readBoolean();
@@ -69,7 +81,15 @@ public final class NettyPacketDecoder extends ByteToMessageDecoder {
 
       ctx.fireChannelRead(packet);
     } catch (Exception exception) {
-      LOGGER.error("Exception while decoding packet", exception);
+      LOGGER.error("Exception decoding packet from {}", ctx.channel().localAddress(), exception);
+    } finally {
+      // ByteToMessageDecoder will start cumulating if there are remaining bytes in the buffer, we
+      // don't want that - just discard left-over bytes in the buffer (should only happen in case of
+      // a decoding failure as not everything was read in that case)
+      var remainingReadableBytes = in.readableBytes();
+      if (remainingReadableBytes > 0) {
+        in.skipReadableBytes(remainingReadableBytes);
+      }
     }
   }
 }

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketEncoder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketEncoder.java
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.driver.impl.network.netty.codec;
 
+import eu.cloudnetservice.driver.impl.network.NetworkConstants;
 import eu.cloudnetservice.driver.impl.network.netty.NettyUtil;
 import eu.cloudnetservice.driver.impl.network.netty.buffer.NettyImmutableDataBuf;
 import eu.cloudnetservice.driver.network.protocol.Packet;
@@ -45,14 +46,14 @@ public final class NettyPacketEncoder extends MessageToByteEncoder<Packet> {
    */
   @Override
   protected Buffer allocateBuffer(@NonNull ChannelHandlerContext ctx, @NonNull Packet msg) {
-    // we allocate 2 booleans (prioritized and isQuery) + content length + channel in advance
-    var bufferLength = 2
+    var bufferLength = 3 // medium for the magic packet header
+      + Byte.BYTES // prioritized
+      + Byte.BYTES // has query id
       + msg.content().readableBytes()
       + NettyUtil.varIntBytes(msg.channel())
       + NettyUtil.varIntBytes(msg.content().readableBytes());
-    // if the given packet has a query unique id we need two longs for that unique id as well
     if (msg.uniqueId() != null) {
-      bufferLength += 16;
+      bufferLength += Long.BYTES * 2; // packet unique id consists of 2 longs
     }
 
     return ctx.bufferAllocator().allocate(bufferLength);
@@ -63,26 +64,27 @@ public final class NettyPacketEncoder extends MessageToByteEncoder<Packet> {
    */
   @Override
   protected void encode(@NonNull ChannelHandlerContext ctx, @NonNull Packet msg, @NonNull Buffer out) {
-    NettyUtil.writeVarInt(out, msg.channel());
-    out.writeBoolean(msg.prioritized());
+    try (var messageContent = msg.content()) {
+      out.writeMedium(NetworkConstants.MAGIC_PACKET_HEADER);
 
-    var queryUniqueId = msg.uniqueId();
-    out.writeBoolean(queryUniqueId != null);
-    if (queryUniqueId != null) {
-      out
-        .writeLong(queryUniqueId.getMostSignificantBits())
-        .writeLong(queryUniqueId.getLeastSignificantBits());
+      NettyUtil.writeVarInt(out, msg.channel());
+      out.writeBoolean(msg.prioritized());
+
+      var queryUniqueId = msg.uniqueId();
+      out.writeBoolean(queryUniqueId != null);
+      if (queryUniqueId != null) {
+        out
+          .writeLong(queryUniqueId.getMostSignificantBits())
+          .writeLong(queryUniqueId.getLeastSignificantBits());
+      }
+
+      // copy over the packet body into the output buffer
+      var content = ((NettyImmutableDataBuf) messageContent).buffer();
+      var length = content.readableBytes();
+      NettyUtil.writeVarInt(out, length);
+      content.copyInto(content.readerOffset(), out, out.writerOffset(), length);
+      out.skipWritableBytes(length);
     }
-
-    // copy over the packet body into the output buffer
-    var content = ((NettyImmutableDataBuf) msg.content()).buffer();
-    var length = content.readableBytes();
-    NettyUtil.writeVarInt(out, length);
-    content.copyInto(0, out, out.writerOffset(), length);
-    out.skipWritableBytes(length);
-
-    // release the packet content once
-    msg.content().release();
   }
 
   /**

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/VarInt32FrameDecoder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/VarInt32FrameDecoder.java
@@ -21,8 +21,12 @@ import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import lombok.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class VarInt32FrameDecoder extends ByteToMessageDecoder {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(VarInt32FrameDecoder.class);
 
   /**
    * {@inheritDoc}
@@ -34,31 +38,31 @@ public final class VarInt32FrameDecoder extends ByteToMessageDecoder {
       return;
     }
 
-    // try to read the full message length from the buffer, reset the buffer if we've read nothing
-    var readerIndex = in.readerOffset();
-    var length = NettyUtil.readVarIntOrNull(in);
-    if (length == null || readerIndex == in.readerOffset()) {
-      in.readerOffset(readerIndex);
+    // try to read the full message length from the buffer, continue cumulation if we've read nothing
+    var initialReaderOffset = in.readerOffset();
+    var packetLength = NettyUtil.readVarIntOrNull(in);
+    if (packetLength == null || initialReaderOffset == in.readerOffset()) {
+      in.readerOffset(initialReaderOffset);
       return;
     }
 
-    // skip empty packets silently
-    if (length <= 0) {
-      // check if there are bytes to skip
-      if (in.readableBytes() > 0) {
-        in.skipReadableBytes(in.readableBytes());
-      }
+    // check if the encoded packet length is valid, close the connection otherwise as there is no
+    // clear path how a valid state can be restored in this particular case
+    if (packetLength <= 0) {
+      ctx.channel().close();
+      LOGGER.warn(
+        "Received packet with invalid length {} from {}, closing connection",
+        packetLength, ctx.channel().remoteAddress());
       return;
     }
 
-    // check if the packet data supplied in the buffer is actually at least the transmitted size
-    if (in.readableBytes() >= length) {
-      // fire the channel read
-      ctx.fireChannelRead(in.copy(in.readerOffset(), length));
-      in.skipReadableBytes(length);
+    // check if we've cumulated the entire packet length already
+    if (in.readableBytes() >= packetLength) {
+      var packetBuffer = in.copy(in.readerOffset(), packetLength);
+      in.skipReadableBytes(packetLength);
+      ctx.fireChannelRead(packetBuffer);
     } else {
-      // reset the reader index, there is still data missing
-      in.readerOffset(readerIndex);
+      in.readerOffset(initialReaderOffset);
     }
   }
 }


### PR DESCRIPTION
### Motivation
It is currently possible that an invalid network state is caused by an invalid packet length being sent from one of the connected clients. Furthermore, an exception can be triggered when trying to connect to a node listener directly through a minecraft client, which isn't very helpful.

### Modification
When an invalid packet length is received the connection to the sender is closed immediately. Furthermore, the packet decoder implementation no longer starts cumulating packet buffers when there is a decoding failure.
Each packet sent by CloudNet is now prefixed with a magic integer. If an incoming packet is not prefixed with this magic number, the connection to the client is closed. This prevents connections that are sending packets not formatted in the CloudNet protocol format (e.g., the minecraft client) to cause decoding exceptions.

### Result
Better protection against unexpected internal faults and better information for user faults.
