### PR TITLE
fix: register outgoing labymod plugin channel

### DIFF
--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitNPCPlugin.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitNPCPlugin.java
@@ -28,6 +28,7 @@ import eu.cloudnetservice.modules.npc.impl.platform.bukkit.listener.BukkitWorldL
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
+import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -65,6 +66,11 @@ public final class BukkitNPCPlugin implements PlatformEntrypoint {
   @Inject
   private void registerNPCManagement() {
     this.npcManagement.initialize();
+  }
+
+  @Inject
+  private void registerChannels(@NonNull Server server, @NonNull Plugin plugin) {
+    server.getMessenger().registerOutgoingPluginChannel(plugin, "labymod:neo");
   }
 
   @Inject

--- a/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitNPCPlugin.java
+++ b/modules/npcs/impl/src/main/java/eu/cloudnetservice/modules/npc/impl/platform/bukkit/BukkitNPCPlugin.java
@@ -69,7 +69,7 @@ public final class BukkitNPCPlugin implements PlatformEntrypoint {
   }
 
   @Inject
-  private void registerChannels(@NonNull Server server, @NonNull Plugin plugin) {
+  private void registerLabyModPluginChannel(@NonNull Server server, @NonNull Plugin plugin) {
     server.getMessenger().registerOutgoingPluginChannel(plugin, "labymod:neo");
   }
 


### PR DESCRIPTION
### Motivation
We need to register the labymod:neo channel in order to send outgoing messages to labymod clients so that npc emotes can be displayed.

### Modification
Registered the labymod:neo channel.

### Result
Emotes are shown correctly.