### PR TITLE
build: improve gradle configuration and jvm options

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,8 @@ org.gradle.warning.mode=all
 org.gradle.logging.stacktrace=all
 org.gradle.configureondemand=true
 org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 org.gradle.configuration-cache.problems=fail
 org.gradle.configuration-cache.integrity-check=true
+org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,5 @@ org.gradle.configureondemand=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.configuration-cache.problems=fail
-org.gradle.configuration-cache.integrity-check=true
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
-org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=1G -Dfile.encoding=UTF-8


### PR DESCRIPTION
### Motivation
Our gradle configuration can be optimized a tiny bit by enabling parallel configuration cache and disabling integrity checks (these only really meant for debugging issues according to the gradle documentation). 

### Modification
* Enable parallel configuration cache
* Disable configuration cache integrity checks
* Enable treatment of all warnings in dsl scripts as errors
* Increase max memory for gradle runs to 4 gigabyte

### Result
Possibly more performant builds, smaller configuration cache size.
