### PR TITLE
chore: switch to custom published netty version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,7 +56,6 @@
       "description": "Dependencies whose updates shouldn't be done automatically",
       "matchPackageNames": [
         "azul/zulu-openjdk", // we update our target java version manually
-        "io.netty:**", // disabled until a stable version was released
         "com.h2database:h2", // breaks old database files & support will be removed in a future release anyway
         "cpw.mods:modlauncher", // can be removed when sponge updated to v9
         "org.spongepowered:spongeapi", // we want to leave the oldest version we support as the dependency

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ dockerJava = "3.6.0"
 nightConfig = "3.8.3"
 annotations = "26.0.2-1"
 influxClient = "7.3.0"
-netty = "5.0.0.Alpha6-SNAPSHOT"
+netty = "2025.11.08-3a259e91"
 
 # logging
 slf4j = "2.0.17"


### PR DESCRIPTION
### Motivation
netty 5 isn't currently published actively to any repository, therefore we have to do it ourself to get and up-to-date version.

### Modification
Switch the netty 5 version to our custom releases published to repository.derklaro.dev and allow renovate to update the version in the future.

### Result
Up-to-date netty release versions in cloudnet.
