### PR TITLE
chore: remove channel message relay timeout

### DIFF
--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/ChannelMessagePacketListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/ChannelMessagePacketListener.java
@@ -29,7 +29,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -122,7 +121,6 @@ public final class ChannelMessagePacketListener implements PacketListener {
     var isQuery = packet.uniqueId() != null;
     if (isQuery) {
       this.messenger.sendChannelMessageQueryAsync(message, comesFromWrapper)
-        .orTimeout(20, TimeUnit.SECONDS)
         .whenComplete((responses, _) -> {
           responses = Objects.requireNonNullElseGet(responses, ArrayList::new);
           if (localResponse != null) {


### PR DESCRIPTION
### Motivation
Currently, a channel message query must respond within 20 seconds of being redirected into the cluster. This is not ideal as some handlers might need more time.

### Modification
Remove forced 20 second channel message relay timeout. It is now up to the caller to apply a timeout to channel message queries, allowing for higher timeouts to be set.

### Result
No more forced 20 second response window for channel message queries.
