### PR TITLE
chore: update copyright headers

### DIFF
--- a/.idea/copyright/CloudNet.xml
+++ b/.idea/copyright/CloudNet.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright 2019-&amp;#36;today.year CloudNetService team &amp;amp; contributors&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="notice" value="Copyright 2019-present CloudNetService team &amp;amp; contributors&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
     <option name="myName" value="CloudNet" />
   </copyright>
 </component>

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/build.gradle.kts
+++ b/build-extensions/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/settings.gradle.kts
+++ b/build-extensions/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetJavaApiPlugin.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetJavaApiPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetJavaPlugin.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetJavaPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetModulesApiPlugin.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetModulesApiPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetModulesPlugin.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetModulesPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetPlugin.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetPluginsPlugin.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetPluginsPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetPublishPlugin.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetPublishPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetUpdaterPlugin.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/plugins/CloudNetUpdaterPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/ExportCnlFile.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/ExportCnlFile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/ExportLanguageFileInformation.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/ExportLanguageFileInformation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/FetchJavadocIndexes.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/FetchJavadocIndexes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/GenerateUpdaterInformationTask.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/GenerateUpdaterInformationTask.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/IncludeNestedModJarsTask.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/IncludeNestedModJarsTask.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/PrepareUpdaterDataTask.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/tasks/PrepareUpdaterDataTask.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/ChecksumHelper.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/ChecksumHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/CustomConfigurations.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/CustomConfigurations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/Extensions.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/Extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/Files.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/Files.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/UpdaterMeta.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/UpdaterMeta.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/VersionCatalogueExtensions.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/VersionCatalogueExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/Versions.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/Versions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/driver/ap/build.gradle.kts
+++ b/driver/ap/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/ap/src/main/java/eu/cloudnetservice/driver/ap/registry/AutoServiceMapping.java
+++ b/driver/ap/src/main/java/eu/cloudnetservice/driver/ap/registry/AutoServiceMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/ap/src/main/java/eu/cloudnetservice/driver/ap/registry/AutoServiceProcessor.java
+++ b/driver/ap/src/main/java/eu/cloudnetservice/driver/ap/registry/AutoServiceProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/ap/src/main/java/eu/cloudnetservice/driver/ap/util/ProcessingUtil.java
+++ b/driver/ap/src/main/java/eu/cloudnetservice/driver/ap/util/ProcessingUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/ap/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/driver/ap/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/driver/api/build.gradle.kts
+++ b/driver/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/CloudNetVersion.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/CloudNetVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/ComponentInfo.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/ComponentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/DriverEnvironment.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/DriverEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/base/JavaVersion.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/base/JavaVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/base/Named.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/base/Named.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessage.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessageSender.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessageSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessageTarget.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/channel/ChannelMessageTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/cluster/NetworkCluster.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/cluster/NetworkCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/cluster/NetworkClusterNode.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/cluster/NetworkClusterNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/cluster/NodeInfoSnapshot.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/cluster/NodeInfoSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/command/CommandInfo.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/command/CommandInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/database/Database.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/database/Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/database/DatabaseProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/database/DatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/Document.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/Document.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/DocumentFactory.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/DocumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/DocumentParseException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/DocumentParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/DocumentSerialisationException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/DocumentSerialisationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/SerialisationStyle.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/SerialisationStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/StandardSerialisationStyle.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/StandardSerialisationStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/annotations/DocumentFieldRename.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/annotations/DocumentFieldRename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/annotations/DocumentValueIgnore.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/annotations/DocumentValueIgnore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/DefaultedDocPropertyHolder.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/DefaultedDocPropertyHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/DefaultingDocProperty.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/DefaultingDocProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/DocProperty.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/DocProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/DocPropertyHolder.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/DocPropertyHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/ReadOnlyDocProperty.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/ReadOnlyDocProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/RewritingDocProperty.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/RewritingDocProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/StandardDocProperty.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/property/StandardDocProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/DocumentSend.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/DocumentSend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/ElementVisitor.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/ElementVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/ArrayElement.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/ArrayElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/Element.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/Element.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/NullElement.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/NullElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/ObjectElement.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/ObjectElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/PrimitiveElement.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/document/send/element/PrimitiveElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/Cancelable.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/Cancelable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/Event.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/EventListener.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/EventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/EventListenerException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/EventListenerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/EventManager.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/EventManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/InvocationOrder.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/InvocationOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/RegisteredEventListener.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/RegisteredEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/channel/ChannelMessageReceiveEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/channel/ChannelMessageReceiveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationAddEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationAddEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationRemoveEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/group/GroupConfigurationRemoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModuleEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModuleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostInstallDependencyEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostInstallDependencyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostLoadEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostLoadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostReloadEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostReloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostStartEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostStopEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostStopEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostUnloadEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePostUnloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreInstallDependencyEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreInstallDependencyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreLoadEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreLoadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreReloadEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreReloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreStartEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreStopEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreStopEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreUnloadEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/ModulePreUnloadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/UnloadedModuleEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/module/UnloadedModuleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/network/ChannelType.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/network/ChannelType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelCloseEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelCloseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelInitEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkChannelInitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/network/NetworkEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceDeferredStateEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceDeferredStateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceLifecycleChangeEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceLifecycleChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceLogEntryEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceLogEntryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceUpdateEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/service/CloudServiceUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskAddEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskAddEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskRemoveEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/event/events/task/ServiceTaskRemoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/inject/BootLayerConfigurator.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/inject/BootLayerConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/inject/DefaultInjectionLayer.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/inject/DefaultInjectionLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectUtil.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayer.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerHolder.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerRegistry.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/inject/InjectionLayerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/inject/NamedImpl.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/inject/NamedImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/inject/UncloseableInjectionLayer.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/inject/UncloseableInjectionLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/language/I18n.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/language/I18n.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/language/PropertiesTranslationProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/language/PropertiesTranslationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/language/TranslationProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/language/TranslationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/DefaultModule.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/DefaultModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/Module.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleConfiguration.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleConfigurationNotFoundException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleConfigurationNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleDependency.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyLoader.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyNotFoundException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyOutdatedException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleDependencyOutdatedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleLifeCycle.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleProviderHandler.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleProviderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleRepository.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleTask.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleTaskEntry.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleTaskEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleWrapper.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/ModuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/driver/DriverModule.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/driver/DriverModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/module/driver/ModuleConfigurationInvalidException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/module/driver/ModuleConfigurationInvalidException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/HostAndPort.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/HostAndPort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkChannel.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkChannelHandler.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkClient.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkComponent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkServer.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/NetworkServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBufFactory.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBufFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBufable.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/buffer/DataBufable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkSessionInformation.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkSessionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedFileQueryBuilder.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedFileQueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketHandler.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketSender.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/ChunkedPacketSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/TransferStatus.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/TransferStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/event/ChunkedPacketSessionOpenEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/event/ChunkedPacketSessionOpenEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/event/EventChunkHandlerFactory.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/event/EventChunkHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/event/FileQueryRequestEvent.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/chunk/event/FileQueryRequestEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/object/ObjectMapper.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/object/ObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/object/ObjectSerializer.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/object/ObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/BasePacket.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/BasePacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/EmptyPacket.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/EmptyPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/Packet.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/Packet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListener.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListenerRegistry.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketListenerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketSender.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/PacketSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/QueryPacketManager.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/protocol/QueryPacketManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/ChainableRPC.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/ChainableRPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPC.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCChain.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCExecutable.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCExecutable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCSender.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/RPCSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCChained.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCChained.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCFieldGetter.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCFieldGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCIgnore.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCIgnore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCInvocationTarget.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCInvocationTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCNoResult.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCNoResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCTimeout.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/annotation/RPCTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/MissingObjectSerializerException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/MissingObjectSerializerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/RPCException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/RPCException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/RPCExecutionException.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/exception/RPCExecutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/factory/RPCFactory.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/factory/RPCFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/factory/RPCImplementationBuilder.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/factory/RPCImplementationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/handler/RPCHandler.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/handler/RPCHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/handler/RPCHandlerRegistry.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/handler/RPCHandlerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/handler/RPCInvocationContext.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/handler/RPCInvocationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/handler/RPCInvocationResult.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/handler/RPCInvocationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/introspec/RPCMethodMetadata.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/rpc/introspec/RPCMethodMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/network/ssl/SSLConfiguration.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/network/ssl/SSLConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/provider/CloudMessenger.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/provider/CloudMessenger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceFactory.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/provider/CloudServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/provider/ClusterNodeProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/provider/ClusterNodeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/provider/GroupConfigurationProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/provider/GroupConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/provider/ServiceTaskProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/provider/ServiceTaskProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/provider/SpecificCloudServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/registry/AutoService.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/registry/AutoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/registry/Service.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/registry/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistry.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistryHolder.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistryHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistryRegistration.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/registry/ServiceRegistryRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/GroupConfiguration.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/GroupConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ProcessConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ProcessSnapshot.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ProcessSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceConfigurationBase.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceConfigurationBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateRetryConfiguration.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceCreateRetryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceDeployment.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceDeployment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironment.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceEnvironmentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceId.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceInfoSnapshot.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceInfoSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceLifeCycle.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceRemoteInclusion.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceRemoteInclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceTemplate.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ServiceTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/service/ThreadSnapshot.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/service/ThreadSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/template/FileInfo.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/template/FileInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/template/TemplateStorage.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/template/TemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/template/TemplateStorageProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/template/TemplateStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/api/src/test/java/eu/cloudnetservice/driver/base/JavaVersionTest.java
+++ b/driver/api/src/test/java/eu/cloudnetservice/driver/base/JavaVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/build.gradle.kts
+++ b/driver/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/channel/BaseCloudMessenger.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/channel/BaseCloudMessenger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/empty/EmptyDocument.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/empty/EmptyDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/empty/EmptyDocumentFactory.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/empty/EmptyDocumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/empty/EmptyDocumentSend.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/empty/EmptyDocumentSend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/DelegateTypeAdapterFactory.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/DelegateTypeAdapterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/DocumentTypeAdapter.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/DocumentTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/DurationTypeAdapter.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/DurationTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/GsonDocumentExclusionStrategy.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/GsonDocumentExclusionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/GsonDocumentFactory.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/GsonDocumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/GsonDocumentFieldNamingStrategy.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/GsonDocumentFieldNamingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/GsonProvider.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/GsonProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/ImmutableGsonDocument.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/ImmutableGsonDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/MutableGsonDocument.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/MutableGsonDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/PathTypeAdapter.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/PathTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/PatternTypeAdapter.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/PatternTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/TimeTypeAdapter.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/TimeTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonArrayVisitor.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonArrayVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonDocumentSend.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonDocumentSend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonObjectVisitor.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonObjectVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonPrimitiveConverter.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonPrimitiveConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonRootObjectVisitor.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/document/gson/send/GsonRootObjectVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/event/DefaultEventManager.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/event/DefaultEventManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/event/DefaultRegisteredEventListener.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/event/DefaultRegisteredEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/language/DefaultI18n.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/language/DefaultI18n.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleDependencyLoader.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleDependencyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleProvider.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleProviderHandler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleProviderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleTaskEntry.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleTaskEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleWrapper.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/DefaultModuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/ModuleDependencyUtil.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/ModuleDependencyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/ModuleHelper.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/ModuleHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/ModuleURLClassLoader.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/module/ModuleURLClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/DefaultNetworkChannel.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/DefaultNetworkChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/NetworkConstants.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/NetworkConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/ChunkedSessionRegistry.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/ChunkedSessionRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultChunkedPacketProvider.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultChunkedPacketProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultFileChunkPacketSender.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultFileChunkPacketSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultFileChunkedPacketHandler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/DefaultFileChunkedPacketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/builder/DefaultChunkedFileQueryBuilder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/builder/DefaultChunkedFileQueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/builder/DefaultChunkedPacketSenderBuilder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/builder/DefaultChunkedPacketSenderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/network/ChunkedPacket.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/network/ChunkedPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/network/ChunkedPacketListener.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/network/ChunkedPacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/splitter/NetworkChannelsPacketSplitter.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/chunk/splitter/NetworkChannelsPacketSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyNetworkChannel.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyNetworkChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyNetworkHandler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyNetworkHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyOptionSettingChannelInitializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyOptionSettingChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyTransport.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyUtil.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyDataBufFactory.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyDataBufFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyImmutableDataBuf.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyImmutableDataBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyMutableDataBuf.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/buffer/NettyMutableDataBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/client/NettyNetworkClient.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/client/NettyNetworkClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/client/NettyNetworkClientHandler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/client/NettyNetworkClientHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/client/NettyNetworkClientInitializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/client/NettyNetworkClientInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketDecoder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketEncoder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/VarInt32FrameDecoder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/VarInt32FrameDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/VarInt32FramePrepender.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/codec/VarInt32FramePrepender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentAllocator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentBuffer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentFreeDrop.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentFreeDrop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentMemoryManager.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentMemoryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/server/NettyNetworkServer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/server/NettyNetworkServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/server/NettyNetworkServerHandler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/server/NettyNetworkServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/server/NettyNetworkServerInitializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/server/NettyNetworkServerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/DefaultObjectMapper.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/DefaultObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/ObjectMapperInjectRegistration.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/ObjectMapperInjectRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/AllocationStatistic.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/AllocationStatistic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/DataClassCodec.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/DataClassCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/DataClassCodecGenerator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/DataClassCodecGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/DataClassSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/data/DataClassSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/CollectionObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/CollectionObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/DataBufObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/DataBufObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/DataBufableObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/DataBufableObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/DocumentObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/DocumentObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/EnumObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/EnumObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/FunctionalObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/FunctionalObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/MapObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/MapObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/OptionalObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/OptionalObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/PathObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/PathObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/PatternObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/PatternObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/TimeObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/TimeObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/UUIDObjectSerializer.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/object/serializers/UUIDObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultPacketListenerRegistry.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultPacketListenerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultQueryPacketManager.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultQueryPacketManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/DefaultRPCFactory.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/DefaultRPCFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/DefaultRPCProvider.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/DefaultRPCProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/RPCRequestPacket.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/RPCRequestPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/BasicRPCMethodGenerator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/BasicRPCMethodGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/ChainedRPCMethodGenerator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/ChainedRPCMethodGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/DefaultRPCImplementationBuilder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/DefaultRPCImplementationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCGenerationCache.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCGenerationCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCGenerationConstants.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCGenerationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCGenerationContext.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCGenerationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCImplementationGenerator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCImplementationGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCInternalInstanceFactory.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCInternalInstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCMethodGenerator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/generation/RPCMethodGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/DefaultRPCHandler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/DefaultRPCHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/DefaultRPCHandlerBuilder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/DefaultRPCHandlerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/DefaultRPCHandlerRegistry.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/DefaultRPCHandlerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/DefaultRPCInvocationContext.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/DefaultRPCInvocationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/invoker/MethodInvoker.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/invoker/MethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/invoker/MethodInvokerGenerator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/invoker/MethodInvokerGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/util/RPCExceptionUtil.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/handler/util/RPCExceptionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/introspec/DefaultRPCMethodMetadata.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/introspec/DefaultRPCMethodMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/introspec/RPCClassMetadata.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/introspec/RPCClassMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/listener/RPCPacketListener.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/listener/RPCPacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/rpc/DefaultRPC.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/rpc/DefaultRPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/rpc/DefaultRPCChain.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/rpc/DefaultRPCChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/rpc/RPCResultMapper.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/rpc/RPCResultMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/sender/DefaultRPCSender.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/sender/DefaultRPCSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/sender/DefaultRPCSenderBuilder.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/rpc/sender/DefaultRPCSenderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/FallbackRejectionHandler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/FallbackRejectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/NetworkTaskScheduler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/NetworkTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/ScalingNetworkTaskScheduler.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/ScalingNetworkTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/TaskSchedulingAction.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/TaskSchedulingAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/TimedSynchronousQueue.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/scheduler/TimedSynchronousQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/standard/AuthorizationPacket.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/standard/AuthorizationPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/standard/ChannelMessagePacket.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/standard/ChannelMessagePacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/AutoServiceMapping.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/AutoServiceMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/DefaultServiceRegistry.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/DefaultServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/FixedInstanceServiceRegistration.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/FixedInstanceServiceRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/NewInstanceServiceRegistration.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/NewInstanceServiceRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/ProxiedServiceRegistration.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/ProxiedServiceRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/ServiceAnnotationInjectConfigurator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/ServiceAnnotationInjectConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/ServiceRegistrationsBinding.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/registry/ServiceRegistrationsBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/template/RemoteTemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/resources/META-INF/services/eu.cloudnetservice.driver.inject.BootLayerConfigurator
+++ b/driver/impl/src/main/resources/META-INF/services/eu.cloudnetservice.driver.inject.BootLayerConfigurator
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/driver/impl/src/main/resources/META-INF/services/io.netty5.buffer.MemoryManager
+++ b/driver/impl/src/main/resources/META-INF/services/io.netty5.buffer.MemoryManager
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/DocumentPropertyTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/DocumentPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/DocumentSerialisationTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/DocumentSerialisationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/DocumentTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/DocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/DocumentValueTestClass.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/DocumentValueTestClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/gson/JavaTimeSerializerTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/document/gson/JavaTimeSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/event/DefaultEventManagerTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/event/DefaultEventManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/junit/EnableServicesInject.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/junit/EnableServicesInject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/junit/EnableServicesInjectExtension.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/junit/EnableServicesInjectExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/language/I18nTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/language/I18nTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/module/ModuleDependencyUtilTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/module/ModuleDependencyUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/HostAndPortTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/HostAndPortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/NetworkTestCase.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/NetworkTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/chunk/ChunkedPacketSenderTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/chunk/ChunkedPacketSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/NettyTransportTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/NettyTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/NettyUtilTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/NettyUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketCodecTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/codec/NettyPacketCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/communication/NettyNetworkServerClientTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/communication/NettyNetworkServerClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentBufferTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultPacketListenerRegistryTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultPacketListenerRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultQueryPacketManagerTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/protocol/DefaultQueryPacketManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/RPCSenderTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/RPCSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/api/BaseDatabase.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/api/BaseDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/api/RPCImplementationGeneratorTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/api/RPCImplementationGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/api/SenderNeedingDatabase.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/api/SenderNeedingDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/api/TestRPCParameters.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/api/TestRPCParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/chain/RPCChainImplementationGeneratorTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/generation/chain/RPCChainImplementationGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/handler/RPCNetworkHandlingTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/handler/RPCNetworkHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/handler/RPCPacketListenerTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/handler/RPCPacketListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/object/AllPrimitiveTypesDataClass.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/object/AllPrimitiveTypesDataClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/object/DefaultObjectMapperTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/object/DefaultObjectMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/object/ObjectWithSpecialGetter.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/object/ObjectWithSpecialGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/registry/DefaultRPCHandlerRegistryTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/rpc/registry/DefaultRPCHandlerRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/scheduler/ScalingNetworkTaskSchedulerTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/network/scheduler/ScalingNetworkTaskSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/registry/ServiceRegistryTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/registry/ServiceRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/build.gradle.kts
+++ b/ext/adventure-helper/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/adventure/AdventureTextFormatLookup.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/adventure/AdventureTextFormatLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/bungee/BungeeComponentUtil.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/bungee/BungeeComponentUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/AdventureComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/AdventureComponentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/BungeeComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/BungeeComponentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentConverter.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormats.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/ComponentFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/JavaEditionComponentFormat.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/JavaEditionComponentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/MappingConverter.java
+++ b/ext/adventure-helper/src/main/java/eu/cloudnetservice/ext/component/MappingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/adventure/AdventureTextFormatLookupTest.java
+++ b/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/adventure/AdventureTextFormatLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/component/ComponentFormatsTest.java
+++ b/ext/adventure-helper/src/test/java/eu/cloudnetservice/ext/component/ComponentFormatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/bukkit-command/build.gradle.kts
+++ b/ext/bukkit-command/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/bukkit-command/src/main/java/eu/cloudnetservice/ext/bukkitcommands/BaseTabExecutor.java
+++ b/ext/bukkit-command/src/main/java/eu/cloudnetservice/ext/bukkitcommands/BaseTabExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/modlauncher/build.gradle.kts
+++ b/ext/modlauncher/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/modlauncher/src/main/java/eu/cloudnetservice/ext/modlauncher/CloudNetLaunchPluginService.java
+++ b/ext/modlauncher/src/main/java/eu/cloudnetservice/ext/modlauncher/CloudNetLaunchPluginService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/modlauncher/src/main/resources/META-INF/services/cpw.mods.modlauncher.serviceapi.ILaunchPluginService
+++ b/ext/modlauncher/src/main/resources/META-INF/services/cpw.mods.modlauncher.serviceapi.ILaunchPluginService
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/build.gradle.kts
+++ b/ext/platform-inject-support/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformEntrypoint.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformEntrypoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformPluginInfo.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformPluginInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformPluginManager.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/PlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/data/ParsedPluginData.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/data/ParsedPluginData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/data/PluginDataParser.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/data/PluginDataParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/defaults/BasePlatformPluginManager.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/defaults/BasePlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/defaults/DefaultPlatformPluginInfo.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/defaults/DefaultPlatformPluginInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/generator/PlatformMainClassGenerator.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/generator/PlatformMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/generator/PluginInfoGenerator.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/generator/PluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/inject/BindingsInstaller.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/inject/BindingsInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/mapping/Container.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/mapping/Container.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/mapping/PlatformedContainer.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/mapping/PlatformedContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/registry/PlatformManagerRegistryHolder.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/registry/PlatformManagerRegistryHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformDataGeneratorProvider.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformDataGeneratorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformPluginManagerProvider.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformPluginManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformPluginManagerRegistry.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/spi/PlatformPluginManagerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Command.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ConstructionListener.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ConstructionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Dependency.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Dependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ExternalDependency.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ExternalDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/PlatformPlugin.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/PlatformPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ProvidesFor.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/ProvidesFor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Repository.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/stereotype/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/util/FunctionalUtil.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/util/FunctionalUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/util/PluginUtil.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/api/util/PluginUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectSupportLoader.java
+++ b/ext/platform-inject-support/api/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectSupportLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/loader/build.gradle.kts
+++ b/ext/platform-inject-support/loader/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/JarInJarClassLoader.java
+++ b/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/JarInJarClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectLoaderLazy.java
+++ b/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectLoaderLazy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectSupportLoaderImpl.java
+++ b/ext/platform-inject-support/loader/src/main/java/eu/cloudnetservice/ext/platforminject/loader/PlatformInjectSupportLoaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/build.gradle.kts
+++ b/ext/platform-inject-support/processor/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/BindingClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/BindingClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/PlatformPluginProcessor.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/PlatformPluginProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/BaseMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/BaseMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/JavapoetMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/JavapoetMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/MethodBasedMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/classgen/MethodBasedMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/id/AllowedCharRange.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/id/AllowedCharRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/id/CharRange.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/id/CharRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/id/PluginIdGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/id/PluginIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/infogen/NightConfigInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/infogen/NightConfigInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bukkit/BukkitPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/bungeecord/BungeeCordPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/fabric/FabricPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/limboloohp/LimboLoohpMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/limboloohp/LimboLoohpMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/limboloohp/LimboLoohpPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/limboloohp/LimboLoohpPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/limboloohp/LimboLoohpPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/limboloohp/LimboLoohpPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/minestom/MinestomPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/nukkit/NukkitPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongeMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongeMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongePlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongePlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongePluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/sponge/SpongePluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/velocity/VelocityPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogMainClassGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogMainClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogPlatformInfoProvider.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogPlatformInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogPluginInfoGenerator.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/platform/waterdog/WaterDogPluginInfoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/ConfigUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/ConfigUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/GeantyrefUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/GeantyrefUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/PatternUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/PatternUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/ResourceUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/ResourceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/TypeUtil.java
+++ b/ext/platform-inject-support/processor/src/main/java/eu/cloudnetservice/ext/platforminject/processor/util/TypeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformDataGeneratorProvider
+++ b/ext/platform-inject-support/processor/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformDataGeneratorProvider
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/ext/platform-inject-support/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/build.gradle.kts
+++ b/ext/platform-inject-support/runtime/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/DefaultPlatformPluginManagerRegistry.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/DefaultPlatformPluginManagerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bukkit/BukkitPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bukkit/BukkitPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bukkit/BukkitPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bukkit/BukkitPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/bungeecord/BungeeCordPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/fabric/FabricPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/fabric/FabricPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/fabric/FabricPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/fabric/FabricPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/limboloohp/LimboLoohpPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/limboloohp/LimboLoohpPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/limboloohp/LimboLoohpPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/limboloohp/LimboLoohpPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/minestom/MinestomPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/minestom/MinestomPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/minestom/MinestomPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/minestom/MinestomPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/nukkit/NukkitPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/nukkit/NukkitPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/nukkit/NukkitPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/nukkit/NukkitPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/sponge/SpongePlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/sponge/SpongePlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/sponge/SpongePlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/sponge/SpongePlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/velocity/VelocityPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/velocity/VelocityPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/velocity/VelocityPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/velocity/VelocityPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/waterdog/WaterDogPlatformManagerProvider.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/waterdog/WaterDogPlatformManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/waterdog/WaterDogPlatformPluginManager.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/platform/waterdog/WaterDogPlatformPluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/util/LazyClassInstantiationUtil.java
+++ b/ext/platform-inject-support/runtime/src/main/java/eu/cloudnetservice/ext/platforminject/runtime/util/LazyClassInstantiationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformPluginManagerProvider
+++ b/ext/platform-inject-support/runtime/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformPluginManagerProvider
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/platform-inject-support/runtime/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformPluginManagerRegistry
+++ b/ext/platform-inject-support/runtime/src/main/resources/META-INF/services/eu.cloudnetservice.ext.platforminject.api.spi.PlatformPluginManagerRegistry
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/updater/build.gradle.kts
+++ b/ext/updater/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/Updater.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/Updater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/UpdaterRegistry.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/UpdaterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/defaults/DefaultUpdaterRegistry.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/defaults/DefaultUpdaterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/util/ChecksumUtil.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/util/ChecksumUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/util/GitHubUtil.java
+++ b/ext/updater/src/main/java/eu/cloudnetservice/ext/updater/util/GitHubUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launcher/java22/build.gradle.kts
+++ b/launcher/java22/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/ApplicationBootstrap.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/ApplicationBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/ApplicationLock.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/ApplicationLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/CloudNetLauncher.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/CloudNetLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/cnl/CnlCommand.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/cnl/CnlCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/cnl/CnlInterpreter.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/cnl/CnlInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/cnl/defaults/VarCnlCommand.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/cnl/defaults/VarCnlCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/dependency/Dependency.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/dependency/Dependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/dependency/DependencyHelper.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/dependency/DependencyHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/dependency/Repository.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/dependency/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/LauncherUpdaterContext.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/LauncherUpdaterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/LauncherUpdaterRegistry.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/LauncherUpdaterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherChecksumsFileUpdater.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherChecksumsFileUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherCloudNetUpdater.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherCloudNetUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherModuleJsonUpdater.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherModuleJsonUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherPatcherUpdater.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherPatcherUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherUpdater.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/updaters/LauncherUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/util/FileDownloadUpdateHelper.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/updater/util/FileDownloadUpdateHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/util/BootstrapUtil.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/util/BootstrapUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/util/CommandLineHelper.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/util/CommandLineHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/util/Environment.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/util/Environment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/util/HttpUtil.java
+++ b/launcher/java22/src/main/java/eu/cloudnetservice/launcher/java22/util/HttpUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java8/build.gradle.kts
+++ b/launcher/java8/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/java8/src/main/java/eu/cloudnetservice/launcher/java8/Launcher.java
+++ b/launcher/java8/src/main/java/eu/cloudnetservice/launcher/java8/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/patcher/build.gradle.kts
+++ b/launcher/patcher/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/patcher/src/main/java/eu/cloudnetservice/launcher/patcher/CloudNetLauncherPatcher.java
+++ b/launcher/patcher/src/main/java/eu/cloudnetservice/launcher/patcher/CloudNetLauncherPatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/build.gradle.kts
+++ b/modules/bridge/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/BridgeDocProperties.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/BridgeDocProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/BridgeManagement.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/BridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceHelper.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/BridgeServiceHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/WorldPosition.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/WorldPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/config/BridgeConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/config/ProxyFallback.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/config/ProxyFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/config/ProxyFallbackConfiguration.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/config/ProxyFallbackConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeConfigurationUpdateEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeConfigurationUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeDeleteCloudOfflinePlayerEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeDeleteCloudOfflinePlayerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerDisconnectEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerDisconnectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerLoginEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerLoginEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerServerSwitchEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeProxyPlayerServerSwitchEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeServerPlayerDisconnectEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeServerPlayerDisconnectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeServerPlayerLoginEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeServerPlayerLoginEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeUpdateCloudOfflinePlayerEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeUpdateCloudOfflinePlayerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeUpdateCloudPlayerEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/event/BridgeUpdateCloudPlayerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/node/event/LocalPlayerPreLoginEvent.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/node/event/LocalPlayerPreLoginEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudOfflinePlayer.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudOfflinePlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudPlayer.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/CloudPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkPlayerProxyInfo.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkPlayerProxyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkPlayerServerInfo.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkPlayerServerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkServiceInfo.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/NetworkServiceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerProvider.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/ServicePlayer.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/ServicePlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/PlayerExecutor.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/PlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/ServerSelectorType.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/executor/ServerSelectorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/build.gradle.kts
+++ b/modules/bridge/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/InternalBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/InternalBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/CloudNetBridgeModule.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/CloudNetBridgeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/NodeBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/NodeBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/command/BridgeCommand.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/command/BridgeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/command/PlayersCommand.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/command/PlayersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/listener/BridgeLocalProxyPlayerDisconnectListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/listener/BridgeLocalProxyPlayerDisconnectListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/listener/NodeSetupListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/listener/NodeSetupListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/network/NodeBridgeChannelMessageListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/network/NodeBridgeChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/network/NodePlayerChannelMessageListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/network/NodePlayerChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerManager.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerProvider.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformPlayerExecutorAdapter.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformPlayerExecutorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformPlayerManager.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformPlayerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitDirectPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitUtil.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bukkit/BukkitUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordHelper.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/BungeeCordPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/command/BungeeCordCloudCommand.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/command/BungeeCordCloudCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/command/BungeeCordFakeReloadCommand.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/command/BungeeCordFakeReloadCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/command/BungeeCordHubCommand.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/bungeecord/command/BungeeCordHubCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/FabricBridgeInitializer.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/FabricBridgeInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/FabricFallbackEventListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/FabricFallbackEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/FabricLoaderLogger.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fabric/FabricLoaderLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fallback/FallbackProfile.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/fallback/FallbackProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/helper/ProxyPlatformHelper.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/helper/ProxyPlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/helper/ServerPlatformHelper.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/helper/ServerPlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpDirectPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/limboloohp/LimboLoohpPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/listener/PlatformChannelMessageListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/listener/PlatformChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/listener/PlatformInformationListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/listener/PlatformInformationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeExtension.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomDefaultPermissionChecker.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomDefaultPermissionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomDirectPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomPermissionChecker.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomPermissionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/minestom/MinestomPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitDirectPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/nukkit/NukkitPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeAddressAccessor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeAddressAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeDirectPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongeDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongePlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/sponge/SpongePlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityDirectPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/VelocityPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/commands/VelocityCloudCommand.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/commands/VelocityCloudCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/commands/VelocityHubCommand.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/velocity/commands/VelocityHubCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEBridgeManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEBridgePlugin.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEBridgePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEDirectPlayerExecutor.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEDirectPlayerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEHandlers.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEPlayerManagementListener.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/WaterDogPEPlayerManagementListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/command/WaterDogPECloudCommand.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/command/WaterDogPECloudCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/command/WaterDogPEHubCommand.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/waterdog/command/WaterDogPEHubCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/rpc/ComponentObjectSerializer.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/rpc/ComponentObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/rpc/TitleObjectSerializer.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/rpc/TitleObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/util/BridgeHostAndPortUtil.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/util/BridgeHostAndPortUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/api/build.gradle.kts
+++ b/modules/cloudflare/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/api/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareConfiguration.java
+++ b/modules/cloudflare/api/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/api/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareConfigurationEntry.java
+++ b/modules/cloudflare/api/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/api/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareGroupConfiguration.java
+++ b/modules/cloudflare/api/src/main/java/eu/cloudnetservice/modules/cloudflare/config/CloudflareGroupConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/impl/build.gradle.kts
+++ b/modules/cloudflare/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/CloudNetCloudflareModule.java
+++ b/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/CloudNetCloudflareModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/cloudflare/CloudFlareRecordManager.java
+++ b/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/cloudflare/CloudFlareRecordManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/cloudflare/DnsRecordDetail.java
+++ b/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/cloudflare/DnsRecordDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/dns/DnsRecord.java
+++ b/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/dns/DnsRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/dns/DnsType.java
+++ b/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/dns/DnsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/dns/SrvRecord.java
+++ b/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/dns/SrvRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/listener/CloudflareServiceStateListener.java
+++ b/modules/cloudflare/impl/src/main/java/eu/cloudnetservice/modules/cloudflare/impl/listener/CloudflareServiceStateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/api/build.gradle.kts
+++ b/modules/database-mongodb/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/api/src/main/java/eu/cloudnetservice/modules/mongodb/config/MongoDBConnectionConfig.java
+++ b/modules/database-mongodb/api/src/main/java/eu/cloudnetservice/modules/mongodb/config/MongoDBConnectionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/impl/build.gradle.kts
+++ b/modules/database-mongodb/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/impl/src/main/java/eu/cloudnetservice/modules/mongodb/impl/CloudNetMongoDatabaseModule.java
+++ b/modules/database-mongodb/impl/src/main/java/eu/cloudnetservice/modules/mongodb/impl/CloudNetMongoDatabaseModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/impl/src/main/java/eu/cloudnetservice/modules/mongodb/impl/MongoDBDatabase.java
+++ b/modules/database-mongodb/impl/src/main/java/eu/cloudnetservice/modules/mongodb/impl/MongoDBDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/impl/src/main/java/eu/cloudnetservice/modules/mongodb/impl/MongoDBDatabaseProvider.java
+++ b/modules/database-mongodb/impl/src/main/java/eu/cloudnetservice/modules/mongodb/impl/MongoDBDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/impl/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
+++ b/modules/database-mongodb/impl/src/test/java/eu/cloudnetservice/modules/mongodb/MongoDBDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/impl/src/test/java/eu/cloudnetservice/modules/mongodb/junit/EnableServicesInject.java
+++ b/modules/database-mongodb/impl/src/test/java/eu/cloudnetservice/modules/mongodb/junit/EnableServicesInject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/impl/src/test/java/eu/cloudnetservice/modules/mongodb/junit/EnableServicesInjectExtension.java
+++ b/modules/database-mongodb/impl/src/test/java/eu/cloudnetservice/modules/mongodb/junit/EnableServicesInjectExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mongodb/impl/src/test/resources/logback-test.xml
+++ b/modules/database-mongodb/impl/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/modules/database-mysql/api/build.gradle.kts
+++ b/modules/database-mysql/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/api/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConfiguration.java
+++ b/modules/database-mysql/api/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/api/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConnectionEndpoint.java
+++ b/modules/database-mysql/api/src/main/java/eu/cloudnetservice/modules/mysql/config/MySQLConnectionEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/impl/build.gradle.kts
+++ b/modules/database-mysql/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/impl/src/main/java/eu/cloudnetservice/modules/mysql/impl/CloudNetMySQLDatabaseModule.java
+++ b/modules/database-mysql/impl/src/main/java/eu/cloudnetservice/modules/mysql/impl/CloudNetMySQLDatabaseModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/impl/src/main/java/eu/cloudnetservice/modules/mysql/impl/MySQLDatabase.java
+++ b/modules/database-mysql/impl/src/main/java/eu/cloudnetservice/modules/mysql/impl/MySQLDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/impl/src/main/java/eu/cloudnetservice/modules/mysql/impl/MySQLDatabaseProvider.java
+++ b/modules/database-mysql/impl/src/main/java/eu/cloudnetservice/modules/mysql/impl/MySQLDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/impl/src/test/java/eu/cloudnetservice/modules/mysql/impl/MySQLDatabaseTest.java
+++ b/modules/database-mysql/impl/src/test/java/eu/cloudnetservice/modules/mysql/impl/MySQLDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/impl/src/test/java/eu/cloudnetservice/modules/mysql/impl/junit/EnableServicesInject.java
+++ b/modules/database-mysql/impl/src/test/java/eu/cloudnetservice/modules/mysql/impl/junit/EnableServicesInject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/impl/src/test/java/eu/cloudnetservice/modules/mysql/impl/junit/EnableServicesInjectExtension.java
+++ b/modules/database-mysql/impl/src/test/java/eu/cloudnetservice/modules/mysql/impl/junit/EnableServicesInjectExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/database-mysql/impl/src/test/resources/logback-test.xml
+++ b/modules/database-mysql/impl/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/api/build.gradle.kts
+++ b/modules/dockerized-services/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerConfiguration.java
+++ b/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerImage.java
+++ b/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerPortMapping.java
+++ b/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerPortMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/TaskDockerConfig.java
+++ b/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/TaskDockerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/api/src/test/java/eu/cloudnetservice/modules/docker/config/DockerImageTest.java
+++ b/modules/dockerized-services/api/src/test/java/eu/cloudnetservice/modules/docker/config/DockerImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/impl/build.gradle.kts
+++ b/modules/dockerized-services/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerCommand.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedLocalCloudServiceFactory.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedLocalCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedService.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedServiceLogCache.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedServiceLogCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedServicesModule.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedServicesModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/api/build.gradle.kts
+++ b/modules/influx/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/api/src/main/java/eu/cloudnetservice/modules/influx/InfluxConfiguration.java
+++ b/modules/influx/api/src/main/java/eu/cloudnetservice/modules/influx/InfluxConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/api/src/main/java/eu/cloudnetservice/modules/influx/publish/Publisher.java
+++ b/modules/influx/api/src/main/java/eu/cloudnetservice/modules/influx/publish/Publisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/impl/build.gradle.kts
+++ b/modules/influx/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/impl/src/main/java/eu/cloudnetservice/modules/influx/impl/InfluxModule.java
+++ b/modules/influx/impl/src/main/java/eu/cloudnetservice/modules/influx/impl/InfluxModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/impl/src/main/java/eu/cloudnetservice/modules/influx/impl/publishers/ConnectedNodeInfoPublisher.java
+++ b/modules/influx/impl/src/main/java/eu/cloudnetservice/modules/influx/impl/publishers/ConnectedNodeInfoPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/impl/src/main/java/eu/cloudnetservice/modules/influx/impl/publishers/RunningServiceProcessSnapshotPublisher.java
+++ b/modules/influx/impl/src/main/java/eu/cloudnetservice/modules/influx/impl/publishers/RunningServiceProcessSnapshotPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/influx/impl/src/main/java/eu/cloudnetservice/modules/influx/impl/util/PointUtil.java
+++ b/modules/influx/impl/src/main/java/eu/cloudnetservice/modules/influx/impl/util/PointUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/api/build.gradle.kts
+++ b/modules/labymod/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/LabyModManagement.java
+++ b/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/LabyModManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModBanner.java
+++ b/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModBanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModConfiguration.java
+++ b/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModPermissions.java
+++ b/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModServiceDisplay.java
+++ b/modules/labymod/api/src/main/java/eu/cloudnetservice/modules/labymod/config/LabyModServiceDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/build.gradle.kts
+++ b/modules/labymod/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/node/CloudNetLabyModModule.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/node/CloudNetLabyModModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/node/NodeLabyModListener.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/node/NodeLabyModListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/node/NodeLabyModManagement.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/node/NodeLabyModManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/PlatformLabyModListener.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/PlatformLabyModListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/PlatformLabyModManagement.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/PlatformLabyModManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/bungeecord/BungeeCordLabyModListener.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/bungeecord/BungeeCordLabyModListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/bungeecord/BungeeCordLabyModPlugin.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/bungeecord/BungeeCordLabyModPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/velocity/VelocityLabyModListener.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/velocity/VelocityLabyModListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/velocity/VelocityLabyModPlugin.java
+++ b/modules/labymod/impl/src/main/java/eu/cloudnetservice/modules/labymod/impl/platform/velocity/VelocityLabyModPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/build.gradle.kts
+++ b/modules/npcs/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/NPC.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/NPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/NPCManagement.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/NPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/InventoryConfiguration.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/InventoryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/ItemLayout.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/ItemLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/LabyModEmoteConfiguration.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/LabyModEmoteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCConfiguration.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCConfigurationEntry.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCPoolOptions.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/configuration/NPCPoolOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformSelectorEntity.java
+++ b/modules/npcs/api/src/main/java/eu/cloudnetservice/modules/npc/platform/PlatformSelectorEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/build.gradle.kts
+++ b/modules/npcs/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/AbstractNPCManagement.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/AbstractNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/InternalNPCManagement.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/InternalNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/SharedChannelMessageListener.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/SharedChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/CloudNPC.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/CloudNPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/NPCAction.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/NPCAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/NPCConstants.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/NPCConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/configuration/NPCConfiguration.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/configuration/NPCConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/configuration/NPCConfigurationEntry.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/configuration/NPCConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/package-info.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/_deprecated/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/CloudNetNPCModule.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/CloudNetNPCModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/NPCCommand.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/NPCCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/NodeNPCManagement.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/NodeNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/listeners/NodeChannelMessageListener.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/listeners/NodeChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/listeners/NodeSetupListener.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/node/listeners/NodeSetupListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/CloudNetServiceListener.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/CloudNetServiceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/PlatformNPCManagement.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/PlatformNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitCompatibility.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitNPCPlugin.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitNPCPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitPlatformNPCManagement.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitPlatformNPCManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/command/NPCCommand.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/command/NPCCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/entity/BukkitPlatformSelectorEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/entity/EntityBukkitPlatformSelectorEntity.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/entity/EntityBukkitPlatformSelectorEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/entity/NPCBukkitPlatformSelector.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/entity/NPCBukkitPlatformSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/listener/BukkitEntityProtectionListener.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/listener/BukkitEntityProtectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/listener/BukkitFunctionalityListener.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/listener/BukkitFunctionalityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/listener/BukkitWorldListener.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/listener/BukkitWorldListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/util/ReflectionUtil.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/util/ReflectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/api/build.gradle.kts
+++ b/modules/report/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/api/src/main/java/eu/cloudnetservice/modules/report/config/PasteServer.java
+++ b/modules/report/api/src/main/java/eu/cloudnetservice/modules/report/config/PasteServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/api/src/main/java/eu/cloudnetservice/modules/report/config/ReportConfiguration.java
+++ b/modules/report/api/src/main/java/eu/cloudnetservice/modules/report/config/ReportConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/build.gradle.kts
+++ b/modules/report/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/CloudNetReportModule.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/CloudNetReportModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/command/ReportCommand.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/command/ReportCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/EmitterService.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/EmitterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/ReportDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/ReportDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/ReportDataWriter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/ReportDataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/SpecificReportDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/SpecificReportDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/GroupConfigDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/GroupConfigDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/HeapDumpDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/HeapDumpDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/LocalModuleDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/LocalModuleDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/LocalNodeConfigDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/LocalNodeConfigDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/NodeServerDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/NodeServerDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/ServiceInfoDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/ServiceInfoDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/ServiceTasksDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/ServiceTasksDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/SystemInfoDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/SystemInfoDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/ThreadInfoDataEmitter.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/emitter/defaults/ThreadInfoDataEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/util/ReportConstants.java
+++ b/modules/report/impl/src/main/java/eu/cloudnetservice/modules/report/impl/util/ReportConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/report/impl/src/test/resources/logback-test.xml
+++ b/modules/report/impl/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/modules/signs/api/build.gradle.kts
+++ b/modules/signs/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/Sign.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/Sign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/SignManagement.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/SignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignConfigurationEntry.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignGroupConfiguration.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignGroupConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayout.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignLayoutsHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignsConfiguration.java
+++ b/modules/signs/api/src/main/java/eu/cloudnetservice/modules/signs/configuration/SignsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/build.gradle.kts
+++ b/modules/signs/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/AbstractSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/AbstractSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/InternalSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/InternalSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/SharedChannelMessageListener.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/SharedChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/Sign.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/Sign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/SignConstants.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/SignConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/SignLayout.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/SignLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/SignConfiguration.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/SignConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/SignConfigurationReaderAndWriter.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/SignConfigurationReaderAndWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/entry/SignConfigurationEntry.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/entry/SignConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/entry/SignConfigurationEntryType.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/entry/SignConfigurationEntryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/entry/SignConfigurationTaskEntry.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/entry/SignConfigurationTaskEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/entry/SignLayoutConfiguration.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/configuration/entry/SignLayoutConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/package-info.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/_deprecated/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/CloudNetSignsModule.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/CloudNetSignsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/NodeSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/NodeSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/NodeSignsListener.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/NodeSignsListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/SignCommand.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/SignCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/configuration/NodeSignsConfigurationHelper.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/configuration/NodeSignsConfigurationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/configuration/SignConfigurationType.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/configuration/SignConfigurationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/util/SignEntryTaskSetup.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/node/util/SignEntryTaskSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSign.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/PlatformSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/SignsPlatformListener.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/SignsPlatformListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/BukkitCompatibility.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/BukkitCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/BukkitPlatformSign.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/BukkitPlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/BukkitSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/BukkitSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/BukkitSignsPlugin.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/BukkitSignsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/event/BukkitCloudSignInteractEvent.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/event/BukkitCloudSignInteractEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/functionality/SignInteractListener.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/functionality/SignInteractListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/functionality/SignsCommand.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/bukkit/functionality/SignsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/MinestomPlatformSign.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/MinestomPlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/MinestomSignBlockHandler.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/MinestomSignBlockHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/MinestomSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/MinestomSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/MinestomSignsExtension.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/MinestomSignsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/event/MinestomCloudSignInteractEvent.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/event/MinestomCloudSignInteractEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/functionality/SignInteractListener.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/functionality/SignInteractListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/functionality/SignsCommand.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/minestom/functionality/SignsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/NukkitPlatformSign.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/NukkitPlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/NukkitSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/NukkitSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/NukkitSignsPlugin.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/NukkitSignsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/event/NukkitCloudSignInteractEvent.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/event/NukkitCloudSignInteractEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/functionality/SignInteractListener.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/functionality/SignInteractListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/functionality/SignsCommand.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/nukkit/functionality/SignsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/CommandRegistrationListener.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/CommandRegistrationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/SpongePlatformSign.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/SpongePlatformSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/SpongeSignManagement.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/SpongeSignManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/SpongeSignsPlugin.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/SpongeSignsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/event/SpongeCloudSignInteractEvent.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/event/SpongeCloudSignInteractEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/functionality/SignInteractListener.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/functionality/SignInteractListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/functionality/SignsCommand.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/platform/sponge/functionality/SignsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/util/LayoutUtil.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/util/LayoutUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/util/PriorityUtil.java
+++ b/modules/signs/impl/src/main/java/eu/cloudnetservice/modules/signs/impl/util/PriorityUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/api/build.gradle.kts
+++ b/modules/smart/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/api/src/main/java/eu/cloudnetservice/modules/smart/SmartServiceTaskConfig.java
+++ b/modules/smart/api/src/main/java/eu/cloudnetservice/modules/smart/SmartServiceTaskConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/impl/build.gradle.kts
+++ b/modules/smart/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/CloudNetSmartModule.java
+++ b/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/CloudNetSmartModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/SmartCommand.java
+++ b/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/SmartCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/listener/CloudNetLocalServiceListener.java
+++ b/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/listener/CloudNetLocalServiceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/listener/CloudNetLocalServiceTaskListener.java
+++ b/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/listener/CloudNetLocalServiceTaskListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/listener/CloudNetTickListener.java
+++ b/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/listener/CloudNetTickListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/util/SmartUtil.java
+++ b/modules/smart/impl/src/main/java/eu/cloudnetservice/modules/smart/impl/util/SmartUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/api/build.gradle.kts
+++ b/modules/storage-s3/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/api/src/main/java/eu/cloudnetservice/modules/s3/config/S3TemplateStorageConfig.java
+++ b/modules/storage-s3/api/src/main/java/eu/cloudnetservice/modules/s3/config/S3TemplateStorageConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/impl/build.gradle.kts
+++ b/modules/storage-s3/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/impl/src/main/java/eu/cloudnetservice/modules/s3/impl/S3TemplateStorage.java
+++ b/modules/storage-s3/impl/src/main/java/eu/cloudnetservice/modules/s3/impl/S3TemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/impl/src/main/java/eu/cloudnetservice/modules/s3/impl/S3TemplateStorageModule.java
+++ b/modules/storage-s3/impl/src/main/java/eu/cloudnetservice/modules/s3/impl/S3TemplateStorageModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/impl/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
+++ b/modules/storage-s3/impl/src/test/java/eu/cloudnetservice/modules/s3/S3TemplateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-s3/impl/src/test/resources/logback-test.xml
+++ b/modules/storage-s3/impl/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/api/build.gradle.kts
+++ b/modules/storage-sftp/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/api/src/main/java/eu/cloudnetservice/modules/sftp/config/SFTPTemplateStorageConfig.java
+++ b/modules/storage-sftp/api/src/main/java/eu/cloudnetservice/modules/sftp/config/SFTPTemplateStorageConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/impl/build.gradle.kts
+++ b/modules/storage-sftp/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/SFTPClientPool.java
+++ b/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/SFTPClientPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/SFTPTemplateStorage.java
+++ b/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/SFTPTemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/SFTPTemplateStorageModule.java
+++ b/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/SFTPTemplateStorageModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/sshj/ActiveHeartbeatKeepAliveProvider.java
+++ b/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/sshj/ActiveHeartbeatKeepAliveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/sshj/FilteringLocalFileSource.java
+++ b/modules/storage-sftp/impl/src/main/java/eu/cloudnetservice/modules/sftp/impl/sshj/FilteringLocalFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/impl/src/test/java/eu/cloudnetservice/modules/sftp/impl/SFTPTemplateStorageTest.java
+++ b/modules/storage-sftp/impl/src/test/java/eu/cloudnetservice/modules/sftp/impl/SFTPTemplateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/storage-sftp/impl/src/test/resources/logback-test.xml
+++ b/modules/storage-sftp/impl/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/modules/syncproxy/api/build.gradle.kts
+++ b/modules/syncproxy/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyConfigurationUpdateEvent.java
+++ b/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyConfigurationUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyConstants.java
+++ b/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyManagement.java
+++ b/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/SyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyConfiguration.java
+++ b/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyLoginConfiguration.java
+++ b/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyLoginConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyMotd.java
+++ b/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyMotd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabList.java
+++ b/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabListConfiguration.java
+++ b/modules/syncproxy/api/src/main/java/eu/cloudnetservice/modules/syncproxy/config/SyncProxyTabListConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/build.gradle.kts
+++ b/modules/syncproxy/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/CloudNetSyncProxyModule.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/CloudNetSyncProxyModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/NodeSyncProxyManagement.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/NodeSyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/command/SyncProxyCommand.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/command/SyncProxyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/listener/NodeSyncProxyChannelMessageListener.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/node/listener/NodeSyncProxyChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/PlatformSyncProxyManagement.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/PlatformSyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/bungee/BungeeCordSyncProxyListener.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/bungee/BungeeCordSyncProxyListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/bungee/BungeeCordSyncProxyManagement.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/bungee/BungeeCordSyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/bungee/BungeeCordSyncProxyPlugin.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/bungee/BungeeCordSyncProxyPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/listener/SyncProxyCloudListener.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/listener/SyncProxyCloudListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/velocity/VelocitySyncProxyListener.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/velocity/VelocitySyncProxyListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/velocity/VelocitySyncProxyManagement.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/velocity/VelocitySyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/velocity/VelocitySyncProxyPlugin.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/velocity/VelocitySyncProxyPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/waterdog/WaterDogPESyncProxyListener.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/waterdog/WaterDogPESyncProxyListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/waterdog/WaterDogPESyncProxyManagement.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/waterdog/WaterDogPESyncProxyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/waterdog/WaterDogPESyncProxyPlugin.java
+++ b/modules/syncproxy/impl/src/main/java/eu/cloudnetservice/modules/syncproxy/impl/platform/waterdog/WaterDogPESyncProxyPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/syncproxy/impl/src/test/resources/logback-test.xml
+++ b/modules/syncproxy/impl/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/node/api/build.gradle.kts
+++ b/node/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/cluster/LocalNodeServer.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/cluster/LocalNodeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/cluster/NodeServer.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/cluster/NodeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/cluster/NodeServerProvider.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/cluster/NodeServerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/cluster/NodeServerState.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/cluster/NodeServerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/cluster/sync/DataSyncHandler.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/cluster/sync/DataSyncHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/cluster/sync/DataSyncRegistry.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/cluster/sync/DataSyncRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/CommandProvider.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/CommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/CommandAlias.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/CommandAlias.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/Description.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/Documentation.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/Documentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/EnableConfirmSkipFlag.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/EnableConfirmSkipFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/exception/ArgumentNotAvailableException.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/exception/ArgumentNotAvailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/source/CommandSource.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/source/CommandSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/config/Configuration.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/config/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/database/LocalDatabase.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/database/LocalDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/CloudNetNodePostInitializationEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/CloudNetNodePostInitializationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/cluster/LocalNodeSnapshotConfigureEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/cluster/LocalNodeSnapshotConfigureEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/cluster/NetworkClusterNodeInfoUpdateEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/cluster/NetworkClusterNodeInfoUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandInvalidSyntaxEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandInvalidSyntaxEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandNotFoundEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandNotFoundEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandPostProcessEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandPostProcessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandPreProcessEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandPreProcessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandProcessEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/command/CommandProcessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/group/LocalGroupConfigurationAddEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/group/LocalGroupConfigurationAddEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/group/LocalGroupConfigurationRemoveEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/group/LocalGroupConfigurationRemoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/instance/CloudNetTickEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/instance/CloudNetTickEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/instance/CloudNetTickServiceStartEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/instance/CloudNetTickServiceStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/network/NetworkClusterNodeAuthSuccessEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/network/NetworkClusterNodeAuthSuccessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/network/NetworkClusterNodeReconnectEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/network/NetworkClusterNodeReconnectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/network/NetworkServiceAuthSuccessEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/network/NetworkServiceAuthSuccessEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceConfigurationPrePrepareEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceConfigurationPrePrepareEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceCreateEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceCreateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceDeploymentEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceDeploymentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceNodeSelectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostLifecycleEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostLifecycleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostPrepareEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostPrepareEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostProcessStartEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePostProcessStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreForceStopEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreForceStopEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLifecycleEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLifecycleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLoadInclusionEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreLoadInclusionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePrePrepareEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePrePrepareEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreProcessStartEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServicePreProcessStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceTemplateLoadEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/service/CloudServiceTemplateLoadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/task/LocalServiceTaskAddEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/task/LocalServiceTaskAddEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/task/LocalServiceTaskRemoveEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/task/LocalServiceTaskRemoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/event/template/ServiceTemplateInstallEvent.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/event/template/ServiceTemplateInstallEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/service/CloudService.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/service/CloudService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/service/CloudServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/service/LocalCloudServiceFactory.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/service/LocalCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/service/ServiceConfigurationPreparer.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/service/ServiceConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/service/ServiceConsoleLineHandler.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/service/ServiceConsoleLineHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/service/ServiceConsoleLogCache.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/service/ServiceConsoleLogCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/tick/Scheduler.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/tick/Scheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/tick/ShutdownHandler.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/tick/ShutdownHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/api/src/main/java/eu/cloudnetservice/node/tick/TickLoop.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/tick/TickLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/build.gradle.kts
+++ b/node/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/Node.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/boot/BootFactories.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/boot/BootFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/boot/Bootstrap.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/boot/Bootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/DefaultLocalNodeServer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/DefaultLocalNodeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/DefaultNodeServerProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/DefaultNodeServerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/RemoteNodeServer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/defaults/RemoteNodeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/DefaultDataSyncHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/DefaultDataSyncHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/DefaultDataSyncRegistry.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/DefaultDataSyncRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/prettyprint/GulfArrayDiffPrinter.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/prettyprint/GulfArrayDiffPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/prettyprint/GulfHelper.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/prettyprint/GulfHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/prettyprint/GulfMapDiffPrinter.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/prettyprint/GulfMapDiffPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/prettyprint/GulfPrettyPrint.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/sync/prettyprint/GulfPrettyPrint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/task/LocalNodeUpdateTask.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/task/LocalNodeUpdateTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/task/NodeDisconnectTrackerTask.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/task/NodeDisconnectTrackerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/util/NodeDisconnectHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/util/NodeDisconnectHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/util/QueuedNetworkChannel.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/cluster/util/QueuedNetworkChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/AerogelInjectionService.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/AerogelInjectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCaptionHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCaptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandManager.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandPostProcessor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandPreProcessor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandPreProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultSuggestionProcessor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/defaults/DefaultSuggestionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/exception/CommandExceptionHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/exception/CommandExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/source/ConsoleCommandSource.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/source/ConsoleCommandSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/source/DriverCommandSource.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/source/DriverCommandSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ClearCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ClearCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ClusterCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ConfigCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/CreateCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/CreateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/DevCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/DevCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ExitCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ExitCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/GroupsCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/GroupsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/HelpCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/HelpCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/MeCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/MeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/MigrateCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/MigrateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ModulesCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ModulesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ServiceCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/ServiceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/TasksCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/TasksCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/TemplateCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/TemplateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/VersionCommand.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/command/sub/VersionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/config/ConfigurationUtil.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/config/ConfigurationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/config/JsonConfiguration.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/config/JsonConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/Console.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/ConsoleColor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/ConsoleColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/ConsoleReadThread.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/ConsoleReadThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/JLine3Completer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/JLine3Completer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/JLine3CompletionMatcher.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/JLine3CompletionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/JLine3Console.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/JLine3Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/AbstractConsoleAnimation.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/AbstractConsoleAnimation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/progressbar/ConsoleProgressAnimation.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/progressbar/ConsoleProgressAnimation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/progressbar/ConsoleProgressWrappers.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/progressbar/ConsoleProgressWrappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/progressbar/wrapper/WrappedInputStream.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/progressbar/wrapper/WrappedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/progressbar/wrapper/WrappedIterator.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/progressbar/wrapper/WrappedIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/ConsoleAnswerTabCompleteHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/ConsoleAnswerTabCompleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/ConsoleSetupAnimation.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/ConsoleSetupAnimation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/answer/Parsers.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/answer/Parsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/answer/QuestionAnswerType.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/answer/QuestionAnswerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/answer/QuestionListEntry.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/animation/setup/answer/QuestionListEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/handler/ConsoleInputHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/handler/ConsoleInputHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/handler/ConsoleTabCompleteHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/handler/ConsoleTabCompleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/handler/Toggleable.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/handler/Toggleable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/log/ConsoleLevelConversion.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/log/ConsoleLevelConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/log/ConsoleLogAppender.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/log/ConsoleLogAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/util/HeaderReader.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/console/util/HeaderReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/AbstractDatabase.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/AbstractDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/AbstractNodeDatabaseProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/AbstractNodeDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/NodeDatabaseProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/NodeDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/h2/H2Database.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/h2/H2Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/h2/H2DatabaseProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/h2/H2DatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/sql/SQLDatabase.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/sql/SQLDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/sql/SQLDatabaseProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/sql/SQLDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/util/LocalDatabaseUtil.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/util/LocalDatabaseUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/xodus/XodusDatabase.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/xodus/XodusDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/xodus/XodusDatabaseProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/database/xodus/XodusDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/log/LoggingEntryEvent.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/log/LoggingEntryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupCancelledEvent.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupCancelledEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupCompleteEvent.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupCompleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupEvent.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupInitiateEvent.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupInitiateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupResponseEvent.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/event/setup/SetupResponseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/log/QueuedConsoleLogAppender.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/log/QueuedConsoleLogAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/ModuleEntry.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/ModuleEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/ModulesHolder.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/ModulesHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/NodeModuleProviderHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/NodeModuleProviderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/listener/PluginIncludeListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/listener/PluginIncludeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/updater/ModuleUpdater.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/updater/ModuleUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/updater/ModuleUpdaterContext.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/updater/ModuleUpdaterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/updater/ModuleUpdaterRegistry.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/updater/ModuleUpdaterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/util/ModuleUpdateUtil.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/module/util/ModuleUpdateUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/DefaultNetworkClientChannelHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/DefaultNetworkClientChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/DefaultNetworkServerChannelHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/DefaultNetworkServerChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/NodeNetworkUtil.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/NodeNetworkUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/FileDeployCallbackListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/FileDeployCallbackListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/FileQueryChannelMessageListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/FileQueryChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/StaticServiceDeployCallback.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/StaticServiceDeployCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/TemplateDeployCallback.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/TemplateDeployCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/TemplateFileDeployCallback.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/chunk/TemplateFileDeployCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/AuthorizationPacketListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/AuthorizationPacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/AuthorizationResponsePacketListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/AuthorizationResponsePacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/ChannelMessagePacketListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/ChannelMessagePacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/ServiceSyncAckPacketListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/ServiceSyncAckPacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/GroupChannelMessageListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/GroupChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/NodeChannelMessageListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/NodeChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/ServiceChannelMessageListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/ServiceChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/TaskChannelMessageListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/listener/message/TaskChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/packet/AuthorizationResponsePacket.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/packet/AuthorizationResponsePacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/packet/ServiceSyncAckPacket.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/network/packet/ServiceSyncAckPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeCloudMessenger.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeCloudMessenger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeClusterNodeProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeClusterNodeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeGroupConfigurationProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeGroupConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeServiceTaskProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/provider/NodeServiceTaskProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/InternalCloudService.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/InternalCloudService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/InternalCloudServiceManager.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/InternalCloudServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/AbstractService.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/AbstractService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/DefaultCloudServiceManager.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/DefaultCloudServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/JVMService.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/JVMService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/NodeCloudServiceFactory.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/NodeCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/ServiceCreateRetryTracker.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/ServiceCreateRetryTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/AbstractServiceConfigurationPreparer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/AbstractServiceConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/BungeeConfigurationPreparer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/BungeeConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/GlowstoneConfigurationPreparer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/GlowstoneConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/LimboLoohpServiceConfigurationPreparer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/LimboLoohpServiceConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/NukkitConfigurationPreparer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/NukkitConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/VanillaServiceConfigurationPreparer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/VanillaServiceConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/VelocityConfigurationPreparer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/VelocityConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/WaterdogPEConfigurationPreparer.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/config/WaterdogPEConfigurationPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/factory/BaseLocalCloudServiceFactory.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/factory/BaseLocalCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/factory/JVMLocalCloudServiceFactory.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/factory/JVMLocalCloudServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/AbstractServiceLogCache.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/AbstractServiceLogCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/NonBlockingLineReader.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/NonBlockingLineReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ProcessServiceLogCache.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ProcessServiceLogCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ProcessServiceLogReadScheduler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ProcessServiceLogReadScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/provider/EmptySpecificCloudServiceProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/provider/EmptySpecificCloudServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/provider/RemoteNodeCloudServiceProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/provider/RemoteNodeCloudServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultClusterSetup.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultClusterSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultConfigSetup.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultConfigSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultInstallation.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultInstallation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultSetup.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultTaskSetup.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultTaskSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/SpecificTaskSetup.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/SpecificTaskSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/LocalTemplateStorage.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/LocalTemplateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/NodeTemplateStorageProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/NodeTemplateStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/TemplateStorageUtil.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/TemplateStorageUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/listener/TemplatePrepareListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/listener/TemplatePrepareListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/tick/DefaultShutdownHandler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/tick/DefaultShutdownHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/tick/DefaultTickLoop.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/tick/DefaultTickLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/IpAllowlist.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/IpAllowlist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/JavaVersionResolver.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/JavaVersionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/NetworkUtil.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/NetworkUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/WildcardUtil.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/WildcardUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/ServiceVersion.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/ServiceVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/ServiceVersionProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/ServiceVersionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/ServiceVersionType.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/ServiceVersionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/InstallStep.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/InstallStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/InstallStepExecutor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/InstallStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/BuildStepExecutor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/BuildStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/CopyFilterStepExecutor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/CopyFilterStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/DeployStepExecutor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/DeployStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/DownloadStepExecutor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/DownloadStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/FabricApiVersionFetch.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/FabricApiVersionFetch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/PaperApiVersionFetchStepExecutor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/PaperApiVersionFetchStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/SpongeApiVersionFetchStepExecutor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/SpongeApiVersionFetchStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/UnzipStepExecutor.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/execute/defaults/UnzipStepExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/information/FileSystemVersionInstaller.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/information/FileSystemVersionInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/information/TemplateVersionInstaller.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/information/TemplateVersionInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/information/VersionInstaller.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/version/information/VersionInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/main/resources/files/nukkit/server.properties
+++ b/node/impl/src/main/resources/files/nukkit/server.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/node/impl/src/main/resources/lang/de_DE.properties
+++ b/node/impl/src/main/resources/lang/de_DE.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/node/impl/src/main/resources/lang/en_US.properties
+++ b/node/impl/src/main/resources/lang/en_US.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/node/impl/src/main/resources/logback.xml
+++ b/node/impl/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/command/CommandProviderTest.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/command/CommandProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/database/h2/H2DatabaseTest.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/database/h2/H2DatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/database/xodus/XodusDatabaseTest.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/database/xodus/XodusDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/junit/EnableServicesInject.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/junit/EnableServicesInject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/junit/EnableServicesInjectExtension.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/junit/EnableServicesInjectExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/service/defaults/log/NonBlockingLineReaderTest.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/service/defaults/log/NonBlockingLineReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/template/LocalTemplateStorageTest.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/template/LocalTemplateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/util/IpAllowlistTest.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/util/IpAllowlistTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/test/java/eu/cloudnetservice/node/impl/util/WildcardUtilTest.java
+++ b/node/impl/src/test/java/eu/cloudnetservice/node/impl/util/WildcardUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/node/impl/src/test/resources/logback-test.xml
+++ b/node/impl/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/luckperms/build.gradle.kts
+++ b/plugins/luckperms/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/BukkitLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/BukkitLuckPermsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/BungeecordLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/BungeecordLuckPermsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/CloudNetContextCalculator.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/CloudNetContextCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/FabricLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/FabricLuckPermsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/NukkitLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/NukkitLuckPermsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/SpongeLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/SpongeLuckPermsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/VelocityLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/VelocityLuckPermsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/WaterDogLuckPermsPlugin.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/WaterDogLuckPermsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/papi-expansion/build.gradle.kts
+++ b/plugins/papi-expansion/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
+++ b/plugins/papi-expansion/src/main/java/eu/cloudnetservice/plugins/papi/CloudNetPapiExpansion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/build.gradle.kts
+++ b/utils/base/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/ClassAllocationUtil.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/ClassAllocationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/CodeGenerationUtil.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/CodeGenerationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/StringUtil.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/StringUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/column/ColumnEntry.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/column/ColumnEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/column/ColumnFormatter.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/column/ColumnFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/column/RowedFormatter.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/column/RowedFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/concurrent/CountingTask.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/concurrent/CountingTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/concurrent/ListenableTask.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/concurrent/ListenableTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/concurrent/TaskUtil.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/concurrent/TaskUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/FileUtil.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/FileUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/ListenableOutputStream.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/ListenableOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/LogOutputStream.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/LogOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/ZipUtil.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/io/ZipUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/resource/CpuUsageResolver.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/resource/CpuUsageResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/resource/ResourceFormatter.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/resource/ResourceFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/main/java/eu/cloudnetservice/utils/base/resource/ResourceResolver.java
+++ b/utils/base/src/main/java/eu/cloudnetservice/utils/base/resource/ResourceResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/ClassAllocationUtilTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/ClassAllocationUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/StringUtilTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/StringUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/column/ColumnTextFormatterTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/column/ColumnTextFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/column/RowedFormatterTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/column/RowedFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/concurrent/CompletedTaskTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/concurrent/CompletedTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/concurrent/CountingTaskTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/concurrent/CountingTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/concurrent/ListenableTaskTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/concurrent/ListenableTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/concurrent/TaskUtilTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/concurrent/TaskUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/io/ZipUtilTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/io/ZipUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/resource/CpuUsageResolverTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/resource/CpuUsageResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/resource/ResourceFormatterTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/resource/ResourceFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/base/src/test/java/eu/cloudnetservice/utils/base/resource/ResourceResolverTest.java
+++ b/utils/base/src/test/java/eu/cloudnetservice/utils/base/resource/ResourceResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/api/build.gradle.kts
+++ b/wrapper-jvm/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/configuration/WrapperConfiguration.java
+++ b/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/configuration/WrapperConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPostStartEvent.java
+++ b/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPostStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPreStartEvent.java
+++ b/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/event/ApplicationPreStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/event/ServiceInfoPropertiesConfigureEvent.java
+++ b/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/event/ServiceInfoPropertiesConfigureEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/event/ServiceInfoSnapshotPublishEvent.java
+++ b/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/event/ServiceInfoSnapshotPublishEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/holder/ServiceInfoHolder.java
+++ b/wrapper-jvm/api/src/main/java/eu/cloudnetservice/wrapper/holder/ServiceInfoHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/build.gradle.kts
+++ b/wrapper-jvm/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/ApplicationThread.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/ApplicationThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Main.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Premain.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Premain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/ShutdownHandler.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/ShutdownHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Wrapper.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/configuration/DocumentWrapperConfiguration.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/configuration/DocumentWrapperConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/database/WrapperDatabase.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/database/WrapperDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/database/WrapperDatabaseProvider.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/database/WrapperDatabaseProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/holder/WrapperServiceInfoHolder.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/holder/WrapperServiceInfoHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/inject/BootFactories.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/inject/BootFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/inject/RPCFactories.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/inject/RPCFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/NetworkClientChannelHandler.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/NetworkClientChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/chunk/TemplateStorageCallbackListener.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/chunk/TemplateStorageCallbackListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/AuthorizationPacketListener.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/AuthorizationPacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/ChannelMessagePacketListener.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/ChannelMessagePacketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/message/GroupChannelMessageListener.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/message/GroupChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/message/ServiceChannelMessageListener.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/message/ServiceChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/message/TaskChannelMessageListener.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/network/listener/message/TaskChannelMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/provider/WrapperCloudMessenger.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/provider/WrapperCloudMessenger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/provider/WrapperTemplateStorageProvider.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/provider/WrapperTemplateStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/ClassTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/ClassTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/ClassTransformerRegistry.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/ClassTransformerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/DefaultClassTransformerRegistry.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/DefaultClassTransformerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/asm/AsmClassReaderTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/asm/AsmClassReaderTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/BukkitJavaVersionCheckTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/BukkitJavaVersionCheckTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/FAWEConfigTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/FAWEConfigTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/FAWEReflectionUtilsTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/FAWEReflectionUtilsTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/FAWEWorldEditDownloadURLTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/FAWEWorldEditDownloadURLTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/PaperConfigTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/PaperConfigTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/WorldEditJava8DetectorTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/bukkit/WorldEditJava8DetectorTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/netty/ConditionalUnsafeDisableTransform.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/netty/ConditionalUnsafeDisableTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/netty/OldEpollDisableTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/netty/OldEpollDisableTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/spark/OldAsyncProfilerDisableTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/spark/OldAsyncProfilerDisableTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/ArrayOps.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/ArrayOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/FieldAccessor.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/FieldAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/FieldOffsetOps.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/FieldOffsetOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/MemoryControlOps.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/MemoryControlOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/MemoryOps.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/MemoryOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/OpConstants.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/OpConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeLogUtil.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeLogUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacement.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDefiner.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDefiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegate.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementMapping.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeTransformer.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeUsageTraceLogger.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeUsageTraceLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/ValueTypeKind.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/ValueTypeKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/util/SourceProvidingMethodTransform.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/transform/util/SourceProvidingMethodTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/resources/META-INF/services/eu.cloudnetservice.wrapper.impl.transform.ClassTransformer
+++ b/wrapper-jvm/impl/src/main/resources/META-INF/services/eu.cloudnetservice.wrapper.impl.transform.ClassTransformer
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/resources/META-INF/services/org.jboss.shrinkwrap.resolver.spi.format.FormatProcessor
+++ b/wrapper-jvm/impl/src/main/resources/META-INF/services/org.jboss.shrinkwrap.resolver.spi.format.FormatProcessor
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/resources/lang/en_US.properties
+++ b/wrapper-jvm/impl/src/main/resources/lang/en_US.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2024 CloudNetService team & contributors
+# Copyright 2019-present CloudNetService team & contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/main/resources/logback.xml
+++ b/wrapper-jvm/impl/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/ClassWithFields.java
+++ b/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/ClassWithFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeLogUtilTest.java
+++ b/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeLogUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegateTest.java
+++ b/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementMappingTest.java
+++ b/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeReplacementMappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeTransformerTest.java
+++ b/wrapper-jvm/impl/src/test/java/eu/cloudnetservice/wrapper/impl/transform/unsafe/UnsafeTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 CloudNetService team & contributors
+ * Copyright 2019-present CloudNetService team & contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wrapper-jvm/impl/src/test/resources/logback-test.xml
+++ b/wrapper-jvm/impl/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019-2024 CloudNetService team & contributors
+  ~ Copyright 2019-present CloudNetService team & contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Motivation
The copyright headers are still using 2024 as the year and we should update.

### Modification
Replace 2024 in copyright year with present to always be up-to-date.

### Result
The copyright headers are up-to-date.
