### PR TITLE
fix: skip OS-level port check for addresses outside network namespace

### DIFF
--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedLocalCloudServiceFactory.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedLocalCloudServiceFactory.java
@@ -27,6 +27,7 @@ import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.impl.service.InternalCloudServiceManager;
 import eu.cloudnetservice.node.impl.service.defaults.factory.BaseLocalCloudServiceFactory;
 import eu.cloudnetservice.node.impl.tick.DefaultTickLoop;
+import eu.cloudnetservice.node.impl.util.NetworkUtil;
 import eu.cloudnetservice.node.impl.version.ServiceVersionProvider;
 import eu.cloudnetservice.node.service.CloudService;
 import eu.cloudnetservice.node.service.CloudServiceManager;
@@ -94,5 +95,16 @@ public class DockerizedLocalCloudServiceFactory extends BaseLocalCloudServiceFac
   @Override
   public @NonNull String name() {
     return this.dockerConfiguration.factoryName();
+  }
+
+  @Override
+  protected boolean isPortInUseAtOsLevel(@NonNull String hostAddress, int port) {
+    // only do OS-level port check if we can actually reach this address
+    // this handles the case where CloudNet runs in a container with an external address configured
+    if (!NetworkUtil.isBindableAddress(hostAddress)) {
+      return false;
+    }
+
+    return super.isPortInUseAtOsLevel(hostAddress, port);
   }
 }

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedLocalCloudServiceFactory.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedLocalCloudServiceFactory.java
@@ -27,7 +27,6 @@ import eu.cloudnetservice.node.config.Configuration;
 import eu.cloudnetservice.node.impl.service.InternalCloudServiceManager;
 import eu.cloudnetservice.node.impl.service.defaults.factory.BaseLocalCloudServiceFactory;
 import eu.cloudnetservice.node.impl.tick.DefaultTickLoop;
-import eu.cloudnetservice.node.impl.util.NetworkUtil;
 import eu.cloudnetservice.node.impl.version.ServiceVersionProvider;
 import eu.cloudnetservice.node.service.CloudService;
 import eu.cloudnetservice.node.service.CloudServiceManager;
@@ -37,6 +36,8 @@ import lombok.NonNull;
 
 @Singleton
 public class DockerizedLocalCloudServiceFactory extends BaseLocalCloudServiceFactory {
+
+  private static final String DOCKER_HOST_NETWORK = "host";
 
   protected final I18n i18n;
   protected final DefaultTickLoop mainThread;
@@ -99,70 +100,10 @@ public class DockerizedLocalCloudServiceFactory extends BaseLocalCloudServiceFac
 
   @Override
   protected boolean isPortInUse(@NonNull CloudServiceManager manager, @NonNull String hostAddress, int port) {
-    // check if any local CloudNet service has the port
-    if (this.isPortUsedByLocalService(manager, hostAddress, port)) {
-      return true;
-    }
-
-    // check if any Docker container has this port binding
-    if (this.isPortBoundInDocker(hostAddress, port)) {
-      return true;
-    }
-
-    // validate that the port is free at OS level
-    return this.isPortInUseAtOsLevel(hostAddress, port);
-  }
-
-  @Override
-  protected boolean isPortInUseAtOsLevel(@NonNull String hostAddress, int port) {
-    // only do OS-level port check if we can actually reach this address
-    // this handles the case where CloudNet runs in a container with an external address configured
-    if (!NetworkUtil.isBindableAddress(hostAddress)) {
+    if (!DOCKER_HOST_NETWORK.equalsIgnoreCase(this.dockerConfiguration.network())) {
       return false;
     }
 
-    return super.isPortInUseAtOsLevel(hostAddress, port);
-  }
-
-  /**
-   * Checks if any running Docker container has a port binding that would conflict
-   * with the desired host address and port.
-   */
-  protected boolean isPortBoundInDocker(@NonNull String hostAddress, int port) {
-    var containers = this.dockerClient.listContainersCmd()
-      .withShowAll(false) // only running containers hold port bindings
-      .exec();
-
-    for (var container : containers) {
-      var ports = container.getPorts();
-      if (ports == null) {
-        continue;
-      }
-
-      for (var binding : ports) {
-        var publicPort = binding.getPublicPort();
-        if (publicPort == null || publicPort != port) {
-          continue;
-        }
-
-        var bindIp = binding.getIp();
-        if (bindIp == null) {
-          // exposed but not published to host - no conflict
-          continue;
-        }
-
-        // conflict if:
-        // 1. exact address match
-        // 2. container binds all interfaces (0.0.0.0)
-        // 3. we want all interfaces and container has any binding
-        if (bindIp.equals(hostAddress)
-            || "0.0.0.0".equals(bindIp)
-            || "0.0.0.0".equals(hostAddress)) {
-          return true;
-        }
-      }
-    }
-
-    return false;
+    return super.isPortInUse(manager, hostAddress, port);
   }
 }

--- a/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedLocalCloudServiceFactory.java
+++ b/modules/dockerized-services/impl/src/main/java/eu/cloudnetservice/modules/docker/impl/DockerizedLocalCloudServiceFactory.java
@@ -98,6 +98,22 @@ public class DockerizedLocalCloudServiceFactory extends BaseLocalCloudServiceFac
   }
 
   @Override
