### PR TITLE
build: add waterdog-snapshots repo to platform-inject-runtime

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Publish snapshot to central portal
-        if: ${{ github.event_name == 'push' && env.STATUS != 'release' }}
+        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') }}
         run: ./gradlew publish --no-daemon
         env:
           CENTRAL_USER: "${{ secrets.CENTRAL_USER }}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Publish snapshot to central portal
-        if: ${{ github.event_name == 'push' && env.STATUS != 'release' && startsWith(github.ref, 'refs/heads/nightly') }}
+        if: ${{ github.event_name == 'push' && env.STATUS != 'release' }}
         run: ./gradlew publish --no-daemon
         env:
           CENTRAL_USER: "${{ secrets.CENTRAL_USER }}"

--- a/ext/platform-inject-support/runtime/build.gradle.kts
+++ b/ext/platform-inject-support/runtime/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
 repositories {
   maven("https://repo.waterdog.dev/releases/")
+  maven("https://repo.waterdog.dev/snapshots/")
   maven("https://repo.loohpjames.com/repository")
   maven("https://repo.md-5.net/repository/releases/")
   maven("https://repo.md-5.net/repository/snapshots/")


### PR DESCRIPTION
### Motivation
The build currently fails due to a missing dependency for Yamler-Core which is provided by the waterdog snapshots repository. This repository is currently not added to the platform-inject-runtime module, causing the build to fail.

### Modification
Add the waterdog snapshots repo to the platform-inject-runtime module.

### Result
The build succeeds again.