### PR TITLE
feat: add templify module as 3rd-party module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -13,6 +13,20 @@
       ],
       "releaseNotes": [],
       "dependingModules": []
+    },
+    {
+      "official": false,
+      "name": "Templify",
+      "website": "https://github.com/whereareiam/Templify",
+      "version": "1.0.0",
+      "sha3256": "638fb559511563534a4affb908bb4161fd63164989b9a5ef1deb95e7c10875c8",
+      "description": "Module for pre-startup processing and modification of service templates before they are deployed",
+      "url": "https://github.com/whereareiam/Templify/releases/download/1.0.0/Templify-1.0.0.jar",
+      "maintainers": [
+        "whereareiam"
+      ],
+      "releaseNotes": [],
+      "dependingModules": []
     }
   ]
 }


### PR DESCRIPTION
### Motivation
As requested, the module was moved from the PR into a dedicated repository so it can be provided as a third-party module for CloudNet.

Closes #1814 

### Modification
Added a new entry to `modules.json` to register the module and provide its metadata.

### Result
The module is now available for download through the CloudNet module system.

