### PR TITLE
fix: remove invalid service annotations

### DIFF
--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/CloudNetNPCModule.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/CloudNetNPCModule.java
@@ -24,7 +24,6 @@ import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.driver.module.ModuleLifeCycle;
 import eu.cloudnetservice.driver.module.ModuleTask;
 import eu.cloudnetservice.driver.module.driver.DriverModule;
-import eu.cloudnetservice.driver.registry.Service;
 import eu.cloudnetservice.modules.npc.NPC;
 import eu.cloudnetservice.modules.npc.NPCManagement;
 import eu.cloudnetservice.modules.npc.configuration.InventoryConfiguration;
@@ -202,7 +201,7 @@ public class CloudNetNPCModule extends DriverModule {
   }
 
   @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
-  public void handleReload(@Nullable @Service NPCManagement management) {
+  public void handleReload(@Nullable NPCManagement management) {
     if (management != null) {
       management.npcConfiguration(this.loadConfig());
     }

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/CloudNetSignsModule.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/CloudNetSignsModule.java
@@ -24,7 +24,6 @@ import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.driver.module.ModuleLifeCycle;
 import eu.cloudnetservice.driver.module.ModuleTask;
 import eu.cloudnetservice.driver.module.driver.DriverModule;
-import eu.cloudnetservice.driver.registry.Service;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.driver.service.ServiceEnvironmentType;
 import eu.cloudnetservice.modules.bridge.WorldPosition;
@@ -103,7 +102,7 @@ public class CloudNetSignsModule extends DriverModule {
   @ModuleTask(order = 20)
   public void handleDatabaseConvert(
     @NonNull DatabaseProvider databaseProvider,
-    @NonNull @Service SignManagement signManagement
+    @NonNull SignManagement signManagement
   ) {
     this.convertDatabaseIfNecessary(databaseProvider, signManagement);
   }
@@ -114,7 +113,7 @@ public class CloudNetSignsModule extends DriverModule {
   }
 
   @ModuleTask(lifecycle = ModuleLifeCycle.RELOADING)
-  public void handleReload(@Nullable @Service SignManagement management) {
+  public void handleReload(@Nullable SignManagement management) {
     if (management != null) {
       management.signsConfiguration(NodeSignsConfigurationHelper.read(this.configPath()));
     }


### PR DESCRIPTION
### Motivation
There were some invalid service annotations left in the source, leading to functionality not working.

### Modification
Remove these invalid service annotations.

### Result
Everything works as expected again.
