### PR TITLE
chore: remove unused web host question from setup

### DIFF
--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultConfigSetup.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/setup/DefaultConfigSetup.java
@@ -126,15 +126,6 @@ public class DefaultConfigSetup extends DefaultClusterSetup {
           .possibleResults(addresses.stream().map(addr -> addr + ":1410").toList())
           .parser(this.parsers.assignableHostAndPort(true)))
         .build(),
-      // web server host
-      QuestionListEntry.<HostAndPort>builder()
-        .key("webHost")
-        .translatedQuestion("cloudnet-init-setup-web-host")
-        .answerType(QuestionAnswerType.<HostAndPort>builder()
-          .recommendation(NetworkUtil.localAddress() + ":2812")
-          .possibleResults(addresses.stream().map(addr -> addr + ":2812").toList())
-          .parser(this.parsers.assignableHostAndPort(true)))
-        .build(),
       // service bind host address
       QuestionListEntry.<HostAndPort>builder()
         .key("hostAddress")

--- a/node/impl/src/main/resources/lang/de_DE.properties
+++ b/node/impl/src/main/resources/lang/de_DE.properties
@@ -30,7 +30,6 @@ cloudnet-init-setup-tasks-server-environment=Was soll das Environment des Servic
 cloudnet-init-setup-tasks-server-version=Welche Service Version soll auf den Services laufen?
 cloudnet-init-setup-tasks-should-install-proxy=Soll ein Standard-Proxy erstellt werden?
 cloudnet-init-setup-tasks-should-install-server=Soll eine Standard-Lobby erstellt werden?
-cloudnet-init-setup-web-host=Auf welchem Host und Port soll der CloudNet Webserver laufen?
 cloudnet-init-default-modules=Welche Standardmodule sollen installiert werden? (durch Leerzeichen getrennt)
 #
 # Console animations

--- a/node/impl/src/main/resources/lang/en_US.properties
+++ b/node/impl/src/main/resources/lang/en_US.properties
@@ -30,7 +30,6 @@ cloudnet-init-setup-tasks-server-environment=What should be the environment of t
 cloudnet-init-setup-tasks-server-version=Which ServiceVersion should be used on the services?
 cloudnet-init-setup-tasks-should-install-proxy=Should a default proxy be created?
 cloudnet-init-setup-tasks-should-install-server=Should a default lobby be created?
-cloudnet-init-setup-web-host=On which host and port should CloudNet's WebServer run?
 cloudnet-init-default-modules=Which default modules should be installed? (separated by a space)
 #
 # Console animations


### PR DESCRIPTION
### Motivation
The web host question in the default setup is obsolete and no longer serves and purpose.

### Modification
Remove the web host question from the default setup.

### Result
No more obsolete questions in the default setup.
