### PR TITLE
refactor: align sync channel message query timeout handling

### DIFF
--- a/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessage.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessage.java
@@ -169,8 +169,9 @@ public record ChannelMessage(
 
   /**
    * Sends this channel message as a query and blocks until all target components have responded to the query or the
-   * query timeout is exceeded.This method is a shortcut for
-   * {@link CloudMessenger#sendChannelMessageQuery(ChannelMessage)}.
+   * timeout of {@link CloudMessenger#SYNC_CHANNEL_MESSAGE_QUERY_TIMEOUT_MS} is exceeded. If more control over the
+   * timeout is required, an async method with a custom timeout applied must be used instead. This method is a shortcut
+   * for {@link CloudMessenger#sendChannelMessageQuery(ChannelMessage)}.
    * <p>
    * Note: it is not possible for CloudNet to detect when a channel message query response was consumed. Therefore, it
    * is crucial that the caller closes the responses to prevent memory leaks. Example:
@@ -195,9 +196,10 @@ public record ChannelMessage(
 
   /**
    * Sends this channel message as a query and blocks until one of the target component responded to this message or the
-   * query timeout is exceeded. This is in particular useful if there is only one target, or you are only expecting one
-   * of the target components to respond. This is a shortcut method for
-   * {@link CloudMessenger#sendSingleChannelMessageQuery(ChannelMessage)}.
+   * timeout of {@link CloudMessenger#SYNC_CHANNEL_MESSAGE_QUERY_TIMEOUT_MS} is exceeded. If more control over the
+   * timeout is required, an async method with a custom timeout applied must be used instead. This is in particular
+   * useful if there is only one target, or you are only expecting one of the target components to respond. This is a
+   * shortcut method for {@link CloudMessenger#sendSingleChannelMessageQuery(ChannelMessage)}.
    * <p>
    * Note: it is not possible for CloudNet to detect when a channel message query response was consumed. Therefore, it
    * is crucial that the caller closes the response to prevent memory leaks. Example:

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/provider/CloudMessenger.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/provider/CloudMessenger.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.driver.channel.ChannelMessage;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -47,6 +48,12 @@ import org.jetbrains.annotations.Nullable;
 public interface CloudMessenger {
 
   /**
+   * The timeout (in milliseconds) that is applied to all sync query messaging methods. If no response is received
+   * within the timespan, an exception is thrown by the method instead.
+   */
+  long SYNC_CHANNEL_MESSAGE_QUERY_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
+
+  /**
    * Sends the given channel message to all of its targets. This method will not wait for the target component to
    * respond (it doesn't even expect a response) but for the handling component to send the message.
    * <p>
@@ -59,8 +66,9 @@ public interface CloudMessenger {
   void sendChannelMessage(@NonNull ChannelMessage channelMessage);
 
   /**
-   * Sends the given channel message as a query and blocks until all target components have responded to the query or
-   * the query timeout is exceeded.
+   * Sends the given channel message as a query and blocks until all target components have responded or the timeout of
+   * {@link #SYNC_CHANNEL_MESSAGE_QUERY_TIMEOUT_MS} is exceeded. If more control over the timeout is required, an async
+   * method with a custom timeout applied must be used instead.
    * <p>
    * Note: it is not possible for CloudNet to detect when a channel message query response was consumed. Therefore, it
    * is crucial that the caller closes the responses to prevent memory leaks. Example:
@@ -86,8 +94,9 @@ public interface CloudMessenger {
 
   /**
    * Sends the given channel message as a query and blocks until one of the target component responded to the message or
-   * the query timeout is exceeded. This is in particular useful if there is only one target, or you are only expecting
-   * one of the target components to respond.
+   * the timeout of {@link #SYNC_CHANNEL_MESSAGE_QUERY_TIMEOUT_MS} is exceeded. If more control over the timeout is
+   * required, an async method with a custom timeout applied must be used instead. This is in particular useful if there
+   * is only one target, or you are only expecting one of the target components to respond.
    * <p>
    * Note: it is not possible for CloudNet to detect when a channel message query response was consumed. Therefore, it
    * is crucial that the caller closes the response to prevent memory leaks. Example:

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/channel/BaseCloudMessenger.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/channel/BaseCloudMessenger.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.driver.impl.channel;
+
+import com.google.common.collect.Iterables;
+import eu.cloudnetservice.driver.channel.ChannelMessage;
+import eu.cloudnetservice.driver.provider.CloudMessenger;
+import eu.cloudnetservice.utils.base.concurrent.TaskUtil;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Base implementation of a {@link CloudMessenger} which implements all sharable methods.
+ *
+ * @since 4.0
+ */
+public abstract class BaseCloudMessenger implements CloudMessenger {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull Collection<ChannelMessage> sendChannelMessageQuery(@NonNull ChannelMessage channelMessage) {
+    var done = new AtomicBoolean();
+    return this.sendChannelMessageQueryAsync(channelMessage)
+      .thenApply(responses -> {
+        // it might be that the timeout defined in the next step was already hit, therefore
+        // this method already returned to the caller before a response is received. in this
+        // case, we release the response we got immediately as it would leak otherwise
+        var didComplete = done.compareAndSet(false, true);
+        if (didComplete) {
+          return responses;
+        } else {
+          responses.forEach(ChannelMessage::close);
+          throw new IllegalStateException("received responses after downstream already completed");
+        }
+      })
+      // hack: get a new incomplete future here so that the previous thenApply step runs as well.
+      // the following orTimeout completes the future it's called on, so the releasing step would never run
+      .thenApply(Function.identity())
+      .orTimeout(SYNC_CHANNEL_MESSAGE_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+      .whenComplete((_, _) -> done.set(true))
+      .join();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @Nullable ChannelMessage sendSingleChannelMessageQuery(@NonNull ChannelMessage channelMessage) {
+    var done = new AtomicBoolean();
+    return this.sendSingleChannelMessageQueryAsync(channelMessage)
+      .thenApply(response -> {
+        // it might be that the timeout defined in the next step was already hit, therefore
+        // this method already returned to the caller before a response is received. in this
+        // case, we release the response we got immediately as it would leak otherwise
+        var didComplete = done.compareAndSet(false, true);
+        if (didComplete) {
+          return response;
+        } else {
+          response.close();
+          throw new IllegalStateException("received response after downstream already completed");
+        }
+      })
+      // hack: get a new incomplete future here so that the previous thenApply step runs as well.
+      // the following orTimeout completes the future it's called on, so the releasing step would never run
+      .thenApply(Function.identity())
+      .orTimeout(SYNC_CHANNEL_MESSAGE_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+      .whenComplete((_, _) -> done.set(true))
+      .join();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public @NonNull CompletableFuture<Void> sendChannelMessageAsync(@NonNull ChannelMessage channelMessage) {
+    return TaskUtil.runAsync(() -> this.sendChannelMessage(channelMessage));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @NonNull
+  @Override
+  public CompletableFuture<ChannelMessage> sendSingleChannelMessageQueryAsync(@NonNull ChannelMessage channelMessage) {
+    return this.sendChannelMessageQueryAsync(channelMessage).thenApply(responses -> {
+      var responseCount = responses.size();
+      return switch (responseCount) {
+        case 0 -> null;
+        case 1 -> Iterables.getOnlyElement(responses);
+        default -> {
+          // there were more than one response, so we need to close the
+          // other responses to prevent leaking their content
+          var responsesArray = responses.toArray(ChannelMessage[]::new);
+          for (var index = 1; index < responsesArray.length; index++) {
+            var response = responsesArray[index];
+            response.close();
+          }
+
+          yield responsesArray[0];
+        }
+      };
+    });
+  }
+}

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeCloudMessenger.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeCloudMessenger.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import dev.derklaro.aerogel.auto.annotation.Provides;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
 import eu.cloudnetservice.driver.channel.ChannelMessageTarget;
+import eu.cloudnetservice.driver.impl.channel.BaseCloudMessenger;
 import eu.cloudnetservice.driver.impl.network.standard.ChannelMessagePacket;
 import eu.cloudnetservice.driver.network.NetworkChannel;
 import eu.cloudnetservice.driver.provider.CloudMessenger;
@@ -29,7 +30,6 @@ import eu.cloudnetservice.node.impl.service.defaults.provider.EmptySpecificCloud
 import eu.cloudnetservice.node.service.CloudService;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import eu.cloudnetservice.utils.base.concurrent.CountingTask;
-import eu.cloudnetservice.utils.base.concurrent.TaskUtil;
 import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -41,12 +41,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.NonNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,11 +53,10 @@ import org.slf4j.LoggerFactory;
  */
 @Singleton
 @Provides(CloudMessenger.class)
-public class NodeCloudMessenger implements CloudMessenger {
+public class NodeCloudMessenger extends BaseCloudMessenger {
 
   protected static final Type CHANNEL_MESSAGE_LIST_TYPE =
     TypeFactory.parameterizedClass(List.class, ChannelMessage.class);
-  protected static final long DEFAULT_QUERY_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(20);
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NodeCloudMessenger.class);
 
@@ -88,101 +83,10 @@ public class NodeCloudMessenger implements CloudMessenger {
   /**
    * {@inheritDoc}
    */
-  @Override
-  public @NonNull Collection<ChannelMessage> sendChannelMessageQuery(@NonNull ChannelMessage channelMessage) {
-    var done = new AtomicBoolean();
-    return this.sendChannelMessageQueryAsync(channelMessage, true)
-      .thenApply(responses -> {
-        // it might be that the timeout defined in the next step was already hit, therefore
-        // this method already returned to the caller before a response is received. in this
-        // case, we release the response we got immediately as it would leak otherwise
-        var didComplete = done.compareAndSet(false, true);
-        if (didComplete) {
-          return responses;
-        } else {
-          responses.forEach(ChannelMessage::close);
-          throw new IllegalStateException("received responses after downstream already completed");
-        }
-      })
-      // hack: get a new incomplete future here so that the previous thenApply step runs as well.
-      // the following orTimeout completes the future it's called on, so the releasing step would never run
-      .thenApply(Function.identity())
-      .orTimeout(DEFAULT_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-      .whenComplete((_, _) -> done.set(true))
-      .join();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public @Nullable ChannelMessage sendSingleChannelMessageQuery(@NonNull ChannelMessage channelMessage) {
-    var done = new AtomicBoolean();
-    return this.sendSingleChannelMessageQueryAsync(channelMessage)
-      .thenApply(response -> {
-        // it might be that the timeout defined in the next step was already hit, therefore
-        // this method already returned to the caller before a response is received. in this
-        // case, we release the response we got immediately as it would leak otherwise
-        var didComplete = done.compareAndSet(false, true);
-        if (didComplete) {
-          return response;
-        } else {
-          response.close();
-          throw new IllegalStateException("received response after downstream already completed");
-        }
-      })
-      // hack: get a new incomplete future here so that the previous thenApply step runs as well.
-      // the following orTimeout completes the future it's called on, so the releasing step would never run
-      .thenApply(Function.identity())
-      .orTimeout(DEFAULT_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-      .whenComplete((_, _) -> done.set(true))
-      .join();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public @NonNull CompletableFuture<Void> sendChannelMessageAsync(@NonNull ChannelMessage channelMessage) {
-    return TaskUtil.supplyAsync(() -> {
-      this.sendChannelMessage(channelMessage);
-      return null;
-    });
-  }
-
-  /**
-   * {@inheritDoc}
-   */
   @NonNull
   @Override
   public CompletableFuture<Collection<ChannelMessage>> sendChannelMessageQueryAsync(@NonNull ChannelMessage message) {
     return this.sendChannelMessageQueryAsync(message, true);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @NonNull
-  @Override
-  public CompletableFuture<ChannelMessage> sendSingleChannelMessageQueryAsync(@NonNull ChannelMessage channelMessage) {
-    return this.sendChannelMessageQueryAsync(channelMessage).thenApply(responses -> {
-      var responseCount = responses.size();
-      return switch (responseCount) {
-        case 0 -> null;
-        case 1 -> Iterables.getOnlyElement(responses);
-        default -> {
-          // there were more than one response, so we need to close the
-          // other responses to prevent leaking their content
-          var responsesArray = responses.toArray(ChannelMessage[]::new);
-          for (var index = 1; index < responsesArray.length; index++) {
-            var response = responsesArray[index];
-            response.close();
-          }
-
-          yield responsesArray[0];
-        }
-      };
-    });
   }
 
   /**

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/provider/WrapperCloudMessenger.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/provider/WrapperCloudMessenger.java
@@ -16,13 +16,12 @@
 
 package eu.cloudnetservice.wrapper.impl.provider;
 
-import com.google.common.collect.Iterables;
 import dev.derklaro.aerogel.auto.annotation.Provides;
 import eu.cloudnetservice.driver.channel.ChannelMessage;
+import eu.cloudnetservice.driver.impl.channel.BaseCloudMessenger;
 import eu.cloudnetservice.driver.impl.network.standard.ChannelMessagePacket;
 import eu.cloudnetservice.driver.network.NetworkClient;
 import eu.cloudnetservice.driver.provider.CloudMessenger;
-import eu.cloudnetservice.utils.base.concurrent.TaskUtil;
 import io.leangen.geantyref.TypeFactory;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -32,11 +31,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import lombok.NonNull;
-import org.jetbrains.annotations.Nullable;
 
 @Singleton
 @Provides(CloudMessenger.class)
-public class WrapperMessenger implements CloudMessenger {
+public class WrapperCloudMessenger extends BaseCloudMessenger {
 
   private static final Type CHANNEL_MESSAGE_LIST_TYPE =
     TypeFactory.parameterizedClass(List.class, ChannelMessage.class);
@@ -44,7 +42,7 @@ public class WrapperMessenger implements CloudMessenger {
   private final NetworkClient networkClient;
 
   @Inject
-  public WrapperMessenger(@NonNull NetworkClient networkClient) {
+  public WrapperCloudMessenger(@NonNull NetworkClient networkClient) {
     this.networkClient = networkClient;
   }
 
@@ -64,30 +62,6 @@ public class WrapperMessenger implements CloudMessenger {
    * {@inheritDoc}
    */
   @Override
-  public @NonNull Collection<ChannelMessage> sendChannelMessageQuery(@NonNull ChannelMessage channelMessage) {
-    return this.sendChannelMessageQueryAsync(channelMessage).join();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public @Nullable ChannelMessage sendSingleChannelMessageQuery(@NonNull ChannelMessage channelMessage) {
-    return this.sendSingleChannelMessageQueryAsync(channelMessage).join();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public @NonNull CompletableFuture<Void> sendChannelMessageAsync(@NonNull ChannelMessage channelMessage) {
-    return TaskUtil.runAsync(() -> this.sendChannelMessage(channelMessage));
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public @NonNull CompletableFuture<Collection<ChannelMessage>> sendChannelMessageQueryAsync(
     @NonNull ChannelMessage message
   ) {
@@ -96,37 +70,11 @@ public class WrapperMessenger implements CloudMessenger {
       .thenApply(response -> {
         var packetContent = response.content();
         try {
-          return Objects.requireNonNullElse(packetContent.readObject(CHANNEL_MESSAGE_LIST_TYPE), List.of());
+          Collection<ChannelMessage> responses = packetContent.readObject(CHANNEL_MESSAGE_LIST_TYPE);
+          return Objects.requireNonNullElse(responses, List.of());
         } finally {
           packetContent.forceRelease();
         }
       });
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public @NonNull CompletableFuture<ChannelMessage> sendSingleChannelMessageQueryAsync(
-    @NonNull ChannelMessage message
-  ) {
-    return this.sendChannelMessageQueryAsync(message).thenApply(responses -> {
-      var responseCount = responses.size();
-      return switch (responseCount) {
-        case 0 -> null;
-        case 1 -> Iterables.getOnlyElement(responses);
-        default -> {
-          // there were more than one response, so we need to close the
-          // other responses to prevent leaking their content
-          var responsesArray = responses.toArray(ChannelMessage[]::new);
-          for (var index = 1; index < responsesArray.length; index++) {
-            var response = responsesArray[index];
-            response.close();
-          }
-
-          yield responsesArray[0];
-        }
-      };
-    });
   }
 }


### PR DESCRIPTION
### Motivation
Currently, the node applies an undocumented timeout to sync channel message queries. Meanwhile the wrapper doesn't do this, leading to possible very long blocking times when calling sync methods.

### Modification
Move some shareable code parts into a `BaseCloudMessenger` implementation. This implementation also has the same timeout handling as the node, which is now transparently documented and applied to the wrapper as well. The timeout of these methods is defined by `CloudMessenger.SYNC_CHANNEL_MESSAGE_QUERY_TIMEOUT_MS` (currently 30 seconds).

### Result
The node no longer applies undocumented timeouts to channel message queries. The wrapper now applies the timeouts as documented. The node and wrapper implementation is aligned in their handling as the base implementation is now shared.
