### PR TITLE
build: cache java indexes locally, fix javadoc violations

### DIFF
--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetPlugin.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetPlugin.kt
@@ -16,9 +16,15 @@
 
 package eu.cloudnetservice.cloudnet.gradle.plugins
 
+import eu.cloudnetservice.cloudnet.gradle.tasks.FetchJavadocIndexes
+import eu.cloudnetservice.cloudnet.gradle.util.EXTERNAL_JAVADOC_LINKS
 import eu.cloudnetservice.cloudnet.gradle.util.Versions
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
 
 class CloudNetPlugin : Plugin<Project> {
   override fun apply(project: Project) {
@@ -26,6 +32,26 @@ class CloudNetPlugin : Plugin<Project> {
       this.version = Versions.CLOUDNET
       this.group = "eu.cloudnetservice.cloudnet"
       this.description = "A modern application that can dynamically and easily deliver Minecraft oriented software"
+
+      val jdCacheDir = layout.buildDirectory.dir("javadoc-cache")
+      val fetchJavadocIndexes = tasks.register("fetchJavadocIndexes", FetchJavadocIndexes::class) {
+        cacheDir.set(jdCacheDir)
+        externalDocs.set(EXTERNAL_JAVADOC_LINKS)
+      }
+
+      subprojects {
+        plugins.withId("java") {
+          tasks.withType(Javadoc::class).configureEach {
+            dependsOn(fetchJavadocIndexes)
+            val options = options as? StandardJavadocDocletOptions ?: return@configureEach
+            options.links = listOf()
+            EXTERNAL_JAVADOC_LINKS.forEach { (baseUrl, dir) ->
+              val cacheDir = jdCacheDir.get().asFile.resolve(dir)
+              options.linksOffline(baseUrl, cacheDir.absolutePath)
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/FetchJavadocIndexes.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/FetchJavadocIndexes.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019-2025 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.cloudnet.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.net.URI
+import java.nio.file.Files
+
+private const val COMPONENT_ELEMENT_LIST = "element-list"
+private const val COMPONENT_PACKAGE_LIST = "package-list"
+
+@CacheableTask
+abstract class FetchJavadocIndexes : DefaultTask() {
+  @get:Input
+  abstract val externalDocs: MapProperty<String, String> // baseUrl -> folder
+
+  @get:OutputDirectory
+  abstract val cacheDir: DirectoryProperty
+
+  @TaskAction
+  fun run() {
+    val cache = cacheDir.get().asFile.also { it.mkdirs() }
+    externalDocs.get().forEach { (baseUrl, folder) ->
+      val target = cache.resolve(folder).also { it.mkdirs() }
+      if (!tryFetch(target, baseUrl, COMPONENT_ELEMENT_LIST)) {
+        if (!tryFetch(target, baseUrl, COMPONENT_PACKAGE_LIST)) {
+          throw IllegalStateException("Unable to download javadoc indexes from $baseUrl")
+        }
+      }
+    }
+  }
+
+  private fun tryFetch(target: File, baseUrl: String, component: String): Boolean {
+    // skip download if the target directory already exists
+    val dest = target.resolve(component)
+    if (dest.exists()) {
+      return true
+    }
+
+    return try {
+      URI("$baseUrl$component").toURL().openStream().use { ins ->
+        Files.newOutputStream(dest.toPath()).use { out -> ins.copyTo(out) }
+      }
+      dest.length() > 0
+    } catch (_: Exception) {
+      dest.delete()
+      return false
+    }
+  }
+}

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
@@ -16,6 +16,7 @@
 
 package eu.cloudnetservice.cloudnet.gradle.util
 
+import eu.cloudnetservice.cloudnet.gradle.plugins.JAVA_CORE_COMPATIBILITY
 import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.plugins.JavaPluginExtension
@@ -147,8 +148,10 @@ fun applyJavadocOptions(options: StandardJavadocDocletOptions) {
   options.links(
     "https://projectlombok.org/api/",
     "https://jd.advntr.dev/api/latest/",
-    "https://javadoc.io/doc/com.konghq/unirest-java/latest/",
+    "https://javadoc.io/doc/io.vavr/vavr/0.10.7/",
+    "https://javadoc.io/doc/org.incendo/cloud-core/latest/",
     "https://javadoc.io/doc/org.jetbrains/annotations/latest/",
-    "https://javadoc.io/doc/org.incendo/cloud-core/latest/"
+    "https://javadoc.io/doc/dev.derklaro.aerogel/aerogel/latest/",
+    "https://docs.oracle.com/en/java/javase/${JAVA_CORE_COMPATIBILITY.asInt()}/docs/api/"
   )
 }

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
@@ -31,6 +31,17 @@ import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
+// map of link (must end with trailing slash) -> cache directory name; links are applied in CloudNetPlugin
+val EXTERNAL_JAVADOC_LINKS = mapOf(
+  "https://projectlombok.org/api/" to "lombok",
+  "https://jd.advntr.dev/api/latest/" to "adventure",
+  "https://javadoc.io/doc/io.vavr/vavr/0.10.7/" to "vavr",
+  "https://javadoc.io/doc/org.incendo/cloud-core/latest/" to "cloud-core",
+  "https://javadoc.io/doc/org.jetbrains/annotations/latest/" to "jb-annotations",
+  "https://javadoc.io/doc/dev.derklaro.aerogel/aerogel/latest/" to "aerogel",
+  "https://docs.oracle.com/en/java/javase/${JAVA_CORE_COMPATIBILITY.asInt()}/docs/api/" to "java"
+)
+
 fun Project.configurePublishing(publishedComponent: String) {
   extensions.configure<PublishingExtension> {
     // pull this out because of configuration cache
@@ -141,17 +152,11 @@ fun Project.configurePublishing(publishedComponent: String) {
 
 fun applyJavadocOptions(options: StandardJavadocDocletOptions) {
   options.use()
+  options.locale = "en"
   options.encoding = "UTF-8"
   options.memberLevel = JavadocMemberLevel.PRIVATE
+  options.addBooleanOption("quiet", true)
   options.addBooleanOption("-enable-preview", true)
-  options.addBooleanOption("Xdoclint:-missing", true)
-  options.links(
-    "https://projectlombok.org/api/",
-    "https://jd.advntr.dev/api/latest/",
-    "https://javadoc.io/doc/io.vavr/vavr/0.10.7/",
-    "https://javadoc.io/doc/org.incendo/cloud-core/latest/",
-    "https://javadoc.io/doc/org.jetbrains/annotations/latest/",
-    "https://javadoc.io/doc/dev.derklaro.aerogel/aerogel/latest/",
-    "https://docs.oracle.com/en/java/javase/${JAVA_CORE_COMPATIBILITY.asInt()}/docs/api/"
-  )
+  options.addBooleanOption("Xdoclint:all,-missing", true)
+  options.addStringOption("-link-modularity-mismatch", "info")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ import eu.cloudnetservice.cloudnet.gradle.plugins.JAVA_CORE_COMPATIBILITY
 import eu.cloudnetservice.cloudnet.gradle.plugins.configureFor
 import eu.cloudnetservice.cloudnet.gradle.plugins.lenientView
 import eu.cloudnetservice.cloudnet.gradle.util.CustomConfigurations
+import eu.cloudnetservice.cloudnet.gradle.util.EXTERNAL_JAVADOC_LINKS
 import eu.cloudnetservice.cloudnet.gradle.util.applyJavadocOptions
 
 plugins {
@@ -45,6 +46,7 @@ tasks.register("globalJavaDoc", Javadoc::class) {
   applyJavadocOptions(options)
   options.windowTitle = "CloudNet JavaDocs"
   options.source = JAVA_CORE_COMPATIBILITY.toString()
+  options.links(*EXTERNAL_JAVADOC_LINKS.keys.toTypedArray())
 
   // set the sources. We are using lenientView to ignore subprojects that shouldn't be included
   source(globalJavadocSources.map { it.lenientView.files })

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/DataClassCodec.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/DataClassCodec.java
@@ -21,7 +21,7 @@ import eu.cloudnetservice.driver.network.object.ObjectMapper;
 import lombok.NonNull;
 
 /**
- * The blueprint of the internally generated class to serialize & deserialize the fields of an object into a buffer.
+ * The blueprint of the internally generated class to serialize and deserialize the fields of an object into a buffer.
  *
  * @since 4.0
  */

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandManager.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandManager.java
@@ -28,7 +28,7 @@ import org.incendo.cloud.meta.CommandMeta;
 import org.incendo.cloud.meta.SimpleCommandMeta;
 
 /**
- * {@inheritDoc}
+ * Default implementation of the command manager.
  */
 @Singleton
 final class DefaultCommandManager extends CommandManager<CommandSource> {

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandPostProcessor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandPostProcessor.java
@@ -29,7 +29,7 @@ import org.incendo.cloud.execution.postprocessor.CommandPostprocessingContext;
 import org.incendo.cloud.execution.postprocessor.CommandPostprocessor;
 
 /**
- * {@inheritDoc}
+ * Default command post processor implementation.
  */
 @Singleton
 final class DefaultCommandPostProcessor implements CommandPostprocessor<CommandSource> {

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandPreProcessor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandPreProcessor.java
@@ -30,7 +30,7 @@ import org.incendo.cloud.execution.preprocessor.CommandPreprocessor;
 import org.incendo.cloud.services.type.ConsumerService;
 
 /**
- * {@inheritDoc}
+ * Default command pre processor implementation.
  */
 @Singleton
 final class DefaultCommandPreProcessor implements CommandPreprocessor<CommandSource> {

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
@@ -80,7 +80,7 @@ import org.incendo.cloud.suggestion.Suggestion;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * {@inheritDoc}
+ * Default implementation of the command provider.
  */
 @Singleton
 @Provides(CommandProvider.class)

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultSuggestionProcessor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultSuggestionProcessor.java
@@ -34,7 +34,7 @@ import org.incendo.cloud.suggestion.Suggestion;
 import org.incendo.cloud.suggestion.SuggestionProcessor;
 
 /**
- * {@inheritDoc}
+ * Default implementation of the suggestion processor.
  */
 @Singleton
 final class DefaultSuggestionProcessor implements SuggestionProcessor<CommandSource> {

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/source/ConsoleCommandSource.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/source/ConsoleCommandSource.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@inheritDoc}
+ * Command source implementation representing the console. This source can execute every command unconditionally.
  */
 @Singleton
 @AutoService(services = CommandSource.class, name = "console")


### PR DESCRIPTION
### Motivation
Currently, javadoc indexes are downloaded on each javadoc task that is being executed. This leads to ratelimits which are failing the build. Also not every external lib that is used in public api has javadoc links present, these should be added too.

### Modification
Download the javadoc indexes once when executing the build and reference them via the `-linkoffline` flag of the javadoc tool. Additionally, more javadoc sources were added for libs used in public apis and javadoc errors were fixed.

### Result
The build no longer fails due to ratelimits when downloading javadocs, javadocs for more libs used in public apis should be available and some javadoc errors are now fixed.
