### PR TITLE
fix: respect array offsets in MemorySegmentBuffer

### DIFF
--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentBuffer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentBuffer.java
@@ -300,7 +300,8 @@ final class MemorySegmentBuffer
 
     if (this.hasReadableArray()) {
       var srcArray = this.readableArray();
-      System.arraycopy(srcArray, srcPos, dest, destPos, length);
+      var srcArrayOff = Math.toIntExact(this.readSegment.address());
+      System.arraycopy(srcArray, srcArrayOff + srcPos, dest, destPos, length);
     } else {
       var destSegment = MemorySegment.ofArray(dest);
       MemorySegment.copy(this.readSegment, srcPos, destSegment, destPos, length);
@@ -320,9 +321,10 @@ final class MemorySegmentBuffer
 
     if (dest.hasArray() && this.hasReadableArray()) {
       var srcArray = this.readableArray();
+      var srcArrayOff = Math.toIntExact(this.readSegment.address());
       var destArray = dest.array();
-      var destFrom = dest.arrayOffset() + destPos;
-      System.arraycopy(srcArray, srcPos, destArray, destFrom, length);
+      var destArrayOff = dest.arrayOffset();
+      System.arraycopy(srcArray, srcArrayOff + srcPos, destArray, destArrayOff + destPos, length);
     } else {
       var cleanedBuffer = dest.duplicate().clear();
       var destSegment = MemorySegment.ofBuffer(cleanedBuffer);

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentBufferTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentBufferTest.java
@@ -767,6 +767,29 @@ public class MemorySegmentBufferTest {
 
   @ParameterizedTest
   @MethodSource("bufferTypes")
+  void testCopyWithInternalOffset(Buffer buffer) {
+    buffer.implicitCapacityLimit(18); // only needing 18 bytes at max
+
+    buffer.writeShort((short) 8943);
+    buffer.writeLong(987654321123456789L);
+    buffer.writeLong(-2784823473287483223L);
+    Assertions.assertEquals(0, buffer.readerOffset());
+    Assertions.assertEquals(18, buffer.writerOffset());
+
+    buffer.split(Short.BYTES); // move MemSeg offset to 2
+    Assertions.assertEquals(0, buffer.readerOffset());
+
+    var longTarget = new byte[8];
+    buffer.copyInto(8, longTarget, 0, 8);
+    Assertions.assertEquals(-2784823473287483223L, BYTE_ARRAY_AS_LONG.get(longTarget, 0));
+
+    var longTargetBB = ByteBuffer.allocate(8);
+    buffer.copyInto(8, longTargetBB, 0, 8);
+    Assertions.assertEquals(-2784823473287483223L, longTargetBB.getLong());
+  }
+
+  @ParameterizedTest
+  @MethodSource("bufferTypes")
   void testTransferToWritableByteChannel(Buffer buffer) throws IOException {
     buffer.implicitCapacityLimit(18); // only needing 18 bytes at max
 


### PR DESCRIPTION
### Motivation
Currently the backing array offset of a MemorySegment is not respected when reading bytes from a MemorySegmentBuffer. This results in random bytes being read instead of the bytes actually associated with the buffer. This issue was previously not detected in tests as the offset only becomes >0 when the backing MemorySegment is sliced, pooled or based off another java.nio.Buffer.

### Modification
Respect the offset into the array wrapped in a MemorySegment to read the bytes associated with the current buffer. Also adds a tests that slices the wrapped MemorySegment making the offset into the array >0.

### Result
No more read of bytes from the backing MemorySegment array outside of the current buffer.

##### Other context
Fixes CloudNetService/module-rest#123
