### PR TITLE
chore: update to minestom 2025.07.26

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,7 +51,6 @@
         "cpw.mods:modlauncher", // can be removed when sponge updated to v9
         "org.spongepowered:spongeapi", // we want to leave the oldest version we support as the dependency
         "io.github.juliarn:npc-lib-**", // currently unstable and will be updated manually
-        "net.minestom:minestom-snapshots", // extremely weird version handling, updates are done manually
         "dev.waterdog.waterdogpe:waterdog", // we don't support v2 and v1 doesn't receive any updates anymore
         "org.incendo:cloud-processors-confirmation", // currently unstable and will be updated manually
       ],

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,7 +62,7 @@ sponge = "9.0.0"
 velocity = "3.4.0-SNAPSHOT"
 waterdogpe = "1.2.4"
 nukkitX = "1.0-SNAPSHOT"
-minestom = "4fe2993057"
+minestom = "2025.07.26-1.21.8"
 minestomExtensions = "1.2.0"
 spigot = "1.8.8-R0.1-SNAPSHOT"
 bungeecord = "1.21-R0.4-SNAPSHOT"
@@ -173,7 +173,7 @@ nukkitX = { group = "cn.nukkit", name = "nukkit", version.ref = "nukkitX" }
 spigot = { group = "org.spigotmc", name = "spigot-api", version.ref = "spigot" }
 sponge = { group = "org.spongepowered", name = "spongeapi", version.ref = "sponge" }
 bungeecord = { group = "net.md-5", name = "bungeecord-api", version.ref = "bungeecord" }
-minestom = { group = "net.minestom", name = "minestom-snapshots", version.ref = "minestom" }
+minestom = { group = "net.minestom", name = "minestom", version.ref = "minestom" }
 minestomExtensions = { group = "dev.hollowcube", name = "minestom-ce-extensions", version.ref = "minestomExtensions" }
 velocity = { group = "com.velocitypowered", name = "velocity-api", version.ref = "velocity" }
 waterdogpe = { group = "dev.waterdog.waterdogpe", name = "waterdog", version.ref = "waterdogpe" }

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeManagement.java
@@ -104,8 +104,10 @@ public final class MinestomBridgeManagement extends PlatformBridgeManagement<Pla
     eventHandler.call(pingEvent);
 
     // init the bridge properties
-    serviceHelper.motd().set(legacySection().serialize(pingEvent.getResponseData().getDescription()));
-    serviceHelper.maxPlayers().set(pingEvent.getResponseData().getMaxPlayer());
+    var status = pingEvent.getStatus();
+    var playerInfo = status.playerInfo();
+    serviceHelper.motd().set(legacySection().serialize(status.description()));
+    serviceHelper.maxPlayers().set(playerInfo == null ? 0 : playerInfo.maxPlayers());
   }
 
   @Override


### PR DESCRIPTION
### Motivation
Minestom released a new version for 1.21.8 support and we should update to it.

### Modification
Update to minestom `2025.07.26-1.21.8` and adopt their new release versioning scheme. Also re-enables automated updates by renovate for minestom, lets see how well this goes.

### Result
Updated minestom version for 1.21.8 support.
