### PR TITLE
feat: add configurable port binding address for dockerized services

### DIFF
--- a/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerConfiguration.java
+++ b/modules/dockerized-services/api/src/main/java/eu/cloudnetservice/modules/docker/config/DockerConfiguration.java
@@ -38,8 +38,11 @@ public record DockerConfiguration(
   @Nullable String registryPassword,
   @Nullable String registryUrl,
   @Nullable String user,
-  @Nullable HostAndPort nodeHostOverride
+  @Nullable HostAndPort nodeHostOverride,
+  @Nullable String portBindAddress
 ) {
+
+  public static final String AUTO_PORT_BIND_ADDRESS = "auto";
 
   public static @NonNull Builder builder() {
     return new Builder();
@@ -59,7 +62,9 @@ public record DockerConfiguration(
       .registryEmail(configuration.registryEmail())
       .registryPassword(configuration.registryPassword())
       .registryUrl(configuration.registryUrl())
-      .user(configuration.user());
+      .user(configuration.user())
+      .nodeHostOverride(configuration.nodeHostOverride())
+      .portBindAddress(configuration.portBindAddress());
   }
 
   public static final class Builder {
@@ -82,6 +87,7 @@ public record DockerConfiguration(
 
     private String user;
     private HostAndPort nodeHostOverride;
+    private String portBindAddress;
 
     public @NonNull Builder javaImage(@NonNull DockerImage javaImage) {
       this.javaImage = javaImage;
@@ -168,6 +174,11 @@ public record DockerConfiguration(
       return this;
     }
 
+    public @NonNull Builder portBindAddress(@Nullable String portBindAddress) {
+      this.portBindAddress = portBindAddress;
+      return this;
+    }
+
     public @NonNull DockerConfiguration build() {
       Preconditions.checkNotNull(this.javaImage, "Java docker image must be given");
       return new DockerConfiguration(
@@ -184,7 +195,8 @@ public record DockerConfiguration(
         this.registryPassword,
         this.registryUrl,
         this.user,
-        this.nodeHostOverride);
+        this.nodeHostOverride,
+        this.portBindAddress);
     }
   }
 }

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedService.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedService.java
@@ -29,6 +29,7 @@ import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.InternetProtocol;
 import com.github.dockerjava.api.model.LogConfig;
+import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.Volume;
 import eu.cloudnetservice.driver.document.property.DocProperty;
@@ -54,6 +55,8 @@ import eu.cloudnetservice.utils.base.StringUtil;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -229,6 +232,36 @@ public class DockerizedService extends JVMService {
       // an isolated, single java installation available which is always accessible via 'java'
       arguments.set(0, "java");
 
+      // build host configuration
+      var hostConfig = HostConfig.newHostConfig()
+        .withBinds(binds)
+        .withCapDrop(DROPPED_CAPABILITIES)
+        .withRestartPolicy(RestartPolicy.noRestart())
+        .withNetworkMode(this.configuration.network())
+        .withLogConfig(new LogConfig(LogConfig.LoggingType.LOCAL, LOGGING_OPTIONS));
+
+      // add port bindings if configured and not using host network mode
+      var portBindAddress = this.configuration.portBindAddress();
+      if (portBindAddress != null && !"host".equals(this.configuration.network())) {
+        var servicePort = this.serviceConfiguration.port();
+
+        // resolve the bind address if it's set to "auto" (uses hostAddress)
+        String resolvedBindAddress;
+        if (DockerConfiguration.AUTO_PORT_BIND_ADDRESS.equals(portBindAddress)) {
+          resolvedBindAddress = this.resolveHostAddress(this.serviceConfiguration.hostAddress());
+        } else {
+          resolvedBindAddress = portBindAddress;
+        }
+
+        // only add port bindings if we have a valid bind address
+        if (resolvedBindAddress != null) {
+          var portBindings = new Ports();
+          portBindings.bind(ExposedPort.tcp(servicePort), Ports.Binding.bindIpAndPort(resolvedBindAddress, servicePort));
+          portBindings.bind(ExposedPort.udp(servicePort), Ports.Binding.bindIpAndPort(resolvedBindAddress, servicePort));
+          hostConfig.withPortBindings(portBindings);
+        }
+      }
+
       // create the container and store the container id
       this.containerId = this.dockerClient.createContainerCmd(image.imageName())
         .withEnv(env)
@@ -243,12 +276,7 @@ public class DockerizedService extends JVMService {
         .withExposedPorts(exposedPorts)
         .withName(this.serviceId().name() + "_" + this.serviceId().uniqueId())
         .withWorkingDir(this.serviceDirectory.toAbsolutePath().toString())
-        .withHostConfig(HostConfig.newHostConfig()
-          .withBinds(binds)
-          .withCapDrop(DROPPED_CAPABILITIES)
-          .withRestartPolicy(RestartPolicy.noRestart())
-          .withNetworkMode(this.configuration.network())
-          .withLogConfig(new LogConfig(LogConfig.LoggingType.LOCAL, LOGGING_OPTIONS)))
+        .withHostConfig(hostConfig)
         .withLabels(Map.of(
           "Service", "CloudNet",
           "Name", this.serviceId().name(),
@@ -400,6 +428,22 @@ public class DockerizedService extends JVMService {
 
   protected @NonNull Bind bindFromPath(@NonNull String path, @NonNull AccessMode accessMode) {
     return new Bind(path, new Volume(path), accessMode);
+  }
+
+  protected @Nullable String resolveHostAddress(@NonNull String hostAddress) {
+    try {
+      var inetAddress = InetAddress.getByName(hostAddress);
+      var resolvedAddress = inetAddress.getHostAddress();
+      // remove IPv6 scope identifier if present (e.g., fe80::1%eth0 -> fe80::1)
+      var scopeIndex = resolvedAddress.indexOf('%');
+      if (scopeIndex != -1) {
+        resolvedAddress = resolvedAddress.substring(0, scopeIndex);
+      }
+      return resolvedAddress;
+    } catch (UnknownHostException exception) {
+      LOGGER.warn("Unable to resolve host address {} for port binding", hostAddress, exception);
+      return null;
+    }
   }
 
   public final class ServiceLogCacheAdapter extends ResultCallback.Adapter<Frame> {

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedServicesModule.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedServicesModule.java
@@ -59,6 +59,7 @@ public class DockerizedServicesModule extends DriverModule {
         null,
         null,
         null,
+        null,
         null),
       DocumentFactory.json());
   }


### PR DESCRIPTION
### Motivation
When using Docker with bridge or custom networks, services need explicit port bindings to be accessible. Currently there's no way to configure the bind address for these port mappings.

### Modification
- Added `portBindAddress` field to `DockerConfiguration`
- Added `AUTO_PORT_BIND_ADDRESS` constant for automatic resolution from service host address
- Implemented port binding logic in `DockerizedService` that binds TCP/UDP ports when not using host network mode
- Fixed missing `nodeHostOverride` copy in the configuration builder

### Result
Users can now configure `portBindAddress` in their docker configuration:
- Set to a specific IP for explicit binding
- Set to `"auto"` to resolve from the service's host address
- Leave `null` to disable port bindings (current behavior)