### PR TITLE
fix: depend on official cloud dependencies in node-api

### DIFF
--- a/node/api/build.gradle.kts
+++ b/node/api/build.gradle.kts
@@ -21,5 +21,5 @@ plugins {
 
 dependencies {
   api(projects.driver.driverApi)
-  compileOnlyApi(libs.bundles.cloud)
+  compileOnlyApi(libs.bundles.cloudApi)
 }

--- a/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/EnableConfirmSkipFlag.java
+++ b/node/api/src/main/java/eu/cloudnetservice/node/command/annotation/EnableConfirmSkipFlag.java
@@ -24,13 +24,11 @@ import java.lang.annotation.Target;
 import lombok.NonNull;
 
 /**
- * This annotation allows users to skip the required confirmation
- * {@link org.incendo.cloud.processors.confirmation.annotation.Confirmation} of a command. When this annotation is
- * applied to a method a flag is implicitly appended to the command which can be used to skip the confirmation.
+ * This annotation allows users to skip the required confirmation of a command. When this annotation is applied to a
+ * method a flag is implicitly appended to the command which can be used to skip the confirmation.
  * <p>
  * The annotations value is used as the flag name, which defaults to {@code confirm}.
  *
- * @see org.incendo.cloud.processors.confirmation.annotation.Confirmation
  * @since 4.0
  */
 @Documented


### PR DESCRIPTION
### Motivation
The node-api currently depends on our custom cloud fork which is not ideal as it requires an additional repository to be defined when using the dependency with gradle.

### Modification
Use the official cloud-api in the node-api module (changes in our fork are only implementation details).

### Result
The node-api can be used without specifying additional repositories.
