### PR TITLE
chore: properly override jvm language to ensure javadoc language is english

### DIFF
--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
@@ -157,6 +157,7 @@ fun applyJavadocOptions(options: StandardJavadocDocletOptions) {
   options.memberLevel = JavadocMemberLevel.PRIVATE
   options.addBooleanOption("quiet", true)
   options.addBooleanOption("-enable-preview", true)
+  options.jFlags("-Duser.language=en", "-Duser.country=US")
   options.addBooleanOption("Xdoclint:all,-missing", true)
   options.addStringOption("-link-modularity-mismatch", "info")
 }

--- a/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
+++ b/build-extensions/src/main/kotlin/eu/cloudnetservice/cloudnet/gradle/util/PublishingExtensions.kt
@@ -157,7 +157,7 @@ fun applyJavadocOptions(options: StandardJavadocDocletOptions) {
   options.memberLevel = JavadocMemberLevel.PRIVATE
   options.addBooleanOption("quiet", true)
   options.addBooleanOption("-enable-preview", true)
-  options.jFlags("-Duser.language=en", "-Duser.country=US")
   options.addBooleanOption("Xdoclint:all,-missing", true)
   options.addStringOption("-link-modularity-mismatch", "info")
+  options.jFlags("-Duser.language=en", "-Duser.country=US")
 }


### PR DESCRIPTION
### Motivation
JavaDoc generation should be in the english language

### Modification
Added a jFlag to the javadoc options to ensure the language is set properly

### Result
Generated JavaDocs are in the english language even if the environment is e.g. german
