### PR TITLE
fix: add missing service annotation to cluster node parser method

### DIFF
--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ClusterCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ClusterCommand.java
@@ -138,7 +138,10 @@ public final class ClusterCommand {
   }
 
   @Parser(suggestions = "networkClusterNode")
-  public @NonNull NetworkClusterNode defaultNetworkClusterNodeParser(@NonNull CommandInput input, @NonNull I18n i18n) {
+  public @NonNull NetworkClusterNode defaultNetworkClusterNodeParser(
+    @NonNull CommandInput input,
+    @NonNull @Service I18n i18n
+  ) {
     var nodeId = input.readString();
     var clusterNode = this.clusterNodeProvider.node(nodeId);
     if (clusterNode == null) {


### PR DESCRIPTION
### Motivation
The service annotation on the I18n parameter of `ClusterCommand#defaultNetworkClusterNodeParser` was missing.

### Modification
Add the missing service annotation.

### Result
The method parameter can now be injected and using certain `cluster` commands no longer results in an exception.

##### Other context
Fixes #1742
