### PR TITLE
fix: advanced format patterns in translation provider

### DIFF
--- a/driver/api/src/main/java/eu/cloudnetservice/driver/language/PropertiesTranslationProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/language/PropertiesTranslationProvider.java
@@ -43,8 +43,8 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class PropertiesTranslationProvider implements TranslationProvider {
 
-  // https://regex101.com/r/FaX3tj/1
-  private static final Pattern TRANSLATION_ARG_FORMAT_PATTERN = Pattern.compile("\\{(\\d+)\\$.+?\\$}");
+  // https://regex101.com/r/MIlVzv/1
+  private static final Pattern TRANSLATION_ARG_FORMAT_PATTERN = Pattern.compile("\\{(.+?)\\$.+?\\$}");
 
   // a lock that must be held when using a MessageFormat to format a translation
   // this is due to the fact that MessageFormats are not thread safe, but we don't expect

--- a/driver/api/src/main/java/eu/cloudnetservice/driver/language/PropertiesTranslationProvider.java
+++ b/driver/api/src/main/java/eu/cloudnetservice/driver/language/PropertiesTranslationProvider.java
@@ -43,8 +43,8 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class PropertiesTranslationProvider implements TranslationProvider {
 
-  // https://regex101.com/r/MIlVzv/1
-  private static final Pattern TRANSLATION_ARG_FORMAT_PATTERN = Pattern.compile("\\{(.+?)\\$.+?\\$}");
+  // https://regex101.com/r/Xs7lNp/1
+  private static final Pattern TRANSLATION_ARG_FORMAT_PATTERN = Pattern.compile("\\{(\\d+|\\d+,.+?)\\$.+?\\$}");
 
   // a lock that must be held when using a MessageFormat to format a translation
   // this is due to the fact that MessageFormats are not thread safe, but we don't expect

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/language/I18nTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/language/I18nTest.java
@@ -178,6 +178,7 @@ public class I18nTest {
   void testAdvancedMessageFormatPatternsArePickedUp() {
     var properties = new Properties();
     properties.put("1", "Hello {0$name$}, your status is {1, choice, 0#deactivated|1#active$status$}");
+    properties.put("2", "{0} {1$name$} {2,number,integer$an int$} {3,choice,0#hello|1#world|2#test$some description$}");
     var provider = PropertiesTranslationProvider.fromProperties(properties);
 
     var i18n = I18n.i18n();
@@ -185,5 +186,8 @@ public class I18nTest {
 
     Assertions.assertEquals("Hello Rob, your status is active", i18n.translate("1", "Rob", 1));
     Assertions.assertEquals("Hello Klaro, your status is deactivated", i18n.translate("1", "Klaro", 0));
+
+    Assertions.assertEquals("World Rob 56,789 test", provider.translate("2", "World", "Rob", 56789, 2));
+    Assertions.assertEquals("Hello World 1,234,568 world", provider.translate("2", "Hello", "World", 1234567.89, 1));
   }
 }

--- a/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/language/I18nTest.java
+++ b/driver/impl/src/test/java/eu/cloudnetservice/driver/impl/language/I18nTest.java
@@ -173,4 +173,17 @@ public class I18nTest {
     Assertions.assertEquals("<missing translation for 1 in en-US>", i18n.translate("1"));
     Assertions.assertEquals("<missing translation for 2 in en-US>", i18n.translate("2"));
   }
+
+  @Test
+  void testAdvancedMessageFormatPatternsArePickedUp() {
+    var properties = new Properties();
+    properties.put("1", "Hello {0$name$}, your status is {1, choice, 0#deactivated|1#active$status$}");
+    var provider = PropertiesTranslationProvider.fromProperties(properties);
+
+    var i18n = I18n.i18n();
+    i18n.registerProvider(i18n.selectedLanguage(), provider);
+
+    Assertions.assertEquals("Hello Rob, your status is active", i18n.translate("1", "Rob", 1));
+    Assertions.assertEquals("Hello Klaro, your status is deactivated", i18n.translate("1", "Klaro", 0));
+  }
 }


### PR DESCRIPTION
### Motivation
Advanced patterns for message formats are not processed correctly when combined with our custom argument naming.

### Modification
Improve the regex to allow for all message format patterns in combination with our custom naming format.

### Result
Advanced message format patterns are correctly displayed when used in our translation system.
