### PR TITLE
chore: add 1.21.9 downloads

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ limboloohp = "0.7.9-ALPHA"
 # platform extensions
 adventure = "4.24.0"
 modlauncher = "8.1.3"
-npcLib = "3.0.0-beta.14"
+npcLib = "3.0.0-beta.15"
 packetEvents = "2.9.5"
 placeholderApi = "2.11.6"
 adventure-serializer-bungee = "4.4.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ limboloohp = "0.7.9-ALPHA"
 # platform extensions
 adventure = "4.24.0"
 modlauncher = "8.1.3"
-npcLib = "3.0.0-beta13"
+npcLib = "3.0.0-beta.14"
 packetEvents = "2.9.5"
 placeholderApi = "2.11.6"
 adventure-serializer-bungee = "4.4.1"

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCPoolOptions.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCPoolOptions.java
@@ -18,7 +18,7 @@ package eu.cloudnetservice.modules.npc.configuration;
 
 import lombok.NonNull;
 
-public record NPCPoolOptions(int spawnDistance, int actionDistance, int tabListRemoveTicks) {
+public record NPCPoolOptions(int spawnDistance, int actionDistance) {
 
   public static @NonNull Builder builder() {
     return new Builder();
@@ -27,15 +27,13 @@ public record NPCPoolOptions(int spawnDistance, int actionDistance, int tabListR
   public static @NonNull Builder builder(@NonNull NPCPoolOptions options) {
     return builder()
       .spawnDistance(options.spawnDistance())
-      .actionDistance(options.actionDistance())
-      .tabListRemoveTicks(options.tabListRemoveTicks());
+      .actionDistance(options.actionDistance());
   }
 
   public static final class Builder {
 
     private int spawnDistance = 50;
     private int actionDistance = 20;
-    private int tabListRemoveTicks = 30;
 
     public @NonNull Builder spawnDistance(int spawnDistance) {
       this.spawnDistance = spawnDistance;
@@ -47,13 +45,8 @@ public record NPCPoolOptions(int spawnDistance, int actionDistance, int tabListR
       return this;
     }
 
-    public @NonNull Builder tabListRemoveTicks(int tabListRemoveTicks) {
-      this.tabListRemoveTicks = tabListRemoveTicks;
-      return this;
-    }
-
     public @NonNull NPCPoolOptions build() {
-      return new NPCPoolOptions(this.spawnDistance, this.actionDistance, this.tabListRemoveTicks);
+      return new NPCPoolOptions(this.spawnDistance, this.actionDistance);
     }
   }
 }

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/CloudNetNPCModule.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/CloudNetNPCModule.java
@@ -29,7 +29,6 @@ import eu.cloudnetservice.modules.npc.NPCManagement;
 import eu.cloudnetservice.modules.npc.configuration.InventoryConfiguration;
 import eu.cloudnetservice.modules.npc.configuration.ItemLayout;
 import eu.cloudnetservice.modules.npc.configuration.LabyModEmoteConfiguration;
-import eu.cloudnetservice.modules.npc.configuration.NPCPoolOptions;
 import eu.cloudnetservice.modules.npc.impl._deprecated.CloudNPC;
 import eu.cloudnetservice.modules.npc.impl._deprecated.NPCConstants;
 import eu.cloudnetservice.modules.npc.impl._deprecated.configuration.NPCConfiguration;
@@ -86,11 +85,6 @@ public class CloudNetNPCModule extends DriverModule {
                 .map(mapEntry -> new Tuple2<>(mapEntry.getKey(), this.convertItemLayout(mapEntry.getValue())))
                 .collect(Collectors.toMap(Tuple2::_1, Tuple2::_2)))
               .inventorySize(entry.inventorySize())
-              .build())
-            .npcPoolOptions(NPCPoolOptions.builder()
-              .tabListRemoveTicks(entry.npcTabListRemoveTicks() > Integer.MAX_VALUE
-                ? Integer.MAX_VALUE
-                : (int) entry.npcTabListRemoveTicks())
               .build())
             .build())
           .collect(Collectors.toSet());

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/NodeNPCManagement.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/NodeNPCManagement.java
@@ -53,7 +53,7 @@ public final class NodeNPCManagement extends AbstractNPCManagement {
   private static final Path PROTOCOL_LIB_CACHE_PATH = FileUtil.TEMP_DIR.resolve("caches/ProtocolLib.jar");
   private static final String PROTOCOL_LIB_DOWNLOAD_URL = System.getProperty(
     "cloudnet.protocollib.download",
-    "https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/build/libs/ProtocolLib.jar");
+    "https://github.com/dmulloy2/ProtocolLib/releases/download/dev-build/ProtocolLib.jar");
 
   private final Database database;
   private final Path configurationPath;

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -108,8 +108,7 @@ public class BukkitPlatformNPCManagement extends
         .debug(true)
         .actionController(builder -> builder
           .flag(NpcActionController.SPAWN_DISTANCE, entry.npcPoolOptions().spawnDistance())
-          .flag(NpcActionController.IMITATE_DISTANCE, entry.npcPoolOptions().actionDistance())
-          .flag(NpcActionController.TAB_REMOVAL_TICKS, entry.npcPoolOptions().tabListRemoveTicks()))
+          .flag(NpcActionController.IMITATE_DISTANCE, entry.npcPoolOptions().actionDistance()))
         .worldAccessor(BukkitWorldAccessor.nameBasedAccessor())
         .packetFactory(this.resolvePacketAdapter())
         .build();

--- a/node/impl/src/main/resources/files/versions.json
+++ b/node/impl/src/main/resources/files/versions.json
@@ -488,7 +488,7 @@
       "versions": [
         {
           "name": "1.21.9",
-          "url": "https://files.mcjars.app/spigot/1.21.9/4537/server.jar"
+          "url": "https://files.mcjars.app/spigot/1.21.9/4539/server.jar"
         },
         {
           "name": "1.21.8",
@@ -803,7 +803,7 @@
       "versions": [
         {
           "name": "1.21.9",
-          "url": "https://files.mcjars.app/loohp-limbo/1.21.9/60/server.jar"
+          "url": "https://files.mcjars.app/loohp-limbo/1.21.9/61/server.jar"
         },
         {
           "name": "1.21.8",

--- a/node/impl/src/main/resources/files/versions.json
+++ b/node/impl/src/main/resources/files/versions.json
@@ -488,84 +488,84 @@
       "versions": [
         {
           "name": "1.21.9",
-          "url": "https://s3.mcjars.app/spigot/1.21.9/4537/server.jar"
+          "url": "https://files.mcjars.app/spigot/1.21.9/4537/server.jar"
         },
         {
           "name": "1.21.8",
-          "url": "https://s3.mcjars.app/spigot/1.21.8/4534/server.jar"
+          "url": "https://files.mcjars.app/spigot/1.21.8/4534/server.jar"
         },
         {
           "name": "1.21.6",
-          "url": "https://s3.mcjars.app/spigot/1.21.6/4518/server.jar"
+          "url": "https://files.mcjars.app/spigot/1.21.6/4518/server.jar"
         },
         {
           "name": "1.21.5",
-          "url": "https://s3.mcjars.app/spigot/1.21.5/4504/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.21.5/4504/server.jar",
           "deprecated": true
         },
         {
           "name": "1.20.6",
-          "url": "https://s3.mcjars.app/spigot/1.20.6/4135/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.20.6/4135/server.jar",
           "deprecated": true
         },
         {
           "name": "1.19.4",
-          "url": "https://s3.mcjars.app/spigot/1.19.4/3763/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.19.4/3763/server.jar",
           "deprecated": true
         },
         {
           "name": "1.18.2",
-          "url": "https://s3.mcjars.app/spigot/1.18.2/3498/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.18.2/3498/server.jar",
           "deprecated": true
         },
         {
           "name": "1.17.1",
-          "url": "https://s3.mcjars.app/spigot/1.17.1/3284/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.17.1/3284/server.jar",
           "deprecated": true
         },
         {
           "name": "1.16.5",
-          "url": "https://s3.mcjars.app/spigot/1.16.5/3096/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.16.5/3096/server.jar",
           "deprecated": true
         },
         {
           "name": "1.15.2",
-          "url": "https://s3.mcjars.app/spigot/1.15.2/2703/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.15.2/2703/server.jar",
           "deprecated": true
         },
         {
           "name": "1.14.4",
-          "url": "https://s3.mcjars.app/spigot/1.14.4/2502/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.14.4/2502/server.jar",
           "deprecated": true
         },
         {
           "name": "1.13.2",
-          "url": "https://s3.mcjars.app/spigot/1.13.2/2148/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.13.2/2148/server.jar",
           "deprecated": true
         },
         {
           "name": "1.12.2",
-          "url": "https://s3.mcjars.app/spigot/1.12.2/1573/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.12.2/1573/server.jar",
           "deprecated": true
         },
         {
           "name": "1.11.2",
-          "url": "https://s3.mcjars.app/spigot/1.11.2/1251/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.11.2/1251/server.jar",
           "deprecated": true
         },
         {
           "name": "1.10.2",
-          "url": "https://s3.mcjars.app/spigot/1.10.2/986/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.10.2/986/server.jar",
           "deprecated": true
         },
         {
           "name": "1.9.4",
-          "url": "https://s3.mcjars.app/spigot/1.9.4/849/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.9.4/849/server.jar",
           "deprecated": true
         },
         {
           "name": "1.8.8",
-          "url": "https://s3.mcjars.app/spigot/1.8.8/582/server.jar",
+          "url": "https://files.mcjars.app/spigot/1.8.8/582/server.jar",
           "deprecated": true
         }
       ]
@@ -803,35 +803,35 @@
       "versions": [
         {
           "name": "1.21.9",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.21.9/60/server.jar"
+          "url": "https://files.mcjars.app/loohp-limbo/1.21.9/60/server.jar"
         },
         {
           "name": "1.21.8",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.21.8/59/server.jar"
+          "url": "https://files.mcjars.app/loohp-limbo/1.21.8/59/server.jar"
         },
         {
           "name": "1.21.6",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.21.6/54/server.jar"
+          "url": "https://files.mcjars.app/loohp-limbo/1.21.6/54/server.jar"
         },
         {
           "name": "1.21.5",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.21.5/52/server.jar"
+          "url": "https://files.mcjars.app/loohp-limbo/1.21.5/52/server.jar"
         },
         {
           "name": "1.21.4",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.21.4/51/server.jar"
+          "url": "https://files.mcjars.app/loohp-limbo/1.21.4/51/server.jar"
         },
         {
           "name": "1.21.3",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.21.3/47/server.jar"
+          "url": "https://files.mcjars.app/loohp-limbo/1.21.3/47/server.jar"
         },
         {
           "name": "1.21.1",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.21.1/46/server.jar"
+          "url": "https://files.mcjars.app/loohp-limbo/1.21.1/46/server.jar"
         },
         {
           "name": "1.20.6",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.20.6/43/server.jar"
+          "url": "https://files.mcjars.app/loohp-limbo/1.20.6/43/server.jar"
         }
       ]
     }

--- a/node/impl/src/main/resources/files/versions.json
+++ b/node/impl/src/main/resources/files/versions.json
@@ -89,8 +89,23 @@
       "website": "https://papermc.io",
       "versions": [
         {
-          "name": "1.21.8",
+          "name": "1.21.9",
           "cacheFiles": false,
+          "properties": {
+            "copy": {
+              "cache/.*": "/",
+              "versions/.*": "/",
+              "paper\\.jar": "paper.jar"
+            },
+            "jvmOptions": [
+              "-Dpaperclip.patchonly=true"
+            ],
+            "fetchOverPaperApi": true,
+            "versionGroup": "1.21.9"
+          }
+        },
+        {
+          "name": "1.21.8",
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -346,9 +361,23 @@
       ],
       "versions": [
         {
+          "name": "1.21.9",
+          "url": "https://api.purpurmc.org/v2/purpur/1.21.9/latest/download",
+          "cacheFiles": false,
+          "properties": {
+            "copy": {
+              "cache/.*": "/",
+              "versions/.*": "/",
+              "purpur\\.jar": "paper.jar"
+            },
+            "jvmOptions": [
+              "-Dpaperclip.patchonly=true"
+            ]
+          }
+        },
+        {
           "name": "1.21.8",
           "url": "https://api.purpurmc.org/v2/purpur/1.21.8/latest/download",
-          "cacheFiles": false,
           "properties": {
             "copy": {
               "cache/.*": "/",
@@ -458,8 +487,12 @@
       ],
       "versions": [
         {
+          "name": "1.21.9",
+          "url": "https://s3.mcjars.app/spigot/1.21.9/4536/server.jar"
+        },
+        {
           "name": "1.21.8",
-          "url": "https://s3.mcjars.app/spigot/1.21.8/4524/server.jar"
+          "url": "https://s3.mcjars.app/spigot/1.21.8/4534/server.jar"
         },
         {
           "name": "1.21.6",
@@ -548,6 +581,26 @@
       ],
       "website": "https://fabricmc.net",
       "versions": [
+        {
+          "name": "1.21.9",
+          "cacheFiles": false,
+          "properties": {
+            "copy": {
+              "fabric-server-launch\\.jar": "fabric.jar",
+              "libraries/.*": "/",
+              "versions/.*": "/",
+              "server\\.jar": "server.jar"
+            },
+            "parameters": [
+              "server",
+              "-mcversion",
+              "%version%",
+              "-downloadMinecraft"
+            ],
+            "fetchOverFabricApi": true
+          },
+          "minJavaVersion": 21
+        },
         {
           "name": "1.21.8",
           "cacheFiles": false,
@@ -750,7 +803,7 @@
       "versions": [
         {
           "name": "1.21.8",
-          "url": "https://s3.mcjars.app/loohp-limbo/1.21.8/58/server.jar"
+          "url": "https://s3.mcjars.app/loohp-limbo/1.21.8/59/server.jar"
         },
         {
           "name": "1.21.6",

--- a/node/impl/src/main/resources/files/versions.json
+++ b/node/impl/src/main/resources/files/versions.json
@@ -488,7 +488,7 @@
       "versions": [
         {
           "name": "1.21.9",
-          "url": "https://s3.mcjars.app/spigot/1.21.9/4536/server.jar"
+          "url": "https://s3.mcjars.app/spigot/1.21.9/4537/server.jar"
         },
         {
           "name": "1.21.8",
@@ -801,6 +801,10 @@
         "DOWNLOAD"
       ],
       "versions": [
+        {
+          "name": "1.21.9",
+          "url": "https://s3.mcjars.app/loohp-limbo/1.21.9/60/server.jar"
+        },
         {
           "name": "1.21.8",
           "url": "https://s3.mcjars.app/loohp-limbo/1.21.8/59/server.jar"


### PR DESCRIPTION
### Motivation
Minecraft 1.21.9 has been released and we should add the ability to install the version.

### Modification
Add downloads for 1.21.9 (no code changes required, fabric-bridge is already updated).

### Result
Minecraft 1.21.9 versions can be installed using the template installer.