### PR TITLE
fix: service register could race and lead to multiple register calls

### DIFF
--- a/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformBridgeManagement.java
+++ b/modules/bridge/impl/src/main/java/eu/cloudnetservice/modules/bridge/impl/platform/PlatformBridgeManagement.java
@@ -194,21 +194,18 @@ public abstract class PlatformBridgeManagement<P, I> implements InternalBridgeMa
   }
 
   public void handleServiceUpdate(@NonNull ServiceInfoSnapshot snapshot) {
-    // if the service is not yet cached check if we need to cache it
-    if (!this.cachedServices.containsKey(snapshot.serviceId().uniqueId())) {
-      // check if we should cache it
-      if (this.cacheTester.test(snapshot)) {
+    var serviceUniqueId = snapshot.serviceId().uniqueId();
+    if (this.cacheTester.test(snapshot)) {
+      var previous = this.cachedServices.put(serviceUniqueId, snapshot);
+      if (previous == null) {
         this.cacheRegisterListener.accept(snapshot);
-        this.cachedServices.put(snapshot.serviceId().uniqueId(), snapshot);
       }
-    } else {
-      // if the service is already cached we need to check if we should still cache it
-      if (this.cacheTester.test(snapshot)) {
-        this.cachedServices.replace(snapshot.serviceId().uniqueId(), snapshot);
-      } else {
-        this.cacheUnregisterListener.accept(snapshot);
-        this.cachedServices.remove(snapshot.serviceId().uniqueId());
-      }
+      return;
+    }
+
+    var cachedService = this.cachedServices.remove(serviceUniqueId);
+    if (cachedService != null) {
+      this.cacheUnregisterListener.accept(snapshot);
     }
   }
 


### PR DESCRIPTION
### Motivation
The service cache of the bridge was not being updated in a thread safe manner. This lead to multiple registration handler calls which at the end results in multiple registrations on velocity / bungeecord.

### Modification
Made sure that the register and unregister calls do not race against other incoming updates.

### Result
No races between service registration updates 

##### Other context
This issue from discord is probably an example for the described race https://discord.com/channels/325362837184577536/818777626663321671/1467177343729664316
