### PR TITLE
build: increase retry resiliency for publishing

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Publish snapshot to central portal
-        if: ${{ github.event_name == 'push' && env.STATUS != 'release' }}
+        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') }}
         run: ./gradlew publish --no-daemon
         env:
           CENTRAL_USER: "${{ secrets.CENTRAL_USER }}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Publish snapshot to central portal
-        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') }}
+        if: ${{ github.event_name == 'push' && env.STATUS != 'release' }}
         run: ./gradlew publish --no-daemon
         env:
           CENTRAL_USER: "${{ secrets.CENTRAL_USER }}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,7 @@ org.gradle.configuration-cache.parallel=true
 org.gradle.configuration-cache.problems=fail
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=1G -Dfile.encoding=UTF-8
+
+# inreased retries and wait time for sonatype deploy (defaults: attempts=3, initial-backoff=1s)
+systemProp.org.gradle.internal.network.retry.max.attempts=4
+systemProp.org.gradle.internal.network.retry.initial.backOff=15000


### PR DESCRIPTION
### Motivation
Currently, the publish action fails due to ratelimits implemented by the sonatype central repository.

### Modification
Increase the retry count to 4 with an initial backoff of 15 seconds. The maximum wait time (fourth retry) will wait 120s.

### Result
No more publish failures due to rate limits from sonatype.
