### PR TITLE
fix: avoid OOM caused by NULL pointer returned from malloc(0)

### DIFF
--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentAllocator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentAllocator.java
@@ -72,9 +72,9 @@ final class MemorySegmentAllocator {
    */
   public static @NonNull MemorySegment malloc(long byteCount) {
     try {
-      // on malloc(0), implementations of malloc(3) have the choice to return either NULL or a unique non-null pointer.
-      // to ensure that we always get a unique non-null pointer we allocate at least one byte
-      var segment = (MemorySegment) MALLOC.invokeExact(Math.max(byteCount, 1L));
+      // on malloc(0), implementations of malloc(3) have the choice to return either NULL or a unique non-null pointer
+      // to ensure that we always get a non-null pointer that we can pass to free(1) we allocate at least one byte
+      var segment = (MemorySegment) MALLOC.invokeExact(Math.max(1L, byteCount));
       validateAllocatedSegment(segment, byteCount);
       return segment.reinterpret(byteCount).fill((byte) 0);
     } catch (Throwable throwable) {

--- a/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentAllocator.java
+++ b/driver/impl/src/main/java/eu/cloudnetservice/driver/impl/network/netty/memory/MemorySegmentAllocator.java
@@ -72,7 +72,9 @@ final class MemorySegmentAllocator {
    */
   public static @NonNull MemorySegment malloc(long byteCount) {
     try {
-      var segment = (MemorySegment) MALLOC.invokeExact(byteCount);
+      // on malloc(0), implementations of malloc(3) have the choice to return either NULL or a unique non-null pointer.
+      // to ensure that we always get a unique non-null pointer we allocate at least one byte
+      var segment = (MemorySegment) MALLOC.invokeExact(Math.max(byteCount, 1L));
       validateAllocatedSegment(segment, byteCount);
       return segment.reinterpret(byteCount).fill((byte) 0);
     } catch (Throwable throwable) {


### PR DESCRIPTION
### Motivation
It's left to the implementations of malloc if a `malloc(0)` returns a NULL pointer or a non-null pointer. However, our validation logic checks if a NULL pointer is returned and treats it as an OOM.

### Modification
Always pass at least 1 to malloc, ensuring that we only get a NULL pointer if we're really out of memory.

### Result
No more OOM errors thrown because of `malloc(0)` calls returning a NULL pointer.
