### PR TITLE
chore: replace usages of ThreadFactoryBuilder

### DIFF
--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyUtil.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/NettyUtil.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.driver.impl.network.netty;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import eu.cloudnetservice.driver.DriverEnvironment;
 import eu.cloudnetservice.driver.impl.network.scheduler.NetworkTaskScheduler;
 import eu.cloudnetservice.driver.impl.network.scheduler.ScalingNetworkTaskScheduler;
@@ -35,7 +34,6 @@ import io.netty5.handler.ssl.OpenSsl;
 import io.netty5.handler.ssl.SslProvider;
 import io.netty5.util.ResourceLeakDetector;
 import io.netty5.util.concurrent.DefaultThreadFactory;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
@@ -128,11 +126,12 @@ public final class NettyUtil {
     var defaultEnvThreadCount = driverEnvironment.equals(DriverEnvironment.NODE) ? 12 : 4;
     var maximumPoolSize = overriddenCountOrDefault(PACKET_DISPATCH_THREADS, defaultEnvThreadCount);
 
-    var threadFactory = new ThreadFactoryBuilder()
-      .setDaemon(true)
-      .setNameFormat("CloudNet-Packet-Dispatcher-%d")
-      .setThreadFactory(Executors.defaultThreadFactory())
-      .build();
+    var threadFactory = Thread.ofPlatform()
+      .daemon(true)
+      .priority(Thread.NORM_PRIORITY)
+      .inheritInheritableThreadLocals(true)
+      .name("CloudNet-Packet-Dispatcher-", 0L)
+      .factory();
     return new ScalingNetworkTaskScheduler(threadFactory, maximumPoolSize);
   }
 

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ProcessServiceLogReadScheduler.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/log/ProcessServiceLogReadScheduler.java
@@ -16,7 +16,6 @@
 
 package eu.cloudnetservice.node.impl.service.defaults.log;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import jakarta.inject.Singleton;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -35,11 +34,12 @@ public final class ProcessServiceLogReadScheduler {
   private final ScheduledThreadPoolExecutor executor;
 
   public ProcessServiceLogReadScheduler() {
-    var threadFactory = new ThreadFactoryBuilder()
-      .setDaemon(true)
-      .setPriority(Thread.NORM_PRIORITY)
-      .setNameFormat("process-log-reader-%d")
-      .build();
+    var threadFactory = Thread.ofPlatform()
+      .daemon(true)
+      .priority(Thread.NORM_PRIORITY)
+      .inheritInheritableThreadLocals(true)
+      .name("process-log-reader-", 0L)
+      .factory();
     this.executor = new ScheduledThreadPoolExecutor(1, threadFactory, new ThreadPoolExecutor.DiscardPolicy());
     this.runningReaderActions = new AtomicInteger(0);
   }

--- a/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Main.java
+++ b/wrapper-jvm/impl/src/main/java/eu/cloudnetservice/wrapper/impl/Main.java
@@ -17,7 +17,6 @@
 package eu.cloudnetservice.wrapper.impl;
 
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import eu.cloudnetservice.driver.inject.InjectionLayer;
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.wrapper.impl.transform.ClassTransformerRegistry;
@@ -53,10 +52,12 @@ public final class Main {
     bootInjectLayer.install(builder.bind(org.slf4j.Logger.class).qualifiedWithName("root").toInstance(rootLogger));
     bootInjectLayer.install(builder.bind(Instant.class).qualifiedWithName("startInstant").toInstance(startInstant));
 
-    var threadFactory = new ThreadFactoryBuilder()
-      .setDaemon(true)
-      .setNameFormat("CloudNet-TaskScheduler-Thread-%d")
-      .build();
+    var threadFactory = Thread.ofPlatform()
+      .daemon(true)
+      .priority(Thread.NORM_PRIORITY)
+      .inheritInheritableThreadLocals(true)
+      .name("CloudNet-TaskScheduler-Thread-", 0L)
+      .factory();
     bootInjectLayer.install(builder
       .bind(ScheduledExecutorService.class)
       .qualifiedWithName("taskScheduler")


### PR DESCRIPTION
### Motivation
Currently, ThreadFactoryBuilder is used in a lot of places but these uses can all be replaced by the new thread builder.

### Modification
Replace uses of ThreadFactoryBuilder with the new thread builder api.

### Result
No more uses of ThreadFactoryBuilder.
