### PR TITLE
feat: print log message of force stopped services to debug

### DIFF
--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/Node.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/Node.java
@@ -55,6 +55,7 @@ import eu.cloudnetservice.node.impl.module.updater.ModuleUpdater;
 import eu.cloudnetservice.node.impl.module.updater.ModuleUpdaterRegistry;
 import eu.cloudnetservice.node.impl.network.chunk.FileDeployCallbackListener;
 import eu.cloudnetservice.node.impl.network.chunk.FileQueryChannelMessageListener;
+import eu.cloudnetservice.node.impl.service.defaults.log.ServiceWatchdogListener;
 import eu.cloudnetservice.node.impl.setup.DefaultInstallation;
 import eu.cloudnetservice.node.impl.template.LocalTemplateStorage;
 import eu.cloudnetservice.node.impl.tick.DefaultShutdownHandler;
@@ -484,6 +485,7 @@ public final class Node {
     eventManager.registerListener(callbackListener);
     eventManager.callEvent(new CloudNetNodePostInitializationEvent());
     eventManager.registerListener(FileQueryChannelMessageListener.class);
+    eventManager.registerListener(ServiceWatchdogListener.class);
 
     // notify that we are done & start the main tick loop
     LOGGER.info(i18n.translate("start-done", Duration.between(startInstant, Instant.now()).toMillis()));

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/DefaultCloudServiceManager.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/DefaultCloudServiceManager.java
@@ -51,7 +51,6 @@ import eu.cloudnetservice.node.impl.service.defaults.config.VanillaServiceConfig
 import eu.cloudnetservice.node.impl.service.defaults.config.VelocityConfigurationPreparer;
 import eu.cloudnetservice.node.impl.service.defaults.config.WaterdogPEConfigurationPreparer;
 import eu.cloudnetservice.node.impl.service.defaults.factory.JVMLocalCloudServiceFactory;
-import eu.cloudnetservice.node.impl.service.defaults.log.ServiceWatchdogListener;
 import eu.cloudnetservice.node.impl.service.defaults.provider.EmptySpecificCloudServiceProvider;
 import eu.cloudnetservice.node.impl.service.defaults.provider.RemoteNodeCloudServiceProvider;
 import eu.cloudnetservice.node.service.CloudService;
@@ -193,8 +192,6 @@ public class DefaultCloudServiceManager implements InternalCloudServiceManager {
       }
       return null;
     }, Duration.ofMillis(SERVICE_WATCHDOG_INTERVAL_MILLIS));
