### PR TITLE
fix: implement async template storage provider list api

### DIFF
--- a/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/NodeTemplateStorageProvider.java
+++ b/node/impl/src/main/java/eu/cloudnetservice/node/impl/template/NodeTemplateStorageProvider.java
@@ -24,6 +24,7 @@ import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.driver.service.ServiceTemplate;
 import eu.cloudnetservice.driver.template.TemplateStorage;
 import eu.cloudnetservice.driver.template.TemplateStorageProvider;
+import eu.cloudnetservice.utils.base.concurrent.TaskUtil;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.Collection;
@@ -71,6 +72,6 @@ public class NodeTemplateStorageProvider implements TemplateStorageProvider {
 
   @Override
   public @NonNull CompletableFuture<Collection<String>> availableTemplateStoragesAsync() {
-    return null;
+    return TaskUtil.supplyAsync(this::availableTemplateStorages);
   }
 }


### PR DESCRIPTION
### Motivation
The api supports async and sync methods but the async method currently does not delegate to the sync method of availableTemplateStoragesAsync

### Modification
Added the delegation to availableTemplateStorages

### Result
availableTemplateStoragesAsync works as expected
