### PR TITLE
chore: refactor BungeeCordHelper to use method handles

### DIFF
--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordBridgeManagement.java
@@ -93,10 +93,9 @@ final class BungeeCordBridgeManagement extends PlatformBridgeManagement<ProxiedP
     // init the default cache listeners
     this.cacheTester = CONNECTED_SERVICE_TESTER
       .and(service -> service.serviceId().environment().readProperty(ServiceEnvironmentType.JAVA_SERVER));
-    // register each service matching the service cache tester
-    this.cacheRegisterListener = bungeeHelper.serverRegisterHandler();
-    // unregister each service matching the service cache tester
-    this.cacheUnregisterListener = bungeeHelper.serverUnregisterHandler();
+
+    this.cacheRegisterListener = bungeeHelper::registerServer;
+    this.cacheUnregisterListener = bungeeHelper::unregisterServer;
   }
 
   @Override

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordHelper.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordHelper.java
@@ -16,23 +16,33 @@
 
 package eu.cloudnetservice.modules.bridge.impl.platform.bungeecord;
 
-import dev.derklaro.reflexion.Reflexion;
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
+import io.vavr.CheckedConsumer;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.net.InetSocketAddress;
-import java.util.function.Consumer;
 import lombok.NonNull;
 import net.md_5.bungee.api.ProxyConfig;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Helper utilities for bungeecord-related functionalities.
+ *
+ * @since 4.0
+ */
 @Singleton