-
-    eventManager.registerListener(ServiceWatchdogListener.class);
   }
 
   @Override

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/DefaultCloudServiceManager.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/DefaultCloudServiceManager.java
@@ -88,9 +88,8 @@ import org.slf4j.LoggerFactory;
 @Provides({InternalCloudServiceManager.class, CloudServiceManager.class, CloudServiceProvider.class})
 public class DefaultCloudServiceManager implements InternalCloudServiceManager {
 
-  protected static final int SERVICE_WATCHDOG_INTERVAL_MILLIS = Integer.getInteger(
-    "cloudnet.service-watchdog-interval",
-    1000);
+  protected static final int SERVICE_WATCHDOG_INTERVAL_MILLIS =
+    Integer.getInteger("cloudnet.service-watchdog-interval-millis", 1000);
 
   protected static final Path TEMP_SERVICE_DIR = Path.of(
     System.getProperty("cloudnet.tempDir.services", "temp/services"));

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/DefaultCloudServiceManager.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/DefaultCloudServiceManager.java
@@ -51,13 +51,14 @@ import eu.cloudnetservice.node.impl.service.defaults.config.VanillaServiceConfig
 import eu.cloudnetservice.node.impl.service.defaults.config.VelocityConfigurationPreparer;
 import eu.cloudnetservice.node.impl.service.defaults.config.WaterdogPEConfigurationPreparer;
 import eu.cloudnetservice.node.impl.service.defaults.factory.JVMLocalCloudServiceFactory;
+import eu.cloudnetservice.node.impl.service.defaults.log.ServiceWatchdogListener;
 import eu.cloudnetservice.node.impl.service.defaults.provider.EmptySpecificCloudServiceProvider;
 import eu.cloudnetservice.node.impl.service.defaults.provider.RemoteNodeCloudServiceProvider;
-import eu.cloudnetservice.node.impl.tick.DefaultTickLoop;
 import eu.cloudnetservice.node.service.CloudService;
 import eu.cloudnetservice.node.service.CloudServiceManager;
 import eu.cloudnetservice.node.service.LocalCloudServiceFactory;
 import eu.cloudnetservice.node.service.ServiceConfigurationPreparer;
+import eu.cloudnetservice.node.tick.Scheduler;
 import eu.cloudnetservice.utils.base.concurrent.TaskUtil;
 import io.vavr.Tuple2;
 import jakarta.inject.Inject;
@@ -88,6 +89,10 @@ import org.slf4j.LoggerFactory;
 @Provides({InternalCloudServiceManager.class, CloudServiceManager.class, CloudServiceProvider.class})
 public class DefaultCloudServiceManager implements InternalCloudServiceManager {
 
+  protected static final int SERVICE_WATCHDOG_INTERVAL_MILLIS = Integer.getInteger(
+    "cloudnet.service-watchdog-interval",
+    1000);
+
   protected static final Path TEMP_SERVICE_DIR = Path.of(
     System.getProperty("cloudnet.tempDir.services", "temp/services"));
   protected static final Path PERSISTENT_SERVICE_DIR = Path.of(
@@ -117,7 +122,6 @@ public class DefaultCloudServiceManager implements InternalCloudServiceManager {
 
   @Inject
   public DefaultCloudServiceManager(
-    @NonNull DefaultTickLoop mainThread,
     @NonNull RPCFactory rpcFactory,
     @NonNull EventManager eventManager,
     @NonNull DataSyncRegistry dataSyncRegistry,
@@ -170,9 +174,16 @@ public class DefaultCloudServiceManager implements InternalCloudServiceManager {
         })
         .currentGetter(group -> this.serviceProviderByName(group.name()).serviceInfo())
         .build());
+  }
 
-    // schedule the service watchdog to run once per second
-    mainThread.scheduleTask(() -> {
+  @Inject
+  private void registerDefaultServiceFactory() {
+    this.addCloudServiceFactory("jvm", JVMLocalCloudServiceFactory.class);
+  }
+
+  @Inject
+  private void scheduleWatchdog(@NonNull Scheduler scheduler, @NonNull EventManager eventManager) {
+    scheduler.scheduleTask(() -> {
       for (var service : this.localCloudServices()) {
         if (service.lifeCycle() == ServiceLifeCycle.RUNNING && !service.alive()) {
           eventManager.callEvent(new CloudServicePreForceStopEvent(service));
@@ -181,12 +192,9 @@ public class DefaultCloudServiceManager implements InternalCloudServiceManager {
         }
       }
       return null;
-    }, Duration.ofMillis(DefaultTickLoop.MILLIS_BETWEEN_TICKS));
-  }
+    }, Duration.ofMillis(SERVICE_WATCHDOG_INTERVAL_MILLIS));
 
-  @Inject
-  private void registerDefaultServiceFactory() {
-    this.addCloudServiceFactory("jvm", JVMLocalCloudServiceFactory.class);
+    eventManager.registerListener(ServiceWatchdogListener.class);
   }
 
   @Override

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ServiceWatchdogListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ServiceWatchdogListener.java
@@ -19,6 +19,7 @@ package eu.cloudnetservice.node.impl.service.defaults.log;
 import eu.cloudnetservice.driver.event.EventListener;
 import eu.cloudnetservice.node.event.service.CloudServicePreForceStopEvent;
 import jakarta.inject.Singleton;
+import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,8 +28,8 @@ import org.slf4j.LoggerFactory;
 public final class ServiceWatchdogListener {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceWatchdogListener.class);
-  private static final int SERVICE_LOG_THRESHOLD_MILLIS =
-    Integer.getInteger("cloudnet.service-watchdog-threshold", 5) * 1000;
+  private static final long SERVICE_LOG_THRESHOLD_MILLIS =
+    TimeUnit.SECONDS.toMillis(Integer.getInteger("cloudnet.service-watchdog-threshold-seconds", 5));
 
   @EventListener
   private void handleCloudServicePreForceStop(@NonNull CloudServicePreForceStopEvent event) {

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ServiceWatchdogListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ServiceWatchdogListener.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019-present CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.node.impl.service.defaults.log;
+
+import eu.cloudnetservice.driver.event.EventListener;
+import eu.cloudnetservice.node.event.service.CloudServicePreForceStopEvent;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public final class ServiceWatchdogListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceWatchdogListener.class);
+  private static final int SERVICE_LOG_THRESHOLD_MILLIS =
+    Integer.getInteger("cloudnet.service-watchdog-threshold", 5) * 1000;
+
+  @EventListener
+  private void handleCloudServicePreForceStop(@NonNull CloudServicePreForceStopEvent event) {
+    var connectionTime = event.serviceInfo().connectedTime();
+    if (System.currentTimeMillis() - connectionTime < SERVICE_LOG_THRESHOLD_MILLIS) {
+      for (var cachedLogMessage : event.service().cachedLogMessages()) {
+        LOGGER.debug("[{} - Watchdog] {}", event.serviceInfo().name(), cachedLogMessage);
+      }
+    }
+  }
+}

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ServiceWatchdogListener.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ServiceWatchdogListener.java
@@ -33,9 +33,13 @@ public final class ServiceWatchdogListener {
   @EventListener
   private void handleCloudServicePreForceStop(@NonNull CloudServicePreForceStopEvent event) {
     var connectionTime = event.serviceInfo().connectedTime();
-    if (System.currentTimeMillis() - connectionTime < SERVICE_LOG_THRESHOLD_MILLIS) {
+    if (SERVICE_LOG_THRESHOLD_MILLIS <= 0) {
+      return;
+    }
+
+    if (connectionTime == -1 || System.currentTimeMillis() - connectionTime < SERVICE_LOG_THRESHOLD_MILLIS) {
       for (var cachedLogMessage : event.service().cachedLogMessages()) {
-        LOGGER.debug("[{} - Watchdog] {}", event.serviceInfo().name(), cachedLogMessage);
+        LOGGER.debug("[{}/WATCHDOG] {}", event.serviceInfo().name(), cachedLogMessage);
       }
     }
   }


### PR DESCRIPTION
### Motivation
Some service software like velocity tend to crash / stop on a wrong configuration file without printing any warning message. CloudNet does not pick them up and report them anywere thus it is hard for a user to debug why the service is constantly stopping and the user needs to rely on great timing to see something in the screen.

### Modification
Add a listener on the existing CloudServicePreForceStopEvent that prints the cached log lines from a service when its killed.
Printing is only done when the feature is not deactivated (set `cloudnet.service-watchdog-threshold` to <= 0) and the service is only living for the seconds specified in `cloudnet.service-watchdog-threshold` .

Also the watchdog now only runs every second like it was intended to instead of every tick. Configurable using `cloudnet.service-watchdog-interval` (millis between to watchdog runs)

### Result
Easy debugging for non warn related stop / kills of services.