### PR TITLE
fix: onlinePlayerAsync method name

### DIFF
--- a/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
+++ b/modules/bridge/api/src/main/java/eu/cloudnetservice/modules/bridge/player/PlayerManager.java
@@ -271,7 +271,7 @@ public interface PlayerManager {
    * @throws NullPointerException if the given unique id is null.
    */
   @NonNull
-  CompletableFuture<CloudPlayer> onlinePlayersAsync(@NonNull UUID uniqueId);
+  CompletableFuture<CloudPlayer> onlinePlayerAsync(@NonNull UUID uniqueId);
 
   /**
    * Gets the first cloud player that is online and has the given case-insensitive name asynchronously.

--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerManager.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/node/player/NodePlayerManager.java
@@ -289,7 +289,7 @@ public class NodePlayerManager implements PlayerManager {
   }
 
   @Override
-  public @NonNull CompletableFuture<CloudPlayer> onlinePlayersAsync(@NonNull UUID uniqueId) {
+  public @NonNull CompletableFuture<CloudPlayer> onlinePlayerAsync(@NonNull UUID uniqueId) {
     return TaskUtil.supplyAsync(() -> this.onlinePlayer(uniqueId));
   }
 


### PR DESCRIPTION
### Motivation
The `onlinePlayerAsync` method was accidentially renamed to `onlinePlayersAsync`, this should be reverted.

### Modification
Rename `onlinePlayersAsync` to `onlinePlayerAsync`.

### Result
The method has the correct name again.