+  protected boolean isPortInUse(@NonNull CloudServiceManager manager, @NonNull String hostAddress, int port) {
+    // check if any local CloudNet service has the port
+    if (this.isPortUsedByLocalService(manager, hostAddress, port)) {
+      return true;
+    }
+
+    // check if any Docker container has this port binding
+    if (this.isPortBoundInDocker(hostAddress, port)) {
+      return true;
+    }
+
+    // validate that the port is free at OS level
+    return this.isPortInUseAtOsLevel(hostAddress, port);
+  }
+
+  @Override
   protected boolean isPortInUseAtOsLevel(@NonNull String hostAddress, int port) {
     // only do OS-level port check if we can actually reach this address
     // this handles the case where CloudNet runs in a container with an external address configured
@@ -106,5 +122,47 @@ public class DockerizedLocalCloudServiceFactory extends BaseLocalCloudServiceFac
     }
 
     return super.isPortInUseAtOsLevel(hostAddress, port);
+  }
+
+  /**
+   * Checks if any running Docker container has a port binding that would conflict
+   * with the desired host address and port.
+   */
+  protected boolean isPortBoundInDocker(@NonNull String hostAddress, int port) {
+    var containers = this.dockerClient.listContainersCmd()
+      .withShowAll(false) // only running containers hold port bindings
+      .exec();
+
+    for (var container : containers) {
+      var ports = container.getPorts();
+      if (ports == null) {
+        continue;
+      }
+
+      for (var binding : ports) {
+        var publicPort = binding.getPublicPort();
+        if (publicPort == null || publicPort != port) {
+          continue;
+        }
+
+        var bindIp = binding.getIp();
+        if (bindIp == null) {
+          // exposed but not published to host - no conflict
+          continue;
+        }
+
+        // conflict if:
+        // 1. exact address match
+        // 2. container binds all interfaces (0.0.0.0)
+        // 3. we want all interfaces and container has any binding
+        if (bindIp.equals(hostAddress)
+            || "0.0.0.0".equals(bindIp)
+            || "0.0.0.0".equals(hostAddress)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/factory/BaseLocalCloudServiceFactory.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/factory/BaseLocalCloudServiceFactory.java
@@ -119,19 +119,29 @@ public abstract class BaseLocalCloudServiceFactory implements LocalCloudServiceF
 
   protected boolean isPortInUse(@NonNull CloudServiceManager manager, @NonNull String hostAddress, int port) {
     // check if any local service has the port
+    if (this.isPortUsedByLocalService(manager, hostAddress, port)) {
+      return true;
+    }
+
+    // validate that the port is free at OS level
+    return this.isPortInUseAtOsLevel(hostAddress, port);
+  }
+
+  protected boolean isPortUsedByLocalService(
+    @NonNull CloudServiceManager manager,
+    @NonNull String hostAddress,
+    int port
+  ) {
     for (var cloudService : manager.localCloudServices()) {
       var address = cloudService.serviceInfo().address();
       if (address.host().equals(hostAddress) && address.port() == port) {
         return true;
       }
     }
+    return false;
+  }
 
-    // skip OS-level port check for addresses outside our network namespace (e.g. containerized environments)
-    if (!NetworkUtil.isBindableAddress(hostAddress)) {
-      return false;
-    }
-
-    // validate that the port is free
+  protected boolean isPortInUseAtOsLevel(@NonNull String hostAddress, int port) {
     return NetworkUtil.isInUse(hostAddress, port);
   }
 }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/factory/BaseLocalCloudServiceFactory.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/service/defaults/factory/BaseLocalCloudServiceFactory.java
@@ -126,6 +126,11 @@ public abstract class BaseLocalCloudServiceFactory implements LocalCloudServiceF
       }
     }
 
+    // skip OS-level port check for addresses outside our network namespace (e.g. containerized environments)
+    if (!NetworkUtil.isBindableAddress(hostAddress)) {
+      return false;
+    }
+
     // validate that the port is free
     return NetworkUtil.isInUse(hostAddress, port);
   }

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/NetworkUtil.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/NetworkUtil.java
@@ -95,6 +95,35 @@ public final class NetworkUtil {
     }
   }
 