-public final class BungeeCordHelper {
+final class BungeeCordHelper {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BungeeCordHelper.class);
 
   private final ProxyServer proxyServer;
-  private final Consumer<ServiceInfoSnapshot> serverRegisterHandler;
-  private final Consumer<ServiceInfoSnapshot> serverUnregisterHandler;
+  private final CheckedConsumer<ServiceInfoSnapshot> serverRegisterHandler;
+  private final CheckedConsumer<ServiceInfoSnapshot> serverUnregisterHandler;
 
   @Inject
   public BungeeCordHelper(
@@ -41,37 +51,95 @@ public final class BungeeCordHelper {
   ) {
     this.proxyServer = proxyServer;
 
-    // waterfall adds a dynamic api to register a server from the proxy.
-    // we need to use that api as the backing map is not concurrent and other plugins might cause issues
-    this.serverRegisterHandler = Reflexion.onBound(proxyConfig)
-      .findMethod("addServer", ServerInfo.class)
-      .map(acc -> (Consumer<ServiceInfoSnapshot>) service -> acc.invokeWithArgs(this.constructServerInfo(service)))
-      .orElse(service -> {
-        var serverInfo = this.constructServerInfo(service);
-        proxyServer.getServers().put(service.name(), serverInfo);
-      });
+    var lookup = MethodHandles.publicLookup(); // everything should be public api
 
-    // waterfall adds a dynamic api to unregister a server from the proxy.
-    // we need to use that api as the backing map is not concurrent and other plugins might cause issues
-    this.serverUnregisterHandler = Reflexion.onBound(proxyConfig)
-      .findMethod("removeServerNamed", String.class)
-      .map(acc -> (Consumer<ServiceInfoSnapshot>) service -> acc.invokeWithArgs(service.name()))
-      .orElse(service -> proxyServer.getServers().remove(service.name()));
+    CheckedConsumer<ServiceInfoSnapshot> serverRegisterHandler;
+    try {
+      // waterfall: ProxyConfig.addServer(ServerInfo):ServerInfo
+      var addServer = lookup.findVirtual(
+        ProxyConfig.class,
+        "addServer",
+        MethodType.methodType(ServerInfo.class, ServerInfo.class));
+      var addServerVoid = MethodHandles.dropReturn(addServer);
+      var addServerBound = addServerVoid.bindTo(proxyConfig);
+      serverRegisterHandler = serviceInfoSnapshot -> {
+        var serverInfo = this.constructServerInfo(serviceInfoSnapshot);
+        addServerBound.invokeExact(serverInfo);
+      };
+      LOGGER.debug("net.md_5.bungee.api.ProxyConfig.addServer(ServerInfo): available");
+    } catch (NoSuchMethodException | IllegalAccessException ex) {
+      // bungeecord: ProxyServer.getServers().put(String, ServerInfo)
+      serverRegisterHandler = serviceInfoSnapshot -> {
+        var serverInfo = this.constructServerInfo(serviceInfoSnapshot);
+        proxyServer.getServers().put(serverInfo.getName(), serverInfo);
+      };
+      LOGGER.debug("net.md_5.bungee.api.ProxyConfig.addServer(ServerInfo): unavailable ({})", ex.getMessage());
+    }
+
+    CheckedConsumer<ServiceInfoSnapshot> serverUnregisterHandler;
+    try {
+      // waterfall: ProxyConfig.removeServerNamed(String):ServerInfo
+      var removeServerNamed = lookup.findVirtual(
+        ProxyConfig.class,
+        "removeServerNamed",
+        MethodType.methodType(ServerInfo.class, String.class));
+      var removeServerNamedVoid = MethodHandles.dropReturn(removeServerNamed);
+      var removeServerBound = removeServerNamedVoid.bindTo(proxyConfig);
+      serverUnregisterHandler = serviceInfoSnapshot -> {
+        var serverName = serviceInfoSnapshot.serviceId().name();
+        removeServerBound.invokeExact(serverName);
+      };
+      LOGGER.debug("net.md_5.bungee.api.ProxyConfig.removeServerNamed(String): available");
+    } catch (NoSuchMethodException | IllegalAccessException ex) {
+      // bungeecord: ProxyServer.getServers().remove(String)
+      serverUnregisterHandler = serviceInfoSnapshot -> {
+        var serverName = serviceInfoSnapshot.serviceId().name();
+        proxyServer.getServers().remove(serverName);
+      };
+      LOGGER.debug("net.md_5.bungee.api.ProxyConfig.removeServerNamed(String): unavailable ({})", ex.getMessage());
+    }
+
+    this.serverRegisterHandler = serverRegisterHandler;
+    this.serverUnregisterHandler = serverUnregisterHandler;
   }
 
-  @NonNull Consumer<ServiceInfoSnapshot> serverRegisterHandler() {
-    return this.serverRegisterHandler;
+  /**
+   * Register the given service to the proxy. An existing service with the same name will be replaced.
+   *
+   * @param serviceInfoSnapshot the snapshot of the service to register.
+   * @throws NullPointerException if the given service info snapshot is null.
+   */
+  public void registerServer(@NonNull ServiceInfoSnapshot serviceInfoSnapshot) {
+    try {
+      this.serverRegisterHandler.accept(serviceInfoSnapshot);
+    } catch (Throwable throwable) {
+      LOGGER.error("Could not register server {}", serviceInfoSnapshot.serviceId(), throwable);
+    }
   }
 
-  @NonNull Consumer<ServiceInfoSnapshot> serverUnregisterHandler() {
-    return this.serverUnregisterHandler;
+  /**
+   * Unregisters the given service from the proxy.
+   *
+   * @param serviceInfoSnapshot the snapshot of the service to unregister.
+   * @throws NullPointerException if the given service info snapshot is null.
+   */
+  public void unregisterServer(@NonNull ServiceInfoSnapshot serviceInfoSnapshot) {
+    try {
+      this.serverUnregisterHandler.accept(serviceInfoSnapshot);
+    } catch (Throwable throwable) {
+      LOGGER.error("Could not unregister server {}", serviceInfoSnapshot.serviceId(), throwable);
+    }
   }
 
-  private @NonNull ServerInfo constructServerInfo(@NonNull ServiceInfoSnapshot snapshot) {
-    return this.proxyServer.constructServerInfo(
-      snapshot.name(),
-      new InetSocketAddress(snapshot.address().host(), snapshot.address().port()),
-      "Just another CloudNet provided service info",
-      false);
+  /**
+   * Constructs a proxy server info from the given service info snapshot.
+   *
+   * @param serviceInfo the service info to construct a server info from.
+   * @return a server info constructed from the given service info snapshot.
+   * @throws NullPointerException if the given service info snapshot is null.
+   */
+  private @NonNull ServerInfo constructServerInfo(@NonNull ServiceInfoSnapshot serviceInfo) {
+    var serviceAddress = new InetSocketAddress(serviceInfo.address().host(), serviceInfo.address().port());
+    return this.proxyServer.constructServerInfo(serviceInfo.name(), serviceAddress, "", false);
   }
 }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordHelper.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordHelper.java
@@ -18,6 +18,7 @@ package eu.cloudnetservice.modules.bridge.impl.platform.bungeecord;
 
 import eu.cloudnetservice.driver.service.ServiceInfoSnapshot;
 import io.vavr.CheckedConsumer;
+import io.vavr.CheckedPredicate;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.lang.invoke.MethodHandles;
@@ -27,6 +28,8 @@ import lombok.NonNull;
 import net.md_5.bungee.api.ProxyConfig;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.protocol.ProtocolConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +42,40 @@ import org.slf4j.LoggerFactory;
 final class BungeeCordHelper {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BungeeCordHelper.class);
+
+  // tests if a player was connected to the proxy before. the last possible usage point is ServerConnectedEvent
+  private static final CheckedPredicate<ProxiedPlayer> PLAYER_INITIAL_CONNECT_TESTER;
+
+  static {
+    var lookup = MethodHandles.publicLookup(); // everything should be public api
+
+    CheckedPredicate<ProxiedPlayer> playerInitialConnectTester;
+    try {
+      // modern access: via UserConnection.getDimension():Object (converted to ProxiedPlayer.getDimension():Object)
+      var userConnectionClass = Class.forName("net.md_5.bungee.UserConnection");
+      var getDimension = lookup.findVirtual(userConnectionClass, "getDimension", MethodType.methodType(Object.class));
+      var getDimensionProxiesPlayer = MethodHandles.explicitCastArguments(
+        getDimension,
+        MethodType.methodType(Object.class, ProxiedPlayer.class));
+      playerInitialConnectTester = proxiedPlayer -> {
+        // login packet sequence changed in 1.20.2, before that checking via getServer() == null is fine
+        var playerVersion = proxiedPlayer.getPendingConnection().getVersion();
+        if (playerVersion >= ProtocolConstants.MINECRAFT_1_20_2) {
+          var dimension = (Object) getDimensionProxiesPlayer.invokeExact(proxiedPlayer);
+          return dimension == null;
+        } else {
+          return proxiedPlayer.getServer() == null;
+        }
+      };
+      LOGGER.debug("net.md_5.bungee.UserConnection.getDimension(): available");
+    } catch (Exception ex) {
+      // fallback to check via ProxiedPlayer.getServer()
+      playerInitialConnectTester = proxiedPlayer -> proxiedPlayer.getServer() == null;
+      LOGGER.debug("net.md_5.bungee.UserConnection.getDimension(): unavailable ({})", ex.getMessage());
+    }
+
+    PLAYER_INITIAL_CONNECT_TESTER = playerInitialConnectTester;
+  }
 
   private final ProxyServer proxyServer;
   private final CheckedConsumer<ServiceInfoSnapshot> serverRegisterHandler;
@@ -101,6 +138,24 @@ final class BungeeCordHelper {
 
     this.serverRegisterHandler = serverRegisterHandler;
     this.serverUnregisterHandler = serverUnregisterHandler;
+  }
+
+  /**
+   * Tests if the connection of the given player is initial, returning {@code false} if the player did successfully
+   * connect to a backend service before. The last point in the login sequence where this check returns a valid result
+   * is in {@code ServerConnectedEvent}.
+   *
+   * @param player the player to test.
+   * @return true if the player was not connected to any service before, false otherwise.
+   * @throws NullPointerException  if the given player is null.
+   * @throws IllegalStateException if the test failed for some reason.
+   */
+  public static boolean isInitialConnect(@NonNull ProxiedPlayer player) {
+    try {
+      return PLAYER_INITIAL_CONNECT_TESTER.test(player);
+    } catch (Throwable throwable) {
+      throw new IllegalStateException("Unable to determine if player was connected before", throwable);
+    }
   }
 
   /**

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordPlayerManagementListener.java
@@ -18,8 +18,6 @@ package eu.cloudnetservice.modules.bridge.impl.platform.bungeecord;
 
 import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
 
-import dev.derklaro.reflexion.MethodAccessor;
-import dev.derklaro.reflexion.Reflexion;
 import eu.cloudnetservice.ext.bungee.BungeeComponentUtil;
 import eu.cloudnetservice.ext.component.ComponentFormats;
 import eu.cloudnetservice.modules.bridge.impl.platform.PlatformBridgeManagement;
@@ -50,15 +48,6 @@ import net.md_5.bungee.event.EventPriority;
 
 @Singleton
 public final class BungeeCordPlayerManagementListener implements Listener {
-
-  // https://minecraft.wiki/w/Java_Edition_1.20.2
-  // 1.20.2 changed the login process and therefore BungeeCord is somewhat breaking
-  private static final int PROTOCOL_1_20_2 = 764;
-  private static final MethodAccessor<?> PLAYER_DIMENSION_ACCESSOR = Reflexion.get(
-      "net.md_5.bungee.UserConnection",
-      null)
-    .findMethod("getDimension")
-    .orElseThrow();
 
   // placeholders when creating reason messages
   private static final Pattern KICK_REASON = Pattern.compile("%reason%", Pattern.LITERAL);
@@ -225,7 +214,7 @@ public final class BungeeCordPlayerManagementListener implements Listener {
       .cachedService(service -> service.name().equals(event.getServer().getInfo().getName()))
       .map(NetworkServiceInfo::fromServiceInfoSnapshot)
       .orElse(null);
-    if (this.initialConnect(player)) {
+    if (BungeeCordHelper.isInitialConnect(player)) {
       // the player logged in successfully if he is now connected to a service for the first time
       var playerInfo = this.management.createPlayerInformation(player);
       this.proxyPlatformHelper.sendChannelMessageLoginSuccess(playerInfo, joinedServiceInfo);
@@ -248,16 +237,6 @@ public final class BungeeCordPlayerManagementListener implements Listener {
     }
 
     this.management.removeFallbackProfile(player);
-  }
-
-  private boolean initialConnect(@NonNull ProxiedPlayer player) {
-    // since 1.20.2 we can not detect an initial connect using the nullability of the server field
-    // but the dimension of a player is null on an initial connect and non-null on a server switch
-    if (player.getPendingConnection().getVersion() >= PROTOCOL_1_20_2) {
-      return PLAYER_DIMENSION_ACCESSOR.invoke(player).getOrThrow() == null;
-    }
-
-    return player.getServer() == null;
   }
 
   private @NonNull BaseComponent buildKickReasonMessage(


### PR DESCRIPTION
### Motivation
The BungeeCordHelper class is currently using reflexion which can be improved by using method handles directly in combination with `invokeExact`. Also, there are currently no debugging information provided the class, making it hard to trace back issues.

### Modification
Refactor BungeeCordHelper to use method handles and add more debug logging when initializing the class.

### Result
Better performance and more debug information which code paths are actually used.
