### PR TITLE
add foojay resolver convention to build-extensions

### DIFF
--- a/build-extensions/build.gradle.kts
+++ b/build-extensions/build.gradle.kts
@@ -19,7 +19,6 @@ plugins {
   id("java-gradle-plugin")
 }
 
-// fabric requires jvm 21, so we can do so too
 kotlin.jvmToolchain {
   vendor = JvmVendorSpec.AZUL
   languageVersion = JavaLanguageVersion.of(21)

--- a/build-extensions/build.gradle.kts
+++ b/build-extensions/build.gradle.kts
@@ -20,7 +20,10 @@ plugins {
 }
 
 // fabric requires jvm 21, so we can do so too
-kotlin.jvmToolchain(21)
+kotlin.jvmToolchain {
+  vendor = JvmVendorSpec.AZUL
+  languageVersion = JavaLanguageVersion.of(21)
+}
 
 dependencies {
   implementation(libs.gson)

--- a/build-extensions/settings.gradle.kts
+++ b/build-extensions/settings.gradle.kts
@@ -32,4 +32,8 @@ dependencyResolutionManagement {
   }
 }
 
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "build-extensions"


### PR DESCRIPTION
### Motivation
The build configuration currently has one deprecation that should be resolved:
`Using toolchain 'Eclipse Temurin JDK 21 (21.0.8+9-LTS)' installed via auto-provisioning without toolchain repositories. This behavior has been deprecated. This will fail with an error in Gradle 10. Builds may fail when this toolchain is not available in other environments. Add toolchain repositories to this build.`

### Modification
Fix deprecation warning about auto-provisioned toolchain without a toolchain repository.

### Result
No more deprecation warning and potential gradle 10 update issues.

