### PR TITLE
chore: update to velocity 3.5.0-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ logback = "1.5.25"
 
 # platform api versions
 sponge = "9.0.0"
-velocity = "3.4.0-SNAPSHOT"
+velocity = "3.5.0-SNAPSHOT"
 waterdogpe = "1.2.4"
 nukkitX = "1.0-SNAPSHOT"
 minestom = "2026.01.08-1.21.11"

--- a/node/impl/src/main/resources/files/versions.json
+++ b/node/impl/src/main/resources/files/versions.json
@@ -883,7 +883,7 @@
           "cacheFiles": false,
           "properties": {
             "fetchOverPaperApi": true,
-            "versionGroup": "3.4.0-SNAPSHOT"
+            "versionGroup": "3.5.0-SNAPSHOT"
           }
         }
       ]


### PR DESCRIPTION
### Motivation
Velocity 3.4.0 development came to an end and development on velocity 3.5.0 started. As 3.5.0 contains fixes for new java versions and given the previous release cycles, we should update to 3.5.0.

### Modification
Update velocity dependency and downloads to 3.5.0.

### Result
We're depending on and downloading Velocity 3.5.0 instead of 3.4.0.