### PR TITLE
[ci skip] chore: schedule renovate s3-sdk patch updates only on sundays

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,9 +29,7 @@
     },
     {
       "matchPackageNames": [
-        "net.kyori:adventure-api",
-        "net.kyori:adventure-text-serializer-gson",
-        "net.kyori:adventure-text-serializer-legacy",
+        "net.kyori:adventure-**",
       ],
       "groupName": "adventure monorepo",
     },
@@ -41,6 +39,18 @@
         "com.google.guava:guava",
       ],
       "versioning": "regex:^(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?(-(?<compatibility>.*))?$",
+    },
+    {
+      "description": "Schedule aws-sdk patch updates on sunday night",
+      "matchUpdateTypes": [
+        "patch",
+      ],
+      "matchPackageNames": [
+        "software.amazon.awssdk:s3",
+      ],
+      "schedule": [
+        "* 20-23 * * 0",
+      ],
     },
     {
       "description": "Dependencies whose updates shouldn't be done automatically",


### PR DESCRIPTION
### Motivation
The s3-sdk releases patch updates very frequently, which leads to a lot of renovate prs for it. We should limit the weekday when updates are scheduled to prevent being "spammed" with update prs.

### Modification
Limit checking for s3-sdk updates to Sundays between 8 p.m. and 11 p.m.

### Result
Less frequent s3-sdk patch update prs.
