### PR TITLE
fix: add server name to lp context if not otherwise configured

### DIFF
--- a/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/CloudNetContextCalculator.java
+++ b/plugins/luckperms/src/main/java/eu/cloudnetservice/plugins/luckperms/CloudNetContextCalculator.java
@@ -16,47 +16,64 @@
 
 package eu.cloudnetservice.plugins.luckperms;
 
+import eu.cloudnetservice.driver.service.ServiceConfiguration;
+import eu.cloudnetservice.driver.service.ServiceId;
 import eu.cloudnetservice.wrapper.configuration.WrapperConfiguration;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
+import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.context.ContextConsumer;
 import net.luckperms.api.context.ContextSet;
-import net.luckperms.api.context.MutableContextSet;
+import net.luckperms.api.context.DefaultContextKeys;
+import net.luckperms.api.context.ImmutableContextSet;
 import net.luckperms.api.context.StaticContextCalculator;
 
 @Singleton
-public class CloudNetContextCalculator implements StaticContextCalculator {
+public final class CloudNetContextCalculator implements StaticContextCalculator {
 
-  private final WrapperConfiguration wrapperConfiguration;
+  private final ServiceId serviceId;
+  private final ServiceConfiguration serviceConfiguration;
 
   @Inject
   public CloudNetContextCalculator(@NonNull WrapperConfiguration wrapperConfiguration) {
-    this.wrapperConfiguration = wrapperConfiguration;
+    this.serviceConfiguration = wrapperConfiguration.serviceConfiguration();
+    this.serviceId = this.serviceConfiguration.serviceId();
   }
 
-  private @NonNull ContextSet contextSet() {
-    var contextSet = MutableContextSet.create();
-    var serviceId = this.wrapperConfiguration.serviceConfiguration().serviceId();
-
-    contextSet.add("service", serviceId.name());
-    contextSet.add("service-uuid", serviceId.uniqueId().toString());
-    contextSet.add("task", serviceId.taskName());
-    contextSet.add("node", serviceId.nodeUniqueId());
-    contextSet.add("environment", serviceId.environmentName());
-    for (var group : this.wrapperConfiguration.serviceConfiguration().groups()) {
-      contextSet.add("group", group);
-    }
-    return contextSet;
-  }
-
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public void calculate(@NonNull ContextConsumer consumer) {
-    consumer.accept(this.contextSet());
+    consumer.accept("service", this.serviceId.name());
+    consumer.accept("service-uuid", this.serviceId.uniqueId().toString());
+    consumer.accept("task", this.serviceId.taskName());
+    consumer.accept("node", this.serviceId.nodeUniqueId());
+    consumer.accept("environment", this.serviceId.environmentName());
+    for (var group : this.serviceConfiguration.groups()) {
+      consumer.accept("group", group);
+    }
+
+    // also add the server key to the context. the key is required as it's used when calculating
+    // the location of the player within the network, not setting it results in the full context
+    // set being used as the location, which can lead to overflows in db columns. however, this
+    // is only applied when no server name is configured in the LuckPerms config already as we
+    // should respect the user configured value.
+    // https://github.com/LuckPerms/LuckPerms/blob/61ce546a041dff4c8e6c1ff6b9d33f4c2820bc85/common/src/main/java/me/lucko/luckperms/common/sender/Sender.java#L86
+    var lpConfiguredServerName = LuckPermsProvider.get().getServerName();
+    if (lpConfiguredServerName.equals("global")) {
+      consumer.accept(DefaultContextKeys.SERVER_KEY, this.serviceId.name());
+    }
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public @NonNull ContextSet estimatePotentialContexts() {
-    return this.contextSet();
+    var contexSetBuilder = ImmutableContextSet.builder();
+    this.calculate(contexSetBuilder::add);
+    return contexSetBuilder.build();
   }
 }


### PR DESCRIPTION
### Motivation
The server key is an essential part of the luckperms context calculation. By default, it is taken from the LuckPerms config file, however, if the default value `global` is left unchanged, the key isn't added to the context. However, we do know the current server name and are able to add it to the LuckPerms context.

### Modification
Add the server key holding the current service name to the luckperms context if the server name is not specified in the LuckPerms configuration file.

### Result
The server context key is correctly configured automatically by default. If the user wants to he can still change the value in the LuckPerms configuration to his needs.