+  /**
+   * Checks if the given host address is bindable in the current network namespace.
+   */
+  public static boolean isBindableAddress(@NonNull String hostAddress) {
+    // resolve the address to check against available addresses
+    String resolvedAddress;
+    try {
+      // try to parse as IP address first
+      var address = InetAddresses.forString(hostAddress);
+      // wildcard addresses are always bindable
+      if (address.isAnyLocalAddress()) {
+        return true;
+      }
+      resolvedAddress = extractHostAddress(address);
+    } catch (IllegalArgumentException exception) {
+      // not a raw IP address, try to resolve as hostname
+      try {
+        var address = InetAddress.getByName(hostAddress);
+        resolvedAddress = extractHostAddress(address);
+      } catch (UnknownHostException e) {
+        // cannot resolve hostname, not bindable
+        return false;
+      }
+    }
+
+    // check if the resolved address is available on this system
+    return availableIPAddresses().contains(resolvedAddress);
+  }
+
   public static @Nullable HostAndPort parseAssignableHostAndPort(@NonNull String address, boolean withPort) {
     // try to parse host and port from the given string
     var hostAndPort = parseHostAndPort(address, withPort);

--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/NetworkUtil.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/util/NetworkUtil.java
@@ -95,35 +95,6 @@ public final class NetworkUtil {
     }
   }
 
-  /**
-   * Checks if the given host address is bindable in the current network namespace.
-   */
-  public static boolean isBindableAddress(@NonNull String hostAddress) {
-    // resolve the address to check against available addresses
-    String resolvedAddress;
-    try {
-      // try to parse as IP address first
-      var address = InetAddresses.forString(hostAddress);
-      // wildcard addresses are always bindable
-      if (address.isAnyLocalAddress()) {
-        return true;
-      }
-      resolvedAddress = extractHostAddress(address);
-    } catch (IllegalArgumentException exception) {
-      // not a raw IP address, try to resolve as hostname
-      try {
-        var address = InetAddress.getByName(hostAddress);
-        resolvedAddress = extractHostAddress(address);
-      } catch (UnknownHostException e) {
-        // cannot resolve hostname, not bindable
-        return false;
-      }
-    }
-
-    // check if the resolved address is available on this system
-    return availableIPAddresses().contains(resolvedAddress);
-  }
-
   public static @Nullable HostAndPort parseAssignableHostAndPort(@NonNull String address, boolean withPort) {
     // try to parse host and port from the given string
     var hostAndPort = parseHostAndPort(address, withPort);


### PR DESCRIPTION
### Motivation
When CloudNet runs inside a containerized environment (e.g., Docker with bridge networking) with a host address that doesn't exist in the container's network namespace, the port allocation fails with "No free port found" error. This happens because `NetworkUtil.isInUse()` tries to bind a `ServerSocket` to an address that doesn't exist locally, causing all port checks to fail.

### Modification
- Added `NetworkUtil.isBindableAddress()` method to check if an address exists in the current network namespace
- Added `isPortInUseAtOsLevel()` hook in `BaseLocalCloudServiceFactory`
- Override the hook in `DockerizedLocalCloudServiceFactory` to skip OS-level port check for non-bindable addresses
- JVM services retain full port validation (unchanged behavior)

### Result
CloudNet can now correctly allocate ports when running in containerized environments with external host addresses. The service registry is used to prevent port conflicts for addresses outside the local network namespace.