### PR TITLE
[ci skip] docs: push repo readme as dockerhub description

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -71,3 +71,11 @@ jobs:
             BRANCH=${{ github.ref_name }}
             VERSION=${{ steps.resolve_variables.outputs.version }}
             CREATED=${{ steps.resolve_variables.outputs.build_time }}
+
+      - name: Update Dockerhub Description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "cloudnetservice/cloudnet"
+          enable-url-completion: true

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ just append the `-SNAPSHOT` suffix to the version.
 - [General Discussion](https://github.com/CloudNetService/CloudNet-v3/discussions)
 - [Latest Release](https://github.com/CloudNetService/CloudNet-v3/releases/latest)
 - [SpigotMC](https://www.spigotmc.org/resources/42059)
+- [Dockerhub](https://hub.docker.com/r/cloudnetservice/cloudnet)
 
 ## Compile from source
 


### PR DESCRIPTION
### Motivation
The current readme should link to our published image on dockerhub and should be included as the description of the image on dockerhub as well.

### Modification
Add Dockerhub url to readme, push readme as Dockerhub description.

### Result
The readme contains a link to our Dockerhub and the readme is published as the Dockerhub description when a new image is pushed.