### PR TITLE
chore: update npc-lib to 3.0.0-beta.16

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ limboloohp = "0.7.9-ALPHA"
 # platform extensions
 adventure = "4.25.0"
 modlauncher = "8.1.3"
-npcLib = "3.0.0-beta.15"
+npcLib = "3.0.0-beta.16"
 packetEvents = "2.10.0"
 placeholderApi = "2.11.6"
 adventure-serializer-bungee = "4.4.1"

--- a/modules/npcs/impl/build.gradle.kts
+++ b/modules/npcs/impl/build.gradle.kts
@@ -34,7 +34,6 @@ repositories {
       includeGroup("com.github.retrooper")
     }
   }
-  maven("https://repo.papermc.io/repository/maven-public/")
   maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
 }
 
@@ -63,7 +62,6 @@ tasks.shadowJar.configure {
   archiveFileName = Files.npcs
 
   relocate("net.kyori", "eu.cloudnetservice.modules.npc.relocate.net.kyori")
-  relocate("io.papermc.lib", "eu.cloudnetservice.modules.npc.relocate.paperlib")
   relocate("io.leangen.geantyref", "eu.cloudnetservice.modules.npc.relocate.geantyref")
   relocate("io.github.retrooper", "eu.cloudnetservice.modules.npc.relocate.io.packetevents")
   relocate("com.github.retrooper", "eu.cloudnetservice.modules.npc.relocate.com.packetevents")


### PR DESCRIPTION
### Motivation
npc-lib beta.16 was released which removes the dependency on PaperLib. This is a critical bug fix, as PaperLib failed to parse multi-digit patch versions (`1.21.10` was parsed as `1.21.1`) resulting in wrong metadata indexes being sent to the player. This resulted in players being kicked with the error:
```
[Render thread/ERROR]: Failed to handle packet class_2739[id=98476749, packedItems=[class_7834[id=17, serializer=net.minecraft.class_2941$$Lambda/0x0000000097c3bc00@13bf0814, value=-1]]], disconnecting
java.lang.IllegalStateException: Invalid entity data item type for field 17 on entity class_745['fa7fe3ebc186d5e4'/98476749, l='ClientLevel', x=16.01, y=76.92, z=17.51]: old=0.0(class java.lang.Float), new=-1(class java.lang.Byte)
```

### Modification
Update the npc-lib dependency to beta.16.

### Result
The latest npc lib version is in use which works as expected on 1.21.10 servers.
